### PR TITLE
feat: MCP distribution (registry, plugin, .mcpb) + opt-in HTTP transport

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "neurodock",
+  "description": "Official NeuroDock marketplace: the local-first cognitive substrate for neurodivergent professionals — MCP servers and ND-aware skills.",
+  "owner": {
+    "name": "NeuroDock contributors",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "plugins": [
+    {
+      "name": "neurodock",
+      "source": "./claude-code/neurodock",
+      "description": "Local-first cognitive substrate for neurodivergent professionals: five MCP servers (time, memory, task decomposition, communication decoding, clinical guardrails) plus ND-aware skills.",
+      "version": "0.1.0",
+      "author": {
+        "name": "NeuroDock contributors"
+      }
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,12 @@ web-ext-artifacts/
 extension-submission/
 
 # ─────────────────────────────────────────────────────────────
+# MCP Bundles (.mcpb desktop extensions, mcpb/)
+# ─────────────────────────────────────────────────────────────
+# Keep the manifest.json sources tracked; ignore the built bundles.
+*.mcpb
+
+# ─────────────────────────────────────────────────────────────
 # Astro / Starlight docs (docs/)
 # ─────────────────────────────────────────────────────────────
 .astro/

--- a/README.md
+++ b/README.md
@@ -175,6 +175,38 @@ Want to see it work without installing from PyPI/npm at all?
 
 </details>
 
+<details>
+<summary><strong>Prefer a plugin, a one-click desktop extension, or the MCP Registry?</strong></summary>
+
+The `install-all` command above is the recommended path. The same servers are
+also distributed through three standard channels — all install the identical
+local stdio servers, so you can pick whichever fits your client:
+
+**Claude Code plugin** — bundles the five MCP servers _and_ a set of ND-aware
+skills in one step. Requires [`uv`](https://docs.astral.sh/uv/) (the servers
+run via `uvx`).
+
+```
+/plugin marketplace add tlennon-ie/neurodock
+/plugin install neurodock@neurodock
+```
+
+**Claude Desktop extension (`.mcpb`)** — one-click install, no config editing.
+One bundle per server under [`mcpb/`](./mcpb/); build with
+`npx @anthropic-ai/mcpb pack mcpb/neurodock-mcp-translation` and drag the
+`.mcpb` onto Claude Desktop → Settings → Extensions. Requires `uv`.
+
+**Official MCP Registry** — each server ships a
+[`server.json`](./packages/mcp-translation/server.json) and is published to
+[registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io)
+under the `io.github.tlennon-ie/*` namespace, so MCP-aware clients can discover
+them directly.
+
+See [ADR 0008 — distribution & remote strategy](./docs/decisions/0008-distribution-and-remote-strategy.md)
+for how these fit together and the (separate) plan for a hosted remote server.
+
+</details>
+
 ## Update
 
 ```sh
@@ -389,6 +421,7 @@ Design rationale lives in `docs/decisions/`:
 - ADR 0005 — translation tool design
 - ADR 0006 — guardrail tool design
 - ADR 0007 — plugin protocol
+- ADR 0008 — distribution & remote strategy
 
 ## Contributing
 

--- a/claude-code/neurodock/.claude-plugin/plugin.json
+++ b/claude-code/neurodock/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "neurodock",
+  "version": "0.1.0",
+  "description": "Local-first cognitive substrate for neurodivergent professionals. Bundles the five NeuroDock MCP servers and a set of ND-aware skills for communication decoding, task decomposition, working-memory recall, and clinical guardrails.",
+  "author": {
+    "name": "NeuroDock contributors",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "homepage": "https://neurodock.org/",
+  "repository": "https://github.com/tlennon-ie/neurodock",
+  "license": "AGPL-3.0-or-later",
+  "keywords": [
+    "neurodivergent",
+    "adhd",
+    "autism",
+    "audhd",
+    "accessibility",
+    "executive-function",
+    "mcp"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/claude-code/neurodock/.mcp.json
+++ b/claude-code/neurodock/.mcp.json
@@ -1,0 +1,24 @@
+{
+  "mcpServers": {
+    "neurodock-chronometric": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-chronometric"]
+    },
+    "neurodock-cognitive-graph": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-cognitive-graph"]
+    },
+    "neurodock-task-fractionator": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-task-fractionator"]
+    },
+    "neurodock-translation": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-translation"]
+    },
+    "neurodock-guardrail": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-guardrail"]
+    }
+  }
+}

--- a/claude-code/neurodock/README.md
+++ b/claude-code/neurodock/README.md
@@ -1,0 +1,59 @@
+# NeuroDock — Claude Code plugin
+
+The local-first cognitive substrate for neurodivergent professionals, packaged
+as a Claude Code plugin. Installing it registers the five NeuroDock MCP servers
+and a set of ND-aware skills in one step.
+
+## Install
+
+```sh
+/plugin marketplace add tlennon-ie/neurodock
+/plugin install neurodock@neurodock
+```
+
+## Prerequisite: `uv`
+
+The bundled MCP servers are Python packages launched with [`uvx`](https://docs.astral.sh/uv/),
+which fetches and runs them from PyPI on first use (no manual `pip install`).
+Install `uv` first:
+
+```sh
+# macOS / Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+Each MCP server still goes through Claude Code's per-server approval the first
+time it runs.
+
+## What's bundled
+
+### MCP servers (`.mcp.json`)
+
+| Server                        | Tools                                                         |
+| ----------------------------- | ------------------------------------------------------------- |
+| `neurodock-chronometric`      | time context, session start/end, break prompts, idle status   |
+| `neurodock-cognitive-graph`   | entity recall, fact recording, decision recall, weekly rollup |
+| `neurodock-task-fractionator` | goal decomposition, next-action selection                     |
+| `neurodock-translation`       | incoming decode, tone check, outgoing rewrite, meeting brief  |
+| `neurodock-guardrail`         | rumination / hyperfocus / sycophancy advisories               |
+
+### Skills (`skills/`)
+
+`translate-incoming`, `record-fact`, `decompose-task`, `check-rumination`,
+`chronometric-mark-start`, `chronometric-mark-end` — each teaches Claude the
+exact tool contract and the ND-aware "voice" for surfacing results.
+
+## Privacy
+
+All NeuroDock data stays on your device. The cognitive graph (`~/.neurodock/`)
+and your profile never leave the machine, and the servers transmit nothing.
+The translation server orchestrates prompts against whatever LLM your MCP
+client is configured to use; it makes no network calls of its own.
+
+## Links
+
+- Project: <https://neurodock.org/>
+- Source & docs: <https://github.com/tlennon-ie/neurodock>
+- License: AGPL-3.0-or-later

--- a/claude-code/neurodock/skills/check-rumination/SKILL.md
+++ b/claude-code/neurodock/skills/check-rumination/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: check-rumination
+description: Detect whether the user's current prompt is a semantic repeat of recent prompts within a rolling window. Returns an advisory signal; never blocks.
+---
+
+# check-rumination
+
+Wrapper for `check_rumination` on the local NeuroDock guardrail server
+(`neurodock-guardrail`). Compares the current prompt against a
+caller-supplied history window and reports whether the count of similar
+prompts has crossed the threshold.
+
+Design rationale: [ADR 0006 — guardrail tool design](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0006-guardrail-tool-design.md).
+The heuristic in v0.1.0 is word-overlap Jaccard, default threshold 0.55,
+default window 90 minutes, default count 3.
+
+This tool **never blocks** the user's action. It returns an advisory
+signal the calling skill decides whether to surface, defer, or ignore.
+
+## When to use
+
+- Inside a guardrail-aware skill at the top of the turn, before doing
+  further analysis.
+- When the same OCD-pattern prompt has been seen multiple times in a row
+  and the skill wants confirmation before responding with more analysis.
+
+## What it does
+
+Calls `mcp__neurodock-guardrail__check_rumination`. The server is
+**stateless** — the caller supplies the history; the server stores
+nothing. The server:
+
+1. Filters history to entries within `window_minutes` of now.
+2. Scores Jaccard word-overlap between `current_prompt` and each
+   surviving history entry.
+3. Counts entries scoring above `similarity_threshold`.
+4. Returns `detected: true` if count ≥ `threshold_count`.
+
+## How to invoke
+
+Input shape:
+
+```json
+{
+  "current_prompt": "should I send the email or not",
+  "history": [
+    {
+      "text": "should I send that email now",
+      "at": "2026-05-23T08:42:00+01:00"
+    },
+    {
+      "text": "is sending the email a bad idea",
+      "at": "2026-05-23T08:51:00+01:00"
+    },
+    {
+      "text": "the email - should I send it",
+      "at": "2026-05-23T09:05:00+01:00"
+    }
+  ],
+  "window_minutes": 90,
+  "threshold_count": 3,
+  "similarity_threshold": 0.55
+}
+```
+
+Field rules:
+
+- `current_prompt` (required): 1–8000 chars, verbatim.
+- `history` (required): up to 500 entries, each `{text, at}`. The caller
+  filters and redacts before sending.
+- `window_minutes` (optional, default 90): 1–1440. Source from
+  `profile.guardrails.rumination_window_minutes` when set.
+- `threshold_count` (optional, default 3): 2–50. Floor of 2 because a
+  single repeat is normal human behaviour.
+- `similarity_threshold` (optional, default 0.55): 0.0–1.0. Lower yields
+  more sensitivity and more false positives.
+
+## Output shape (excerpt)
+
+```json
+{
+  "detected": true,
+  "count": 3,
+  "window_seconds": 5400,
+  "threshold": 3,
+  "confidence": 0.78,
+  "reason": "3 similar prompts within 90 minutes",
+  "heuristic": "jaccard_v0_1_0",
+  "override_options": [
+    "genuinely_new",
+    "i_know_im_ruminating_continue",
+    "remind_me_later"
+  ],
+  "false_positive_feedback_path": "~/.neurodock/guardrail/false-positives.jsonl",
+  "similar_prompts": [
+    {
+      "text": "should I send that email now",
+      "at": "2026-05-23T08:42:00+01:00",
+      "similarity": 0.82
+    }
+  ]
+}
+```
+
+`detected: false` is a first-class return. The caller MUST respond
+normally and SHOULD NOT surface any guardrail UI when detected is false.
+
+## Override vocabulary
+
+The `override_options` array is the v0.1.0 controlled vocabulary the user
+can invoke when they disagree with the detection:
+
+- `genuinely_new` — the user asserts the prompt is not a repeat. Lowers
+  similarity weighting for the matched cluster in future evaluations.
+- `i_know_im_ruminating_continue` — the user is aware and chooses to
+  continue. The skill MUST proceed without further nudging in this turn.
+- `remind_me_later` — defer the advisory; do not surface again until the
+  next session boundary.
+
+## Limitations
+
+- Jaccard is a deliberately simple heuristic. v0.1.0 will produce false
+  positives on prompts that share boilerplate words ("can you help me
+  with..."). Embedding-based similarity lands in a later version; the
+  `similarity_threshold` field will remain to support deterministic
+  fallback.
+- The tool is advisory. It is the caller's responsibility to surface the
+  signal without lecturing.
+- Clinical-review-required: schema and heuristic changes need sign-off
+  per the `x-clinical-review-required` annotation in the schema and the
+  project's [ETHICS.md](https://github.com/tlennon-ie/neurodock/blob/main/ETHICS.md)
+  commitments.
+
+## Voice
+
+When surfacing a detection, quote the prior similar prompt verbatim and
+state the count plainly ("4 times in the last 90 minutes — same shape").
+Always offer the override options as the next interaction; the user has
+the final call. Do not pathologise — "ruminating" is the technical term
+in code, not in the user-facing message.

--- a/claude-code/neurodock/skills/chronometric-mark-end/SKILL.md
+++ b/claude-code/neurodock/skills/chronometric-mark-end/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: chronometric-mark-end
+description: Close the currently open chronometric session, optionally attaching a verbatim summary. Triggers the auto-summary side effect used by weekly_rollup.
+---
+
+# chronometric-mark-end
+
+Quick wrapper for `mark_session_end` on the local NeuroDock chronometric
+server (`neurodock-chronometric`). Closes the most-recent open session and
+returns its final metadata.
+
+Authoritative schema `$id`:
+`https://schemas.neurodock.org/mcp-chronometric/v0.1.0/mark_session_end.schema.json`
+([source](https://github.com/tlennon-ie/neurodock/blob/main/packages/mcp-chronometric/schemas/mark_session_end.schema.json)).
+
+## When to use
+
+- When the user says they're done with a focused block.
+- At the end of a planning skill that opened a session at the top.
+- After detecting a hard context switch (long idle, calendar transition,
+  explicit "I'm stopping").
+
+## What it does
+
+Calls `mcp__neurodock-chronometric__mark_session_end` with an optional
+`summary`. The server:
+
+1. Looks up the most recent open session for the user (no `session_id`
+   argument — by design, per [ADR 0001](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0001-chronometric-tool-design.md)).
+2. Stamps `ended_at` (ISO 8601 with offset).
+3. Computes `duration` as an ISO 8601 duration string.
+4. Stores the summary verbatim alongside the original `intent`.
+5. Returns `session_id`, `started_at`, `ended_at`, `duration`, `intent`,
+   `summary`.
+
+### Side effect: weekly rollup feeds on this
+
+The verbatim `intent` + `summary` pair is the unit consumed by the
+cognitive graph's `weekly_rollup` tool. Sessions ended without a summary
+are still included but contribute less signal. Encourage the user to write
+a one-line summary even when nothing "finished" — `"got distracted into
+refactor; did not finish the planned migration ADR"` is more useful than
+no summary at all.
+
+## How to invoke
+
+Minimal:
+
+```json
+{}
+```
+
+With summary:
+
+```json
+{
+  "summary": "shipped the RFC reply, parked two follow-ups in inbox"
+}
+```
+
+Constraints:
+
+- `summary` is optional, 1–1000 chars, plain language.
+- No `session_id` field — the server picks the most recent open session.
+
+Example response:
+
+```json
+{
+  "session_id": "6f9f4f5e-3b1c-4e2a-9f7d-2b3c4d5e6f70",
+  "started_at": "2026-05-23T09:14:22+01:00",
+  "ended_at": "2026-05-23T10:42:18+01:00",
+  "duration": "PT1H27M56S",
+  "intent": "finish draft RFC reply",
+  "summary": "shipped the RFC reply, parked two follow-ups in inbox"
+}
+```
+
+## Errors
+
+- `NO_OPEN_SESSION` — caller thought a session was open; it was not.
+  Distinct from silent success so the caller can tell "I forgot to
+  start one" from "this worked".
+- `SUMMARY_TOO_LONG` — over 1000 chars. Trim and retry.
+
+## Limitations
+
+- Cannot end an arbitrary historical session — only the currently open one.
+- If two sessions are open, only the most recent closes.
+- Summary stored verbatim including PII; redaction is the caller's job.
+
+## Voice
+
+Read the duration back plainly. Do not editorialise ("wow, an hour!" — no).
+Just the numbers and the user's own words. The summary is theirs, not
+something to reformulate.

--- a/claude-code/neurodock/skills/chronometric-mark-start/SKILL.md
+++ b/claude-code/neurodock/skills/chronometric-mark-start/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: chronometric-mark-start
+description: Open a chronometric session by calling mark_session_start with the user's stated intent. Returns a session_id that later interventions quote back verbatim.
+---
+
+# chronometric-mark-start
+
+Quick wrapper for the `mark_session_start` tool on the local NeuroDock
+chronometric server (`neurodock-chronometric`). Captures the user's
+plain-language framing of what they are about to do, so later nudges
+(hyperfocus warnings, end-of-session reflection) can quote it back
+unchanged.
+
+Authoritative schema `$id`:
+`https://schemas.neurodock.org/mcp-chronometric/v0.1.0/mark_session_start.schema.json`
+([source](https://github.com/tlennon-ie/neurodock/blob/main/packages/mcp-chronometric/schemas/mark_session_start.schema.json)).
+
+## When to use
+
+- When the user announces a piece of focused work ("right, I'm going to
+  finish the RFC reply now").
+- At the top of a planning skill that wants to anchor the rest of the
+  session against a stated intent.
+- At the start of a pomodoro or timeboxed block.
+
+## What it does
+
+Calls `mcp__neurodock-chronometric__mark_session_start` with a single
+`intent` string. The server:
+
+1. Generates a UUIDv4 `session_id`.
+2. Records `started_at` (ISO 8601 with offset).
+3. Stores the `intent` verbatim — no paraphrase, no summarisation.
+4. If a prior session was still open, may auto-close it; the response
+   includes `auto_closed_prior_session` with the prior id and `closed_at`.
+
+## How to invoke
+
+Input shape:
+
+```json
+{
+  "intent": "finish draft RFC reply"
+}
+```
+
+Constraints:
+
+- `intent` is required, 1–500 chars, plain language.
+- Long intents (>200 chars) are themselves a hyperfocus signal — split
+  before calling, or accept the warning.
+
+Example response:
+
+```json
+{
+  "session_id": "6f9f4f5e-3b1c-4e2a-9f7d-2b3c4d5e6f70",
+  "started_at": "2026-05-23T09:14:22+01:00",
+  "intent": "finish draft RFC reply",
+  "auto_closed_prior_session": null
+}
+```
+
+## What to do with the session_id
+
+The `session_id` is opaque. Callers do NOT need to track it across calls —
+`mark_session_end` always closes the most-recent open session for the user
+by design (see [ADR 0001](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0001-chronometric-tool-design.md)
+— avoids the LLM having to maintain state).
+
+The id is useful for:
+
+- Logging which session a piece of work belongs to.
+- Cross-referencing in the cognitive graph (`source: "session://<id>"`).
+
+## Errors
+
+- `INTENT_REQUIRED` — empty/missing intent. Ask the user to state one.
+- `INTENT_TOO_LONG` — over 500 chars. Truncate or split.
+- `SESSION_ALREADY_OPEN` — only when the server is configured to reject
+  overlaps. The default policy auto-closes.
+
+## Limitations
+
+- The tool is local-only; there is no remote sync of sessions in v0.1.0.
+- Intent is stored verbatim including any PII the user types. Redaction
+  is upstream; this server analyses what it is given.
+- Auto-close behaviour is policy-dependent.
+
+## Voice
+
+Quote the intent back to the user in the confirmation. They said it; show
+that you heard it. Do not add encouragement ("great goal!") — that is
+exactly the sycophancy the project's manifesto rejects.

--- a/claude-code/neurodock/skills/decompose-task/SKILL.md
+++ b/claude-code/neurodock/skills/decompose-task/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: decompose-task
+description: Break a vague goal into 3–12 atomic 5–90 minute tasks with acceptance criteria and dependencies via the NeuroDock task-fractionator. The acceptance bar is "I can start now".
+---
+
+# decompose-task
+
+Wrapper for the `decompose` tool on the local NeuroDock task-fractionator
+server (`neurodock-task-fractionator`). Takes a goal and returns an ordered
+list of atomic tasks the user can pick up cold.
+
+Design rationale: [ADR 0003 — task-fractionator tool design](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0003-task-fractionator-tool-design.md)
+("goblin-style" decomposition; acceptance bar is _I can start this right
+now without thinking_).
+
+## When to use
+
+- The user states a goal that is bigger than a single task ("ship the
+  founding-scope RFC by Friday").
+- A planner skill needs structured sub-tasks to schedule.
+- The user is staring at a vague item and cannot start.
+
+Do NOT use for:
+
+- Tasks already small enough (a single email reply).
+- Strategic planning over weeks/months — this tool caps total
+  estimated_minutes at the decompose-level budget, not a roadmap.
+
+## What it does
+
+Calls `mcp__neurodock-task-fractionator__decompose`. The server:
+
+1. Decomposes the goal into 3–12 atomic tasks (hard cap 20).
+2. Each task gets: `id` (UUIDv4), `title`, `description`,
+   `estimated_minutes` (5–90), `acceptance_criteria[]` (≥1),
+   `dependencies[]` (refs to sibling ids), `sequence` (1-indexed total
+   order), `tags[]`.
+3. Returns the `tasks` array plus a `rationale` paragraph explaining the
+   split.
+4. Does **NOT** persist anything — the caller is responsible for writing
+   the result to the cognitive graph (see the `record-fact` skill) if
+   persistence is desired.
+
+## How to invoke
+
+Minimal:
+
+```json
+{
+  "goal": "ship the founding-scope RFC by Friday"
+}
+```
+
+With a time budget (ISO 8601 duration — natural language is rejected):
+
+```json
+{
+  "goal": "fix the chronometric idle-status consent bug",
+  "time_budget": "PT3H"
+}
+```
+
+Common `time_budget` values:
+
+- `PT30M` — 30 minutes
+- `PT3H` — 3 hours
+- `PT1H30M` — 1 hour 30 minutes
+- `P1D` — 1 day
+- `P3D` — 3 days
+
+If the budget cannot fit a credible task list, the server returns
+`BUDGET_INFEASIBLE` rather than silently truncating.
+
+## Output shape (excerpt)
+
+```json
+{
+  "tasks": [
+    {
+      "id": "c1e4d2a8-7b3f-4f9a-9c1e-2d3a4b5c6d7e",
+      "title": "Draft the manifesto section",
+      "description": "Write the manifesto section covering ...",
+      "estimated_minutes": 45,
+      "acceptance_criteria": [
+        "File exists at the named path",
+        "Section headings match the plan"
+      ],
+      "dependencies": [],
+      "sequence": 1,
+      "tags": ["writing"]
+    }
+  ],
+  "rationale": "Split into draft, review, publish because ..."
+}
+```
+
+## The "I can start now" acceptance bar
+
+Per ADR 0003: every returned task must be small enough that an ADHD-prone
+user can pick it up cold without further planning. If a task's
+`description` uses words like "consider", "think about", or "explore",
+that is the server's bug — the task is not atomic. Surface the issue;
+do not paper over it.
+
+## Errors
+
+- `GOAL_REQUIRED` — empty goal.
+- `GOAL_TOO_LONG` — over 500 chars (itself a hyperfocus signal — split
+  the goal first).
+- `TIME_BUDGET_UNPARSEABLE` — `time_budget` was not ISO 8601.
+- `BUDGET_INFEASIBLE` — no credible task list fits the budget.
+- `ACCEPTANCE_CRITERIA_REQUIRED` — internal; means the model produced a
+  task with no criteria. Retry.
+- `DEPENDENCY_CYCLE` — internal; retry.
+
+## Limitations
+
+- Stateless. The task list is gone the moment you discard the response.
+  Persist via `record-fact` (`predicate: "depends_on"` for the edges) if
+  you want it back tomorrow.
+- Task estimates are LLM-generated and tend optimistic. Consider adding a
+  buffer when the user is showing distress signals; this server does not
+  adjust the estimates for you.
+- Cross-response dependencies are not modelled — `dependencies[]`
+  references siblings only.
+
+## Voice
+
+When showing the task list, lead with sequence 1 — "start here". Do not
+present the rationale before the tasks; the user wants the next action,
+not the meta-explanation. Save the rationale for a collapsible follow-up.

--- a/claude-code/neurodock/skills/record-fact/SKILL.md
+++ b/claude-code/neurodock/skills/record-fact/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: record-fact
+description: Persist a subject-predicate-object fact in the local cognitive graph. Load this BEFORE calling record_fact to send the correct input shape on the first attempt.
+---
+
+# record-fact
+
+Wrapper around `mcp__neurodock-cognitive-graph__record_fact` that shows
+the exact valid input shape up front. The bare tool has strict validation;
+load this skill first and call it correctly on the first attempt.
+
+Authoritative schema `$id`:
+`https://schemas.neurodock.org/mcp-cognitive-graph/v0.1.0/record_fact.schema.json`
+([source](https://github.com/tlennon-ie/neurodock/blob/main/packages/mcp-cognitive-graph/schemas/record_fact.schema.json)).
+
+## When to use
+
+- The user says "remember X", "make a note that X", "log that X".
+- A skill needs to persist an attribution, a decision, a dependency, or a
+  tag into the graph.
+- After a meeting brief identifies a commitment worth retaining.
+
+## The shape you MUST send
+
+A fact is a **triple**: `subject`, `predicate`, `object`. Flat shapes like
+`{fact: "..."}` are rejected with `SUBJECT_REQUIRED`. Subject and object
+are **entity dictionaries**, not strings.
+
+### Entity dictionary
+
+```json
+{ "type": "<entity-type>", "name": "<display name>" }
+```
+
+Optional `id` field if you already know the canonical id.
+
+### v0.1.0 entity types (closed enum)
+
+- `person`
+- `project`
+- `decision`
+- `concept`
+- `source`
+
+Common wrong values that get rejected: `feature`, `bug`, `task`, `note`,
+`user`, `goal`. Map them: a feature is a `concept`; a person's name is
+`person`; an architectural choice is `decision`.
+
+### v0.1.0 predicates (closed enum)
+
+- `mentioned_in`
+- `decided_in`
+- `reports_to`
+- `depends_on`
+- `resolved_by`
+- `blocked_by`
+- `tagged`
+- `belongs_to`
+
+Common wrong values: `has_bug`, `is_a`, `causes`. Free-form predicates land
+in v0.2 via `type_extensions`. For v0.1.0, pick the closest verb above —
+most situations map to `blocked_by`, `depends_on`, `mentioned_in`, or
+`tagged`.
+
+### Object can be a literal
+
+When the object is a tag, status, or short note rather than an entity:
+
+```json
+{ "literal": "external-memory" }
+```
+
+## How to invoke — canonical examples
+
+### Example 1: a decision attribution
+
+```json
+{
+  "subject": { "type": "person", "name": "Roberto" },
+  "predicate": "decided_in",
+  "object": { "type": "decision", "name": "Adopt SQLite + sqlite-vec" },
+  "source": "msg://slack/C123/p1715683200000100",
+  "confidence": 1.0
+}
+```
+
+### Example 2: a dependency between concepts
+
+```json
+{
+  "subject": { "type": "project", "name": "NeuroDock" },
+  "predicate": "depends_on",
+  "object": { "type": "concept", "name": "sqlite-vec" }
+}
+```
+
+### Example 3: a tag (object is a literal)
+
+```json
+{
+  "subject": { "type": "project", "name": "NeuroDock" },
+  "predicate": "tagged",
+  "object": { "literal": "external-memory" },
+  "confidence": 0.8
+}
+```
+
+### Example 4: a bug-blocks-a-feature relationship
+
+User says "remember that the Gmail translation bug is blocking the LM Studio launch".
+Both sides model as `concept` because v0.1.0 has no `feature` or `bug` type:
+
+```json
+{
+  "subject": { "type": "concept", "name": "LM Studio launch" },
+  "predicate": "blocked_by",
+  "object": { "type": "concept", "name": "Gmail translation silent failure" }
+}
+```
+
+## Errors and how to recover
+
+| Error                     | Cause                             | Fix                                            |
+| ------------------------- | --------------------------------- | ---------------------------------------------- |
+| `SUBJECT_REQUIRED`        | Sent a flat string or missing key | Wrap as `{"type": "...", "name": "..."}`       |
+| `OBJECT_REQUIRED`         | Same on object                    | Same fix, or use `{"literal": "..."}`          |
+| `PREDICATE_UNKNOWN`       | Predicate not in the closed enum  | Pick from the eight above                      |
+| `ENTITY_TYPE_UNKNOWN`     | Type not in the closed enum       | Pick from the five above                       |
+| `CONFIDENCE_OUT_OF_RANGE` | Confidence outside [0, 1]         | Clamp                                          |
+| `GRAPH_WRITE_FAILED`      | SQLite store rejected the write   | Retry once; if persistent, surface to the user |
+
+## Side effects
+
+- Auto-creates referenced entities by `(type, name)` if they do not exist.
+- Returns `auto_created_entities[]` so callers can show what was created.
+- Idempotent at `(subject, predicate, object)` — duplicate calls return the
+  same `fact_id` with `deduplicated: true`.
+
+## Limitations
+
+- v0.1.0 vocabulary is small. If nothing fits, model it as `tagged` with a
+  literal object and revisit when v0.2 extension predicates land.
+- Auto-create can fragment the graph if you keep creating `concept`
+  entities from long free-text descriptions. Prefer short canonical names
+  ("Gmail translation bug") over sentences.
+- The tool is local-only; no remote sync in v0.1.0.
+
+## Voice
+
+If you need to translate the user's plain English into a triple, show the
+mapping briefly ("logging this as `concept blocked_by concept`") so the
+user can correct you in one turn. Do not dump the full schema at them.
+Quote any `auto_created_entities` back so they can spot duplicates.

--- a/claude-code/neurodock/skills/translate-incoming/SKILL.md
+++ b/claude-code/neurodock/skills/translate-incoming/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: translate-incoming
+description: Decode subtext and ambiguity in an incoming corporate message via the NeuroDock translation server. Returns explicit ask, ranked subtext, ambiguity spans anchored verbatim, and a recommended next action.
+---
+
+# translate-incoming
+
+Wrapper for `translate_incoming` on the local NeuroDock translation server
+(`neurodock-translation`). Takes a verbatim incoming message and returns a
+structured decode useful for autistic / AuDHD readers who want the implicit
+corporate-speak made explicit.
+
+Design rationale: [ADR 0005 — translation tool design](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0005-translation-tool-design.md)
+— ambiguity spans MUST anchor verbatim to the input.
+
+## When to use
+
+- The user pastes a Slack / email / Linear / GitHub message and says
+  "what does this actually mean" or "decode this".
+- Before drafting a reply, when the user is unsure what is actually being
+  asked.
+
+## What it does
+
+Calls `mcp__neurodock-translation__translate_incoming`. The server
+itself performs no LLM calls — it orchestrates a prompt template against
+the caller's MCP-client LLM (local Ollama or cloud, per the user's
+profile) and returns the typed response.
+
+The response contains:
+
+- `explicit_ask` — the surface-level request, paraphrased plainly. Null
+  if the message is a status update with no ask.
+- `likely_subtext[]` — up to 5 ranked hypotheses about implicit meaning,
+  each with a 0..1 `confidence` score.
+- `ambiguity` — a report of spans whose meaning is unclear, with
+  `{start_char, end_char, reason, note}`. **The quoted span MUST equal
+  `text[start_char:end_char]` exactly.** This is the verbatim-anchor
+  invariant from ADR 0005.
+- `recommended_next_action` — a single coarse action + a short
+  justification.
+- `model_provenance` — which model ran the call (local vs cloud, model id).
+
+## How to invoke
+
+Input shape:
+
+```json
+{
+  "text": "Hey — can we revisit the rollout timeline? I'm not sure everyone is aligned.",
+  "channel": "slack",
+  "thread_context": [
+    "We agreed last sprint to ship the rollout by end of May.",
+    "Two engineers flagged risk on the migration script."
+  ]
+}
+```
+
+Field rules:
+
+- `text` (required): 1–8000 chars. Stored only in-memory; never logged.
+- `channel` (optional): one of the v0.1.0 enum
+  (`slack`, `email`, `teams`, `linear`, `github`, `generic`). Influences
+  register expectations. Use `generic` if unsure.
+- `thread_context` (optional): up to 20 prior messages, oldest first.
+  Each entry is a verbatim quote, 1–2000 chars.
+- `target_language` (optional): BCP-47 tag (e.g. `en-IE`, `de`, `ja`).
+  Falls back to English prompts if no language pack is registered.
+
+## The verbatim-anchor invariant
+
+Every ambiguity span the caller receives satisfies:
+
+```
+input.text[span.start_char : span.end_char]  ==  (the substring shown in note context)
+```
+
+The server's `VERBATIM_ANCHOR_FAILED` error guarantees this — the LLM
+cannot fabricate a span. If the response is invalid, the server rejects
+and the caller retries; it does not "fix up" mismatches.
+
+When rendering ambiguity to a user, **always quote the verbatim substring,
+not a paraphrase**. The whole point of the schema's anchor is that the
+user can trust the quote.
+
+## Errors
+
+- `TEXT_REQUIRED` — empty text.
+- `TEXT_TOO_LONG` — over 8000 chars. Split or excerpt.
+- `CHANNEL_UNKNOWN` — channel not in the v0.1.0 enum. Use `generic`.
+- `LANGUAGE_PACK_MISSING` — target_language has no pack. Retry without
+  it to fall back to English.
+- `MODEL_UNAVAILABLE` — caller's MCP client could not reach its LLM.
+  Server does not retry; caller decides to surface or queue.
+- `VERBATIM_ANCHOR_FAILED` — LLM fabricated a span. Retry the call.
+
+## Limitations
+
+- The translation quality depends on the caller's configured model.
+  Local 7B Ollama is more likely to hallucinate than a frontier cloud
+  model, and the verbatim-anchor enforcement will reject those responses.
+- The server does not store transcripts. If the user wants to come back
+  to a decode later, the caller must persist it.
+
+## Voice
+
+When surfacing subtext to the user, lead with the top-confidence
+hypothesis and label it as a hypothesis ("most likely they mean X"), not
+as a fact. Quote ambiguous spans verbatim. Do not perform the recommended
+next action without confirmation — the user reads the brief; the user
+decides.

--- a/docs/decisions/0008-distribution-and-remote-strategy.md
+++ b/docs/decisions/0008-distribution-and-remote-strategy.md
@@ -1,0 +1,111 @@
+# 0008 — Distribution and remote strategy (registry, desktop extension, plugin, hosted remote)
+
+- **Status:** proposed
+- **Date:** 2026-05-30
+- **Deciders:** maintainer (TBD), `mcp-architect`
+- **Consulted:** `cli-expert` (owns the installer story), `mcp-server-builder` (HTTP transport in Phase 2), `skill-author` (distributed skill conventions), `community-triage` (registry/marketplace submissions), `clinical-expert` (cognitive-graph / profile sensitivity), `governance-author` (AGPL + privacy-policy posture)
+- **Informed:** `release-pilot`, `changelog-keeper`, `doc-writer`, `accessibility-auditor`
+
+## Context
+
+Until now NeuroDock has been distributed exactly one way: the `@neurodock/cli`
+npm package pip/uv-installs the five Python MCP servers from PyPI and writes
+**stdio** `command` entries into Claude Desktop / Claude Code / Cursor configs.
+The servers are stdio-only (FastMCP `app.run()`), single-user, and local-first —
+the cognitive graph (`~/.neurodock/cognitive-graph.sqlite`) and `profile.yaml`
+never leave the device. There is no HTTP transport, no auth, and no remote
+endpoint, so "install remotely" is not currently possible.
+
+We want two things that are in tension with that posture:
+
+1. **Official recognition and lower-friction install** — listing in the MCP
+   ecosystem (the official MCP Registry, a one-click Claude Desktop extension, a
+   Claude Code plugin that also carries the skills).
+2. **A genuine remote server** at `mcp.neurodock.org/mcp` that Claude web/desktop
+   can add as a custom connector, eventually submitted to the Anthropic
+   Connectors Directory.
+
+The hard constraint is that the cognitive graph holds personal facts and the
+profile holds neurotype data. Hosting those multi-tenant is a privacy and
+clinical-review obligation we are not taking on now (see `ETHICS.md`).
+
+## Decision drivers
+
+1. **Preserve the local-first / privacy ethos.** Sensitive per-user state must
+   not be forced into a remote multi-tenant store.
+2. **Zero regression for existing users.** The npm + stdio path must keep
+   working byte-for-byte; new channels are additive.
+3. **Minimum-effort recognition first.** Prefer the self-serve, no-hosting wins
+   before standing up infrastructure.
+4. **AGPL boundary.** AGPL-3.0-or-later is fine for self-hosting (source is
+   already public); flag it for any enterprise/partner positioning.
+5. **One source of truth for the server list.** The server keys/entrypoints in
+   `packages/cli/src/lib/mcp-entries.ts` remain canonical; the plugin `.mcp.json`
+   and the `.mcpb` manifests mirror it.
+
+## Decision
+
+### Phased rollout
+
+**Phase 1 — local recognition (now, no hosting, no auth):**
+
+- **MCP Registry.** Each server ships a `server.json` (schema `2025-12-11`) under
+  the `io.github.tlennon-ie/*` namespace, PyPI package, `uvx` runtime hint, stdio
+  transport. Package ownership is proven with an `mcp-name:` HTML-comment marker
+  in each package README (the PyPI long-description). Publish via `mcp-publisher`.
+- **`.mcpb` Desktop Extensions.** One bundle per server under `mcpb/`, each a thin
+  `uvx neurodock-mcp-<server>` launcher (`manifest_version` 0.3).
+- **Claude Code plugin.** A marketplace at `.claude-plugin/marketplace.json` lists
+  one plugin at `claude-code/neurodock/`, bundling the five MCP servers
+  (`.mcp.json`, via `uvx`) and six adapted ND-aware skills.
+
+**Phase 2 — hosted remote (later): stateless servers only.** A single deployment
+at `https://mcp.neurodock.org/mcp` (Streamable HTTP + OAuth 2.1 / RFC 9728)
+exposing **only** stateless tools. HTTP mode is opt-in behind a flag/env; stdio
+stays default. Submit to the Anthropic Connectors Directory (requires a hosted
+privacy policy — the current top rejection cause).
+
+**Phase 3 — secondary registries.** mcp.so, Smithery, Glama, PulseMCP, and a PR
+to `punkpeye/awesome-mcp-servers`.
+
+### Remote-eligibility boundary (load-bearing)
+
+| Server / tool                         | Remote-eligible | Reason                                         |
+| ------------------------------------- | --------------- | ---------------------------------------------- |
+| `mcp-translation` (4 tools)           | ✅              | Stateless; no profile/graph reads.             |
+| `mcp-guardrail` (3 tools)             | ✅              | Stateless heuristics; advisory only.           |
+| `mcp-task-fractionator` → `decompose` | ✅              | Pure decomposition.                            |
+| `mcp-task-fractionator` → `next_one`  | ❌              | Reads pending tasks from the cognitive graph.  |
+| `mcp-cognitive-graph` (4 tools)       | ❌              | Personal-facts SQLite. Local only.             |
+| `mcp-chronometric` (5 tools)          | ❌              | Per-session state + profile reads. Local only. |
+
+### Namespace
+
+Start with `io.github.tlennon-ie/*` (GitHub-OAuth verified, zero friction).
+A branded `org.neurodock/*` namespace via DNS-TXT verification on neurodock.org
+is a later option once DNS control is confirmed; it requires re-publishing under
+the new name.
+
+## Consequences
+
+**Positive:**
+
+- Discoverable through the official Registry, one-click in Claude Desktop, and a
+  single-step Claude Code install that also brings the skills.
+- No change to the existing npm/stdio path; sensitive state stays local.
+
+**Negative / costs:**
+
+- The Registry `mcp-name` markers only take effect on the next PyPI publish, so
+  Phase 1A landing requires a patch release of each server.
+- The six distributed skills under `claude-code/neurodock/skills/` are adapted
+  copies of the repo-dev skills in `.claude/skills/`; they must be kept in sync
+  (a future generation step should dedupe this).
+- Phase 2 adds a maintained remote surface (auth, hosting, keeping the stateless
+  boundary correct) and depends on DNS control of neurodock.org and a hosted
+  privacy policy.
+
+**Neutral:**
+
+- Several package READMEs carry stale prose version strings; out of scope here,
+  tracked separately. `pyproject.toml` remains the version source of truth.

--- a/docs/decisions/0009-remote-transport-and-hosting.md
+++ b/docs/decisions/0009-remote-transport-and-hosting.md
@@ -1,0 +1,78 @@
+# 0009 — Remote transport and hosting for the stateless servers (Phase 2)
+
+- **Status:** proposed
+- **Date:** 2026-05-30
+- **Deciders:** maintainer (TBD), `mcp-architect`
+- **Consulted:** `mcp-server-builder`, `mcp-translation-expert`, `mcp-guardrail-expert`, `mcp-task-fractionator-expert`, `governance-author` (privacy policy / AGPL)
+- **Informed:** `release-pilot`, `doc-writer`, `cli-expert`
+
+## Context
+
+ADR 0008 committed to a phased rollout in which **only the stateless servers**
+are ever exposed over a network: `mcp-translation` (4 tools), `mcp-guardrail`
+(3 tools), and `mcp-task-fractionator`'s `decompose` tool. The cognitive graph,
+chronometric session state, the profile, and task-fractionator's `next_one`
+(which reads the graph) stay strictly local.
+
+This ADR records the Phase 2 transport, scope, auth, and hosting decisions, and
+the concrete first step taken now (the opt-in HTTP transport flag).
+
+The servers use **FastMCP ≥ 3.3.0**, which ships Streamable HTTP and auth
+providers built in, so enabling HTTP is a small entrypoint change, not a rewrite.
+`neurodock.org` DNS is managed in Cloudflare (verified), and the `mcp.` subdomain
+is unused — so wiring a host later is a single record.
+
+## Decision
+
+1. **Transport — opt-in HTTP, stdio stays default (implemented now).** Each
+   stateless server's entrypoint selects transport from the environment:
+
+   - default → **stdio** (today's behaviour, byte-for-byte unchanged);
+   - `NEURODOCK_HTTP` truthy **or** `--http` flag → **Streamable HTTP**, bound to
+     `NEURODOCK_HTTP_HOST` (default `127.0.0.1`) and `NEURODOCK_HTTP_PORT`
+     (default `8000`).
+     This is the scaffolding landed in this change; it adds a network _option_, not
+     a running service. No client default changes.
+
+2. **Scope — enforce the ADR 0008 boundary in code.** The HTTP build of
+   `mcp-task-fractionator` exposes **only `decompose`**; `next_one` is registered
+   in stdio mode only. translation and guardrail expose their full toolset in
+   both modes (already stateless). cognitive-graph and chronometric get **no**
+   HTTP transport.
+
+3. **Auth — OAuth 2.1 + RFC 9728 via a managed IdP (deferred to the next
+   sub-phase).** A public remote endpoint and the Connectors Directory require
+   OAuth 2.1, Protected Resource Metadata at
+   `/.well-known/oauth-protected-resource`, Dynamic Client Registration, and
+   audience-bound tokens. We will use FastMCP's auth provider backed by a managed
+   IdP (WorkOS AuthKit / Auth0 / Clerk / Stytch) rather than hand-rolling it.
+   **Not** part of this scaffold — the bare HTTP flag binds to localhost and is
+   for local/integration testing only until auth lands.
+
+4. **Hosting — container host fronted by Cloudflare; _not_ Workers.** The servers
+   are Python FastMCP; Python-on-Workers is too limited to run FastMCP cleanly,
+   so Cloudflare Workers is rejected for hosting the existing servers. Chosen
+   shape: deploy the combined stateless toolset as a container (Fly.io / Render /
+   Cloudflare Containers) and point `mcp.neurodock.org` at it via a **proxied
+   Cloudflare DNS record** (or a Cloudflare Tunnel). A from-scratch TypeScript
+   Worker rewrite of the three stateless tools remains a possible alternative but
+   duplicates logic and the eval corpus binding — deferred unless hosting cost
+   forces it.
+
+5. **Endpoint shape.** Lean toward a **single combined endpoint** at
+   `https://mcp.neurodock.org/mcp` mounting translation + guardrail +
+   `decompose`, rather than per-server subpaths. Final call when the host lands.
+
+## Consequences
+
+**Positive:** the HTTP option is available now for integration tests and a future
+deploy, with zero change to the default stdio path; the remote boundary is
+enforced in code, not just documented.
+
+**Costs / deferred:** OAuth, the container deployment, the privacy-policy page on
+neurodock.org, and the Connectors Directory submission are all still pending. A
+hosted privacy policy is the top Directory rejection cause and must precede
+submission.
+
+**Open questions:** managed-IdP choice; container host; single-vs-multi endpoint;
+whether to ever rewrite the stateless tools as a TS Worker.

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -1,0 +1,61 @@
+# NeuroDock — Claude Desktop Extensions (`.mcpb`)
+
+One [MCP Bundle](https://github.com/anthropics/mcpb) per NeuroDock server, for
+**one-click install in Claude Desktop** without editing `claude_desktop_config.json`.
+
+Claude Desktop extensions are one-server-per-bundle, so there is one manifest
+directory per server:
+
+| Directory                          | Server                   | Tools |
+| ---------------------------------- | ------------------------ | ----- |
+| `neurodock-mcp-chronometric/`      | time / sessions / breaks | 5     |
+| `neurodock-mcp-cognitive-graph/`   | persistent entity memory | 4     |
+| `neurodock-mcp-task-fractionator/` | goal decomposition       | 2     |
+| `neurodock-mcp-translation/`       | communication decoding   | 4     |
+| `neurodock-mcp-guardrail/`         | clinical advisories      | 3     |
+
+Each `manifest.json` is a **thin launcher**: it runs `uvx neurodock-mcp-<server>`,
+which fetches and runs the published PyPI package on first use. This keeps the
+bundles tiny and always in sync with the released servers.
+
+## Prerequisite: `uv`
+
+`uvx` must be on the user's PATH. Install [`uv`](https://docs.astral.sh/uv/) first:
+
+```sh
+# macOS / Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+## Build a bundle
+
+```sh
+# validate
+npx @anthropic-ai/mcpb validate mcpb/neurodock-mcp-translation/manifest.json
+# pack -> a .mcpb file (gitignored; treat as a release artefact)
+npx @anthropic-ai/mcpb pack mcpb/neurodock-mcp-translation dist/neurodock-mcp-translation.mcpb
+```
+
+Then double-click the `.mcpb`, or drag it onto Claude Desktop → Settings →
+Extensions. Each server still goes through Claude Desktop's per-extension
+approval.
+
+## Privacy
+
+All NeuroDock data stays on the user's device. The cognitive graph and profile
+live under `~/.neurodock/` and never leave the machine; the servers make no
+network calls of their own. (The translation server orchestrates prompts
+against whatever LLM the user's client is configured to use — it does not call
+out independently.) Because these bundles do not transmit user data to any
+external service, no remote privacy-policy endpoint is required for local
+install. A hosted privacy policy on neurodock.org is still needed before
+submitting to the **Anthropic Connectors / Desktop Extension directory** — see
+[ADR 0008](../docs/decisions/0008-distribution-and-remote-strategy.md).
+
+## Links
+
+- Project: <https://neurodock.org/>
+- Source & docs: <https://github.com/tlennon-ie/neurodock>
+- License: AGPL-3.0-or-later

--- a/mcpb/neurodock-mcp-chronometric/manifest.json
+++ b/mcpb/neurodock-mcp-chronometric/manifest.json
@@ -1,0 +1,51 @@
+{
+  "manifest_version": "0.3",
+  "name": "neurodock-mcp-chronometric",
+  "display_name": "NeuroDock Chronometric",
+  "version": "0.0.2",
+  "description": "Externalises time-of-day, session boundaries, and break prompts for time-blind users.",
+  "long_description": "Time, idle, and break-management MCP server for neurodivergent professionals. Externalises time-of-day context, opens and closes work sessions around the user's verbatim stated intent, prompts for breaks, and reports OS idle status (with consent). Part of NeuroDock, a local-first cognitive substrate. All session state is held locally.",
+  "author": {
+    "name": "NeuroDock contributors",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "homepage": "https://neurodock.org/",
+  "documentation": "https://github.com/tlennon-ie/neurodock/tree/main/packages/mcp-chronometric",
+  "support": "https://github.com/tlennon-ie/neurodock/issues",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "keywords": ["neurodivergent", "adhd", "time-blindness", "focus", "mcp"],
+  "server": {
+    "type": "binary",
+    "entry_point": "uvx",
+    "mcp_config": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-chronometric"]
+    }
+  },
+  "tools": [
+    {
+      "name": "get_time_context",
+      "description": "Return current time-of-day context and the active energy zone."
+    },
+    {
+      "name": "mark_session_start",
+      "description": "Open a session with the user's verbatim stated intent."
+    },
+    {
+      "name": "mark_session_end",
+      "description": "Close the most recent open session with an optional summary."
+    },
+    {
+      "name": "request_break_if_needed",
+      "description": "Advise whether a break is due based on session length and profile thresholds."
+    },
+    {
+      "name": "idle_status",
+      "description": "Report OS idle status, gated on user consent."
+    }
+  ]
+}

--- a/mcpb/neurodock-mcp-cognitive-graph/manifest.json
+++ b/mcpb/neurodock-mcp-cognitive-graph/manifest.json
@@ -1,0 +1,53 @@
+{
+  "manifest_version": "0.3",
+  "name": "neurodock-mcp-cognitive-graph",
+  "display_name": "NeuroDock Cognitive Graph",
+  "version": "0.0.4",
+  "description": "A local typed-edge graph of people, projects, and decisions that externalises memory.",
+  "long_description": "Persistent entity-memory MCP server for neurodivergent professionals. Stores a local typed-edge property graph of people, projects, decisions, and concepts so a hyperfocused or context-switched session does not start from zero. Records facts as subject-predicate-object triples, recalls entities and decisions, and produces a weekly rollup. Part of NeuroDock, a local-first cognitive substrate. The graph is stored in a local SQLite database under ~/.neurodock and never leaves the device.",
+  "author": {
+    "name": "NeuroDock contributors",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "homepage": "https://neurodock.org/",
+  "documentation": "https://github.com/tlennon-ie/neurodock/tree/main/packages/mcp-cognitive-graph",
+  "support": "https://github.com/tlennon-ie/neurodock/issues",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "keywords": [
+    "neurodivergent",
+    "memory",
+    "knowledge-graph",
+    "executive-function",
+    "mcp"
+  ],
+  "server": {
+    "type": "binary",
+    "entry_point": "uvx",
+    "mcp_config": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-cognitive-graph"]
+    }
+  },
+  "tools": [
+    {
+      "name": "recall_entity",
+      "description": "Recall a person, project, decision, or concept by name or alias."
+    },
+    {
+      "name": "record_fact",
+      "description": "Persist a subject-predicate-object fact in the local graph."
+    },
+    {
+      "name": "recall_decisions",
+      "description": "Recall recorded decisions, optionally filtered by entity."
+    },
+    {
+      "name": "weekly_rollup",
+      "description": "Summarise the week's recorded sessions and facts."
+    }
+  ]
+}

--- a/mcpb/neurodock-mcp-guardrail/manifest.json
+++ b/mcpb/neurodock-mcp-guardrail/manifest.json
@@ -1,0 +1,43 @@
+{
+  "manifest_version": "0.3",
+  "name": "neurodock-mcp-guardrail",
+  "display_name": "NeuroDock Guardrail",
+  "version": "0.0.3",
+  "description": "Advisory detectors for rumination, hyperfocus, and sycophancy. Never silently blocks.",
+  "long_description": "Clinical-guardrail MCP server for neurodivergent professionals. Provides advisory detectors for three patterns that unmodified LLM interaction tends to amplify: rumination loops (OCD), unregulated hyperfocus (ADHD), and sycophancy / over-validation. Every detector is advisory only — it never silently blocks an action and always returns override options. Part of NeuroDock, a local-first cognitive substrate. The detectors are stateless and make no network calls.",
+  "author": {
+    "name": "NeuroDock contributors",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "homepage": "https://neurodock.org/",
+  "documentation": "https://github.com/tlennon-ie/neurodock/tree/main/packages/mcp-guardrail",
+  "support": "https://github.com/tlennon-ie/neurodock/issues",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "keywords": ["neurodivergent", "ocd", "adhd", "wellbeing", "mcp"],
+  "server": {
+    "type": "binary",
+    "entry_point": "uvx",
+    "mcp_config": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-guardrail"]
+    }
+  },
+  "tools": [
+    {
+      "name": "check_rumination",
+      "description": "Advisory: detect whether the current prompt is a semantic repeat within a rolling window."
+    },
+    {
+      "name": "check_hyperfocus",
+      "description": "Advisory: detect unregulated hyperfocus from session length and signals."
+    },
+    {
+      "name": "check_sycophancy",
+      "description": "Advisory: detect sycophancy / over-validation in a draft response."
+    }
+  ]
+}

--- a/mcpb/neurodock-mcp-task-fractionator/manifest.json
+++ b/mcpb/neurodock-mcp-task-fractionator/manifest.json
@@ -1,0 +1,45 @@
+{
+  "manifest_version": "0.3",
+  "name": "neurodock-mcp-task-fractionator",
+  "display_name": "NeuroDock Task Fractionator",
+  "version": "0.0.3",
+  "description": "Decompose a vague goal into atomic 5-90 minute tasks and surface the next safe action.",
+  "long_description": "Local-first goal-decomposition MCP server for neurodivergent professionals. Turns a vague goal into a small ordered list of atomic 5-90 minute tasks, each with acceptance criteria and dependencies, against an 'I can start now' bar. Also surfaces the single safe next action from pending work. Part of NeuroDock, a local-first cognitive substrate.",
+  "author": {
+    "name": "NeuroDock contributors",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "homepage": "https://neurodock.org/",
+  "documentation": "https://github.com/tlennon-ie/neurodock/tree/main/packages/mcp-task-fractionator",
+  "support": "https://github.com/tlennon-ie/neurodock/issues",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "keywords": [
+    "neurodivergent",
+    "adhd",
+    "task-decomposition",
+    "executive-function",
+    "mcp"
+  ],
+  "server": {
+    "type": "binary",
+    "entry_point": "uvx",
+    "mcp_config": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-task-fractionator"]
+    }
+  },
+  "tools": [
+    {
+      "name": "decompose",
+      "description": "Decompose a goal into atomic 5-90 minute tasks with acceptance criteria and dependencies."
+    },
+    {
+      "name": "next_one",
+      "description": "Surface the single safe next action from pending tasks."
+    }
+  ]
+}

--- a/mcpb/neurodock-mcp-translation/manifest.json
+++ b/mcpb/neurodock-mcp-translation/manifest.json
@@ -1,0 +1,47 @@
+{
+  "manifest_version": "0.3",
+  "name": "neurodock-mcp-translation",
+  "display_name": "NeuroDock Translation",
+  "version": "0.2.0",
+  "description": "Decode subtext, tone, and ambiguity in messages; rewrite outgoing replies; brief meetings.",
+  "long_description": "Communication-decoding MCP server for neurodivergent professionals. Decodes the implicit ask and ranked subtext in an incoming corporate message, anchors every ambiguous span verbatim to the source, checks the tone of a draft, rewrites outgoing replies, and briefs meetings. Part of NeuroDock, a local-first cognitive substrate. The server performs no LLM calls of its own — it orchestrates prompt templates against whatever model your MCP client is configured to use.",
+  "author": {
+    "name": "NeuroDock contributors",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "homepage": "https://neurodock.org/",
+  "documentation": "https://github.com/tlennon-ie/neurodock/tree/main/packages/mcp-translation",
+  "support": "https://github.com/tlennon-ie/neurodock/issues",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tlennon-ie/neurodock"
+  },
+  "keywords": ["neurodivergent", "communication", "autism", "audhd", "mcp"],
+  "server": {
+    "type": "binary",
+    "entry_point": "uvx",
+    "mcp_config": {
+      "command": "uvx",
+      "args": ["neurodock-mcp-translation"]
+    }
+  },
+  "tools": [
+    {
+      "name": "translate_incoming",
+      "description": "Decode the explicit ask, ranked subtext, and verbatim-anchored ambiguity in an incoming message."
+    },
+    {
+      "name": "check_tone",
+      "description": "Assess the tone of a draft message against the intended register."
+    },
+    {
+      "name": "rewrite_outgoing",
+      "description": "Rewrite an outgoing message to a target tone while preserving meaning."
+    },
+    {
+      "name": "brief_meeting",
+      "description": "Produce a structured pre-meeting brief from agenda and context."
+    }
+  ]
+}

--- a/packages/mcp-chronometric/README.md
+++ b/packages/mcp-chronometric/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.tlennon-ie/neurodock-mcp-chronometric -->
+
 # neurodock-mcp-chronometric
 
 Time, idle, and break management as an MCP server. Part of [NeuroDock](https://neurodock.org/) — a local-first cognitive substrate for neurodivergent professionals.

--- a/packages/mcp-chronometric/server.json
+++ b/packages/mcp-chronometric/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tlennon-ie/neurodock-mcp-chronometric",
+  "title": "NeuroDock Chronometric",
+  "description": "Externalises time-of-day, session boundaries, and break prompts for time-blind users.",
+  "version": "0.0.2",
+  "websiteUrl": "https://neurodock.org/",
+  "repository": {
+    "url": "https://github.com/tlennon-ie/neurodock",
+    "source": "github",
+    "subfolder": "packages/mcp-chronometric"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "neurodock-mcp-chronometric",
+      "version": "0.0.2",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/mcp-cognitive-graph/README.md
+++ b/packages/mcp-cognitive-graph/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.tlennon-ie/neurodock-mcp-cognitive-graph -->
+
 # `neurodock-mcp-cognitive-graph`
 
 Persistent entity memory for the NeuroDock substrate, exposed as an MCP

--- a/packages/mcp-cognitive-graph/server.json
+++ b/packages/mcp-cognitive-graph/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tlennon-ie/neurodock-mcp-cognitive-graph",
+  "title": "NeuroDock Cognitive Graph",
+  "description": "A local typed-edge graph of people, projects, and decisions that externalises memory.",
+  "version": "0.0.4",
+  "websiteUrl": "https://neurodock.org/",
+  "repository": {
+    "url": "https://github.com/tlennon-ie/neurodock",
+    "source": "github",
+    "subfolder": "packages/mcp-cognitive-graph"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "neurodock-mcp-cognitive-graph",
+      "version": "0.0.4",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/mcp-guardrail/CHANGELOG.md
+++ b/packages/mcp-guardrail/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `neurodock-mcp-guardrail` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This package follows semantic versioning.
 
+## [unreleased]
+
+### Added — opt-in HTTP transport (ADR 0009 Phase 2)
+
+`main()` can now run over **Streamable HTTP** in addition to stdio. The default is
+unchanged: with no HTTP signal it runs **stdio**, byte-for-byte identical to before.
+HTTP is opt-in via the `NEURODOCK_HTTP` env var (truthy `1`/`true`/`yes`/`on`,
+case-insensitive) or a `--http` flag, binding `NEURODOCK_HTTP_HOST` (default
+`127.0.0.1`) and `NEURODOCK_HTTP_PORT` (default `8000`). No auth yet — the bare flag
+binds to localhost only (ADR 0009 §3). Detector logic, thresholds, and schemas are
+unchanged. Transport selection lives in a new pure `transport.py` helper shared (by
+identical copy) across the three stateless servers.
+
 ## [0.0.3] - 2026-05-22
 
 ### Changed

--- a/packages/mcp-guardrail/README.md
+++ b/packages/mcp-guardrail/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.tlennon-ie/neurodock-mcp-guardrail -->
+
 # neurodock-mcp-guardrail
 
 Clinical guardrails MCP server for NeuroDock. Detects three patterns that

--- a/packages/mcp-guardrail/server.json
+++ b/packages/mcp-guardrail/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tlennon-ie/neurodock-mcp-guardrail",
+  "title": "NeuroDock Guardrail",
+  "description": "Advisory detectors for rumination, hyperfocus, and sycophancy. Never silently blocks.",
+  "version": "0.0.3",
+  "websiteUrl": "https://neurodock.org/",
+  "repository": {
+    "url": "https://github.com/tlennon-ie/neurodock",
+    "source": "github",
+    "subfolder": "packages/mcp-guardrail"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "neurodock-mcp-guardrail",
+      "version": "0.0.3",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/server.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/server.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from typing import Any
 
@@ -23,6 +24,7 @@ from neurodock_mcp_guardrail.tools.check_sycophancy import (
     SycophancyInputMissingError,
     check_sycophancy,
 )
+from neurodock_mcp_guardrail.transport import select_transport
 from neurodock_mcp_guardrail.types import (
     HyperfocusInput,
     RuminationInput,
@@ -154,7 +156,16 @@ def main() -> None:
         level=logging.INFO,
         format='{"logger":"%(name)s","level":"%(levelname)s","msg":"%(message)s"}',
     )
-    app.run()
+    config = select_transport(os.environ, sys.argv[1:])
+    if config.transport == "stdio":
+        _LOG.info("transport_selected", extra={"transport": "stdio"})
+        app.run()
+        return
+    _LOG.info(
+        "transport_selected",
+        extra={"transport": "http", "host": config.host, "port": config.port},
+    )
+    app.run(transport="http", host=config.host, port=config.port)
 
 
 if __name__ == "__main__":

--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/transport.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/transport.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Transport selection for the NeuroDock stateless MCP servers (ADR 0009, Phase 2).
+
+stdio is the default and stays byte-for-byte unchanged. HTTP (FastMCP's
+Streamable HTTP transport) is opt-in via the ``NEURODOCK_HTTP`` env var (truthy:
+``1``/``true``/``yes``/``on``, case-insensitive) or a ``--http`` CLI flag, binding
+to ``NEURODOCK_HTTP_HOST`` (default ``127.0.0.1``) and ``NEURODOCK_HTTP_PORT``
+(default ``8000``). The helper is pure — env mapping + argv in, config out — so the
+selection logic is unit-testable without binding a socket. Per ADR 0009 §3 auth is
+deferred and the bare flag binds to localhost only.
+
+The three stateless servers (translation, guardrail, task-fractionator) keep an
+identical copy of this module: they are independently published packages and
+cannot share an import, so the contract is held identical by duplication.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Literal, NamedTuple
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+DEFAULT_HTTP_HOST = "127.0.0.1"
+DEFAULT_HTTP_PORT = 8000
+
+
+class TransportConfig(NamedTuple):
+    """The chosen transport and (for HTTP) its bind target.
+
+    ``host`` and ``port`` are ``None`` for stdio.
+    """
+
+    transport: Literal["stdio", "http"]
+    host: str | None = None
+    port: int | None = None
+
+
+def _is_truthy(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in _TRUTHY
+
+
+def _parse_port(raw: str | None) -> int:
+    """Parse a port override, falling back to the default on missing/invalid input."""
+    if raw is None or raw.strip() == "":
+        return DEFAULT_HTTP_PORT
+    try:
+        port = int(raw.strip())
+    except ValueError:
+        return DEFAULT_HTTP_PORT
+    return port if 1 <= port <= 65535 else DEFAULT_HTTP_PORT
+
+
+def select_transport(env: Mapping[str, str], argv: Sequence[str]) -> TransportConfig:
+    """Decide the transport from an env mapping and argv, without side effects.
+
+    HTTP is selected when ``NEURODOCK_HTTP`` is truthy OR ``--http`` is present in
+    ``argv``; otherwise stdio. ``argv`` excludes the program name (``sys.argv[1:]``).
+    """
+    http_requested = _is_truthy(env.get("NEURODOCK_HTTP")) or ("--http" in argv)
+    if not http_requested:
+        return TransportConfig(transport="stdio")
+    host = env.get("NEURODOCK_HTTP_HOST", "").strip() or DEFAULT_HTTP_HOST
+    port = _parse_port(env.get("NEURODOCK_HTTP_PORT"))
+    return TransportConfig(transport="http", host=host, port=port)

--- a/packages/mcp-guardrail/tests/test_transport.py
+++ b/packages/mcp-guardrail/tests/test_transport.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Transport-selection tests (ADR 0009, Phase 2 scaffolding).
+
+Covers the pure ``select_transport`` helper plus the ``main()`` wiring. No test
+binds a real socket: ``app.run`` is intercepted via monkeypatch so HTTP mode is
+verified by the kwargs passed, not by a listening server. Detector/tool logic is
+untouched here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from neurodock_mcp_guardrail import server
+from neurodock_mcp_guardrail.transport import (
+    DEFAULT_HTTP_HOST,
+    DEFAULT_HTTP_PORT,
+    TransportConfig,
+    select_transport,
+)
+
+
+def test_default_selects_stdio() -> None:
+    config = select_transport(env={}, argv=[])
+    assert config == TransportConfig(transport="stdio", host=None, port=None)
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on", "  on  "])
+def test_neurodock_http_truthy_selects_http_defaults(value: str) -> None:
+    config = select_transport(env={"NEURODOCK_HTTP": value}, argv=[])
+    assert config.transport == "http"
+    assert config.host == DEFAULT_HTTP_HOST == "127.0.0.1"
+    assert config.port == DEFAULT_HTTP_PORT == 8000
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "maybe"])
+def test_neurodock_http_falsy_stays_stdio(value: str) -> None:
+    config = select_transport(env={"NEURODOCK_HTTP": value}, argv=[])
+    assert config.transport == "stdio"
+
+
+def test_host_and_port_overrides_respected() -> None:
+    config = select_transport(
+        env={
+            "NEURODOCK_HTTP": "1",
+            "NEURODOCK_HTTP_HOST": "0.0.0.0",
+            "NEURODOCK_HTTP_PORT": "9123",
+        },
+        argv=[],
+    )
+    assert config == TransportConfig(transport="http", host="0.0.0.0", port=9123)
+
+
+def test_http_flag_selects_http() -> None:
+    config = select_transport(env={}, argv=["--http"])
+    assert config.transport == "http"
+    assert config.host == DEFAULT_HTTP_HOST
+    assert config.port == DEFAULT_HTTP_PORT
+
+
+@pytest.mark.parametrize("raw", ["abc", "70000", "0", "-1", ""])
+def test_invalid_port_falls_back_to_default(raw: str) -> None:
+    """Unparseable / out-of-range ports fall back to 8000 rather than crashing."""
+    config = select_transport(env={"NEURODOCK_HTTP": "1", "NEURODOCK_HTTP_PORT": raw}, argv=[])
+    assert config.port == DEFAULT_HTTP_PORT
+
+
+def test_main_default_runs_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(server.app, "run", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(server.sys, "argv", ["neurodock-mcp-guardrail"])
+    monkeypatch.delenv("NEURODOCK_HTTP", raising=False)
+
+    server.main()
+
+    assert calls == [{}]
+
+
+def test_main_http_env_runs_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(server.app, "run", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(server.sys, "argv", ["neurodock-mcp-guardrail"])
+    monkeypatch.setenv("NEURODOCK_HTTP", "1")
+    monkeypatch.delenv("NEURODOCK_HTTP_HOST", raising=False)
+    monkeypatch.delenv("NEURODOCK_HTTP_PORT", raising=False)
+
+    server.main()
+
+    assert calls == [{"transport": "http", "host": "127.0.0.1", "port": 8000}]
+
+
+def test_main_http_respects_host_and_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(server.app, "run", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(server.sys, "argv", ["neurodock-mcp-guardrail"])
+    monkeypatch.setenv("NEURODOCK_HTTP", "yes")
+    monkeypatch.setenv("NEURODOCK_HTTP_HOST", "localhost")
+    monkeypatch.setenv("NEURODOCK_HTTP_PORT", "8765")
+
+    server.main()
+
+    assert calls == [{"transport": "http", "host": "localhost", "port": 8765}]
+
+
+def test_main_http_flag_runs_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(server.app, "run", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(server.sys, "argv", ["neurodock-mcp-guardrail", "--http"])
+    monkeypatch.delenv("NEURODOCK_HTTP", raising=False)
+
+    server.main()
+
+    assert calls == [{"transport": "http", "host": "127.0.0.1", "port": 8000}]

--- a/packages/mcp-task-fractionator/CHANGELOG.md
+++ b/packages/mcp-task-fractionator/CHANGELOG.md
@@ -6,6 +6,33 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+### Added — opt-in HTTP transport (ADR 0009 Phase 2)
+
+The entrypoint can now run over **Streamable HTTP** in addition to stdio. The
+default is unchanged: with no HTTP signal, `main()` runs **stdio** with BOTH
+tools, byte-for-byte identical to before. HTTP is opt-in and selected when
+either the `NEURODOCK_HTTP` env var is truthy (`1`/`true`/`yes`/`on`,
+case-insensitive) or a `--http` CLI arg is passed; it binds
+`NEURODOCK_HTTP_HOST` (default `127.0.0.1`) and `NEURODOCK_HTTP_PORT`
+(default `8000`).
+
+- **Remote scope boundary enforced in code (ADR 0008/0009 §2).** The HTTP build
+  registers ONLY `decompose` (stateless, remote-safe). `next_one` reads the
+  local cognitive graph and is registered in **stdio mode only** — it is absent
+  from the HTTP build's tool list entirely. `build_server` gained an
+  `http_mode` keyword that gates the `next_one` registration.
+- New pure helper `transport.select_transport(env, argv) -> TransportConfig`
+  factors transport selection out of `main()` so it is unit-testable without
+  binding a socket.
+- No auth/OAuth, no tool-logic changes, and no other packages touched — the bare
+  HTTP flag binds to localhost and is for local/integration testing until the
+  OAuth sub-phase lands (ADR 0009 §3).
+- Tests (`test_transport.py`): default→stdio (both tools), `NEURODOCK_HTTP=1`→
+  http 127.0.0.1:8000, host/port overrides, `--http`→http, and the scope
+  assertion that the HTTP toolset contains `decompose` and not `next_one` while
+  the stdio toolset contains both. `FastMCP.run` is monkeypatched so no socket
+  binds.
+
 ### Fixed — removed unreachable forward-reference block in sources/base.py
 
 The `if False:` guard around the type-checker-only imports in

--- a/packages/mcp-task-fractionator/README.md
+++ b/packages/mcp-task-fractionator/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.tlennon-ie/neurodock-mcp-task-fractionator -->
+
 # neurodock-mcp-task-fractionator
 
 Local-first goal decomposition and single next-action selection, exposed as

--- a/packages/mcp-task-fractionator/server.json
+++ b/packages/mcp-task-fractionator/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tlennon-ie/neurodock-mcp-task-fractionator",
+  "title": "NeuroDock Task Fractionator",
+  "description": "Decompose a vague goal into atomic 5-90 minute tasks and surface the next safe action.",
+  "version": "0.0.3",
+  "websiteUrl": "https://neurodock.org/",
+  "repository": {
+    "url": "https://github.com/tlennon-ie/neurodock",
+    "source": "github",
+    "subfolder": "packages/mcp-task-fractionator"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "neurodock-mcp-task-fractionator",
+      "version": "0.0.3",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/server.py
+++ b/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/server.py
@@ -2,9 +2,14 @@
 # Copyright (c) 2026 NeuroDock contributors.
 """FastMCP server registration for the task fractionator tools.
 
-Two tools are registered (`decompose`, `next_one`). The server is pure glue —
-the heuristic engine lives in :mod:`decomposer`, the source protocol lives in
+Two tools exist (`decompose`, `next_one`). The server is pure glue — the
+heuristic engine lives in :mod:`decomposer`, the source protocol lives in
 :mod:`sources`, and Pydantic models live in :mod:`types`.
+
+Transport (ADR 0009 sections 1-2): stdio is the default and exposes BOTH
+tools. HTTP is opt-in (env ``NEURODOCK_HTTP`` truthy or ``--http``) and exposes
+ONLY ``decompose`` — ``next_one`` reads the local cognitive graph and is
+therefore not remote-safe, so it is registered in stdio mode only.
 
 Per ADR 0003 §7 nothing in this module logs goal text or project names.
 """
@@ -12,6 +17,7 @@ Per ADR 0003 §7 nothing in this module logs goal text or project names.
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from typing import Any
 
@@ -39,6 +45,10 @@ from neurodock_mcp_task_fractionator.tools.next_one import (
     next_one,
 )
 from neurodock_mcp_task_fractionator.topological import DependencyCycleError
+from neurodock_mcp_task_fractionator.transport import (
+    TransportConfig,
+    select_transport,
+)
 
 SERVER_NAME = "neurodock-mcp-task-fractionator"
 SERVER_VERSION = "0.0.1"
@@ -54,12 +64,22 @@ class _ToolError(RuntimeError):
         self.code = code
 
 
-def build_server(*, source: PendingTaskSource | None = None) -> FastMCP[Any]:
-    """Construct a fully wired FastMCP server with both tools registered.
+def build_server(
+    *,
+    source: PendingTaskSource | None = None,
+    http_mode: bool = False,
+) -> FastMCP[Any]:
+    """Construct a wired FastMCP server.
 
     ``source`` controls where ``next_one`` reads pending tasks from. Production
     callers pass nothing and the env-var-driven factory selects the default.
     Tests pass a stub source explicitly.
+
+    ``http_mode`` enforces the ADR 0008/0009 remote boundary: when ``True`` the
+    server registers ONLY ``decompose`` (the stateless, remote-safe tool) and
+    omits ``next_one`` entirely, because ``next_one`` reads the local cognitive
+    graph and must never be reachable over a network transport. When ``False``
+    (the stdio default) BOTH tools are registered, unchanged from today.
     """
 
     effective_source: PendingTaskSource = (
@@ -118,49 +138,75 @@ def build_server(*, source: PendingTaskSource | None = None) -> FastMCP[Any]:
             raise _ToolError("ACCEPTANCE_CRITERIA_REQUIRED", str(exc)) from exc
         return result.model_dump(exclude_none=False)
 
-    @mcp.tool(
-        name="next_one",
-        description=(
-            "Return exactly one task for the given project — the single thing "
-            "the user should do next — with reasoning and a confidence number. "
-            "Errors with NO_TASKS_AVAILABLE when nothing is pending."
-        ),
-    )
-    def _next_one(project: str) -> dict[str, Any]:
-        _LOG.info("tool_invoked", extra={"tool": "next_one"})
-        try:
-            result = next_one(project=project, source=effective_source)
-        except ProjectRequiredError as exc:
-            raise _ToolError("PROJECT_REQUIRED", str(exc)) from exc
-        except ProjectTooLongError as exc:
-            raise _ToolError("PROJECT_TOO_LONG", str(exc)) from exc
-        except NoTasksAvailableError as exc:
-            raise _ToolError("NO_TASKS_AVAILABLE", str(exc)) from exc
-        except AllTasksBlockedError as exc:
-            raise _ToolError(
-                "ALL_TASKS_BLOCKED",
-                (f"blocked_task_id: {exc.blocked_task_id}; blocker_ids: {exc.blocker_ids}"),
-            ) from exc
-        except CognitiveGraphUnavailableError as exc:
-            raise _ToolError("COGNITIVE_GRAPH_UNAVAILABLE", str(exc)) from exc
-        return result.model_dump(exclude_none=False)
+    # ``next_one`` reads the LOCAL cognitive graph and is NOT remote-safe
+    # (ADR 0008/0009). It is registered in stdio mode only; in HTTP mode it is
+    # absent from the tool list entirely.
+    if not http_mode:
+
+        @mcp.tool(
+            name="next_one",
+            description=(
+                "Return exactly one task for the given project — the single thing "
+                "the user should do next — with reasoning and a confidence number. "
+                "Errors with NO_TASKS_AVAILABLE when nothing is pending."
+            ),
+        )
+        def _next_one(project: str) -> dict[str, Any]:
+            _LOG.info("tool_invoked", extra={"tool": "next_one"})
+            try:
+                result = next_one(project=project, source=effective_source)
+            except ProjectRequiredError as exc:
+                raise _ToolError("PROJECT_REQUIRED", str(exc)) from exc
+            except ProjectTooLongError as exc:
+                raise _ToolError("PROJECT_TOO_LONG", str(exc)) from exc
+            except NoTasksAvailableError as exc:
+                raise _ToolError("NO_TASKS_AVAILABLE", str(exc)) from exc
+            except AllTasksBlockedError as exc:
+                raise _ToolError(
+                    "ALL_TASKS_BLOCKED",
+                    (f"blocked_task_id: {exc.blocked_task_id}; blocker_ids: {exc.blocker_ids}"),
+                ) from exc
+            except CognitiveGraphUnavailableError as exc:
+                raise _ToolError("COGNITIVE_GRAPH_UNAVAILABLE", str(exc)) from exc
+            return result.model_dump(exclude_none=False)
 
     return mcp
 
 
 # Module-level "default" server, useful for ``python -m`` invocation and for
-# smoke tests that just want to confirm registration succeeds.
+# smoke tests that just want to confirm registration succeeds. This is the
+# stdio build (BOTH tools), matching the default transport.
 app: FastMCP[Any] = build_server()
 
 
 def main() -> None:
-    """Console-script entrypoint: run the server over stdio."""
+    """Console-script entrypoint.
+
+    Default transport is stdio (BOTH tools). HTTP is opt-in via the
+    ``NEURODOCK_HTTP`` env var or the ``--http`` flag, and serves ONLY
+    ``decompose`` (ADR 0009 sections 1-2).
+    """
 
     logging.basicConfig(
         stream=sys.stderr,
         level=logging.INFO,
         format='{"logger":"%(name)s","level":"%(levelname)s","msg":"%(message)s"}',
     )
+
+    config: TransportConfig = select_transport(os.environ, sys.argv[1:])
+
+    if config.transport == "http":
+        # Build a dedicated HTTP server that registers ONLY ``decompose``.
+        # ``next_one`` is omitted so it cannot be reached over the network.
+        http_app: FastMCP[Any] = build_server(http_mode=True)
+        _LOG.info(
+            "transport_selected",
+            extra={"transport": "http", "host": config.host, "port": config.port},
+        )
+        http_app.run(transport="http", host=config.host, port=config.port)
+        return
+
+    _LOG.info("transport_selected", extra={"transport": "stdio"})
     app.run()
 
 

--- a/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/transport.py
+++ b/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/transport.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Transport selection for the NeuroDock stateless MCP servers (ADR 0009, Phase 2).
+
+stdio is the default and stays byte-for-byte unchanged. HTTP (FastMCP's
+Streamable HTTP transport) is opt-in via the ``NEURODOCK_HTTP`` env var (truthy:
+``1``/``true``/``yes``/``on``, case-insensitive) or a ``--http`` CLI flag, binding
+to ``NEURODOCK_HTTP_HOST`` (default ``127.0.0.1``) and ``NEURODOCK_HTTP_PORT``
+(default ``8000``). The helper is pure — env mapping + argv in, config out — so the
+selection logic is unit-testable without binding a socket. Per ADR 0009 §3 auth is
+deferred and the bare flag binds to localhost only.
+
+The three stateless servers (translation, guardrail, task-fractionator) keep an
+identical copy of this module: they are independently published packages and
+cannot share an import, so the contract is held identical by duplication.
+
+For task-fractionator the HTTP build additionally exposes only ``decompose``
+(``next_one`` reads the local cognitive graph); that scope gate lives in
+``server.build_server(http_mode=...)``, not here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Literal, NamedTuple
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+DEFAULT_HTTP_HOST = "127.0.0.1"
+DEFAULT_HTTP_PORT = 8000
+
+
+class TransportConfig(NamedTuple):
+    """The chosen transport and (for HTTP) its bind target.
+
+    ``host`` and ``port`` are ``None`` for stdio.
+    """
+
+    transport: Literal["stdio", "http"]
+    host: str | None = None
+    port: int | None = None
+
+
+def _is_truthy(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in _TRUTHY
+
+
+def _parse_port(raw: str | None) -> int:
+    """Parse a port override, falling back to the default on missing/invalid input."""
+    if raw is None or raw.strip() == "":
+        return DEFAULT_HTTP_PORT
+    try:
+        port = int(raw.strip())
+    except ValueError:
+        return DEFAULT_HTTP_PORT
+    return port if 1 <= port <= 65535 else DEFAULT_HTTP_PORT
+
+
+def select_transport(env: Mapping[str, str], argv: Sequence[str]) -> TransportConfig:
+    """Decide the transport from an env mapping and argv, without side effects.
+
+    HTTP is selected when ``NEURODOCK_HTTP`` is truthy OR ``--http`` is present in
+    ``argv``; otherwise stdio. ``argv`` excludes the program name (``sys.argv[1:]``).
+    """
+    http_requested = _is_truthy(env.get("NEURODOCK_HTTP")) or ("--http" in argv)
+    if not http_requested:
+        return TransportConfig(transport="stdio")
+    host = env.get("NEURODOCK_HTTP_HOST", "").strip() or DEFAULT_HTTP_HOST
+    port = _parse_port(env.get("NEURODOCK_HTTP_PORT"))
+    return TransportConfig(transport="http", host=host, port=port)

--- a/packages/mcp-task-fractionator/tests/test_transport.py
+++ b/packages/mcp-task-fractionator/tests/test_transport.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Transport-selection tests (ADR 0009 Phase 2).
+
+Three concerns are covered:
+
+1. The pure :func:`select_transport` helper (env dict + argv -> config), which
+   is unit-testable without binding a socket.
+2. The :func:`main` entrypoint wiring, exercised by monkeypatching ``run`` so
+   no real network listener is started.
+3. The tool-scope boundary: the HTTP build exposes ONLY ``decompose``; the
+   stdio build exposes BOTH ``decompose`` and ``next_one``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp import FastMCP
+from neurodock_mcp_task_fractionator import server as server_module
+from neurodock_mcp_task_fractionator.server import build_server
+from neurodock_mcp_task_fractionator.sources import InMemoryPendingTaskSource
+from neurodock_mcp_task_fractionator.transport import (
+    DEFAULT_HTTP_HOST,
+    DEFAULT_HTTP_PORT,
+    TransportConfig,
+    select_transport,
+)
+
+# --------------------------------------------------------------------------- #
+# Pure helper: select_transport
+# --------------------------------------------------------------------------- #
+
+
+def test_default_selects_stdio() -> None:
+    """No HTTP signal at all -> stdio with no host/port."""
+
+    config = select_transport(env={}, argv=[])
+
+    assert config == TransportConfig(transport="stdio", host=None, port=None)
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on", "  on  "])
+def test_truthy_env_selects_http(value: str) -> None:
+    """NEURODOCK_HTTP truthy (case-insensitive, trimmed) -> http on defaults."""
+
+    config = select_transport(env={"NEURODOCK_HTTP": value}, argv=[])
+
+    assert config.transport == "http"
+    assert config.host == DEFAULT_HTTP_HOST
+    assert config.port == DEFAULT_HTTP_PORT
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "maybe"])
+def test_falsy_env_stays_stdio(value: str) -> None:
+    """Anything not in the truthy set leaves the default stdio transport."""
+
+    config = select_transport(env={"NEURODOCK_HTTP": value}, argv=[])
+
+    assert config.transport == "stdio"
+
+
+def test_http_cli_flag_selects_http() -> None:
+    """A --http arg selects http even with no env var present."""
+
+    config = select_transport(env={}, argv=["--http"])
+
+    assert config.transport == "http"
+    assert config.host == DEFAULT_HTTP_HOST
+    assert config.port == DEFAULT_HTTP_PORT
+
+
+def test_host_and_port_overrides_are_applied() -> None:
+    """NEURODOCK_HTTP_HOST / NEURODOCK_HTTP_PORT override the defaults."""
+
+    config = select_transport(
+        env={
+            "NEURODOCK_HTTP": "1",
+            "NEURODOCK_HTTP_HOST": "0.0.0.0",
+            "NEURODOCK_HTTP_PORT": "9001",
+        },
+        argv=[],
+    )
+
+    assert config == TransportConfig(transport="http", host="0.0.0.0", port=9001)
+
+
+@pytest.mark.parametrize("raw", ["abc", "70000", "0", "-1", ""])
+def test_invalid_port_falls_back_to_default(raw: str) -> None:
+    """Unparseable / out-of-range ports fall back to 8000 rather than crashing."""
+
+    config = select_transport(env={"NEURODOCK_HTTP": "1", "NEURODOCK_HTTP_PORT": raw}, argv=[])
+
+    assert config.port == DEFAULT_HTTP_PORT
+
+
+# --------------------------------------------------------------------------- #
+# main() wiring — monkeypatch run so no socket binds
+# --------------------------------------------------------------------------- #
+
+
+class _RunRecorder:
+    """Records the args FastMCP.run was called with, instead of binding a socket.
+
+    Patched onto the FastMCP class as an attribute, this instance is *not* a
+    function, so the descriptor protocol does not bind ``self``; the bound
+    server instance is therefore absent from the call and the signature simply
+    captures positional and keyword args.
+    """
+
+    def __init__(self) -> None:
+        self.called = False
+        self.kwargs: dict[str, Any] = {}
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        self.called = True
+        self.kwargs = kwargs
+
+
+@pytest.fixture
+def run_recorder(monkeypatch: pytest.MonkeyPatch) -> _RunRecorder:
+    """Patch FastMCP.run on the class so both the module app and freshly
+    built HTTP apps are intercepted without opening a port."""
+
+    recorder = _RunRecorder()
+    monkeypatch.setattr(FastMCP, "run", recorder, raising=True)
+    return recorder
+
+
+def test_main_defaults_to_stdio(
+    monkeypatch: pytest.MonkeyPatch, run_recorder: _RunRecorder
+) -> None:
+    """With no env signal and no --http, main() runs stdio (no transport kwarg)."""
+
+    monkeypatch.delenv("NEURODOCK_HTTP", raising=False)
+    monkeypatch.setattr(server_module.sys, "argv", ["prog"])
+
+    server_module.main()
+
+    assert run_recorder.called is True
+    # stdio path calls app.run() with no transport/host/port kwargs.
+    assert run_recorder.kwargs == {}
+
+
+def test_main_env_selects_http_on_default_host_port(
+    monkeypatch: pytest.MonkeyPatch, run_recorder: _RunRecorder
+) -> None:
+    """NEURODOCK_HTTP=1 runs http bound to 127.0.0.1:8000."""
+
+    monkeypatch.setenv("NEURODOCK_HTTP", "1")
+    monkeypatch.delenv("NEURODOCK_HTTP_HOST", raising=False)
+    monkeypatch.delenv("NEURODOCK_HTTP_PORT", raising=False)
+    monkeypatch.setattr(server_module.sys, "argv", ["prog"])
+
+    server_module.main()
+
+    assert run_recorder.called is True
+    assert run_recorder.kwargs["transport"] == "http"
+    assert run_recorder.kwargs["host"] == "127.0.0.1"
+    assert run_recorder.kwargs["port"] == 8000
+
+
+def test_main_http_host_and_port_overrides(
+    monkeypatch: pytest.MonkeyPatch, run_recorder: _RunRecorder
+) -> None:
+    """Host/port env overrides flow through to the http run() call."""
+
+    monkeypatch.setenv("NEURODOCK_HTTP", "1")
+    monkeypatch.setenv("NEURODOCK_HTTP_HOST", "0.0.0.0")
+    monkeypatch.setenv("NEURODOCK_HTTP_PORT", "9100")
+    monkeypatch.setattr(server_module.sys, "argv", ["prog"])
+
+    server_module.main()
+
+    assert run_recorder.kwargs["transport"] == "http"
+    assert run_recorder.kwargs["host"] == "0.0.0.0"
+    assert run_recorder.kwargs["port"] == 9100
+
+
+def test_main_http_cli_flag(monkeypatch: pytest.MonkeyPatch, run_recorder: _RunRecorder) -> None:
+    """A --http CLI arg selects http even without the env var."""
+
+    monkeypatch.delenv("NEURODOCK_HTTP", raising=False)
+    monkeypatch.setattr(server_module.sys, "argv", ["prog", "--http"])
+
+    server_module.main()
+
+    assert run_recorder.kwargs["transport"] == "http"
+    assert run_recorder.kwargs["host"] == "127.0.0.1"
+    assert run_recorder.kwargs["port"] == 8000
+
+
+# --------------------------------------------------------------------------- #
+# Tool-scope boundary: decompose-only over HTTP
+# --------------------------------------------------------------------------- #
+
+
+async def test_http_build_exposes_only_decompose() -> None:
+    """The HTTP build CONTAINS decompose and does NOT contain next_one."""
+
+    http_server = build_server(source=InMemoryPendingTaskSource(), http_mode=True)
+
+    names = {tool.name for tool in await http_server.list_tools()}
+
+    assert "decompose" in names
+    assert "next_one" not in names
+    assert names == {"decompose"}
+
+
+async def test_stdio_build_exposes_both_tools() -> None:
+    """The stdio build CONTAINS both decompose and next_one (unchanged today)."""
+
+    stdio_server = build_server(source=InMemoryPendingTaskSource())
+
+    names = {tool.name for tool in await stdio_server.list_tools()}
+
+    assert names == {"decompose", "next_one"}

--- a/packages/mcp-task-fractionator/tests/test_transport.py
+++ b/packages/mcp-task-fractionator/tests/test_transport.py
@@ -14,6 +14,7 @@ Three concerns are covered:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -196,23 +197,28 @@ def test_main_http_cli_flag(monkeypatch: pytest.MonkeyPatch, run_recorder: _RunR
 # --------------------------------------------------------------------------- #
 
 
-async def test_http_build_exposes_only_decompose() -> None:
-    """The HTTP build CONTAINS decompose and does NOT contain next_one."""
+def test_http_build_exposes_only_decompose() -> None:
+    """The HTTP build CONTAINS decompose and does NOT contain next_one.
+
+    Synchronous (``asyncio.run``) rather than ``async def`` so it does not depend
+    on pytest-asyncio auto-mode — CI runs ``pytest`` from the repo root where the
+    per-package ``asyncio_mode = "auto"`` does not apply.
+    """
 
     http_server = build_server(source=InMemoryPendingTaskSource(), http_mode=True)
 
-    names = {tool.name for tool in await http_server.list_tools()}
+    names = {tool.name for tool in asyncio.run(http_server.list_tools())}
 
     assert "decompose" in names
     assert "next_one" not in names
     assert names == {"decompose"}
 
 
-async def test_stdio_build_exposes_both_tools() -> None:
+def test_stdio_build_exposes_both_tools() -> None:
     """The stdio build CONTAINS both decompose and next_one (unchanged today)."""
 
     stdio_server = build_server(source=InMemoryPendingTaskSource())
 
-    names = {tool.name for tool in await stdio_server.list_tools()}
+    names = {tool.name for tool in asyncio.run(stdio_server.list_tools())}
 
     assert names == {"decompose", "next_one"}

--- a/packages/mcp-translation/CHANGELOG.md
+++ b/packages/mcp-translation/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to `neurodock-mcp-translation` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This package follows semantic versioning per .
 
+## [unreleased]
+
+### Added — opt-in HTTP transport (ADR 0009 Phase 2)
+
+`main()` can now run over **Streamable HTTP** in addition to stdio. The default is
+unchanged: with no HTTP signal it runs **stdio**, byte-for-byte identical to before.
+HTTP is opt-in via the `NEURODOCK_HTTP` env var (truthy `1`/`true`/`yes`/`on`,
+case-insensitive) or a `--http` flag, binding `NEURODOCK_HTTP_HOST` (default
+`127.0.0.1`) and `NEURODOCK_HTTP_PORT` (default `8000`). No auth yet — the bare flag
+binds to localhost only (ADR 0009 §3). Transport selection lives in a new pure
+`transport.py` helper shared (by identical copy) across the three stateless servers.
+
 ## [0.2.0] - 2026-05-25 — translate-not-summarize, for real this time
 
 The 0.1.0 / v0.2.0-schema ship added `content_translation` as an OPTIONAL

--- a/packages/mcp-translation/README.md
+++ b/packages/mcp-translation/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.tlennon-ie/neurodock-mcp-translation -->
+
 # neurodock-mcp-translation
 
 Communication and translation tools as an MCP server. Shares its schemas and

--- a/packages/mcp-translation/server.json
+++ b/packages/mcp-translation/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tlennon-ie/neurodock-mcp-translation",
+  "title": "NeuroDock Translation",
+  "description": "Decode subtext, tone, and ambiguity in messages; rewrite outgoing replies; brief meetings.",
+  "version": "0.2.0",
+  "websiteUrl": "https://neurodock.org/",
+  "repository": {
+    "url": "https://github.com/tlennon-ie/neurodock",
+    "source": "github",
+    "subfolder": "packages/mcp-translation"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "neurodock-mcp-translation",
+      "version": "0.2.0",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/mcp-translation/src/neurodock_mcp_translation/server.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/server.py
@@ -11,6 +11,7 @@ OpenAI, ...). The server is provider-agnostic.
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from typing import Any
 
@@ -24,6 +25,7 @@ from neurodock_mcp_translation.tools.brief_meeting import (
 from neurodock_mcp_translation.tools.check_tone import check_tone
 from neurodock_mcp_translation.tools.rewrite_outgoing import rewrite_outgoing
 from neurodock_mcp_translation.tools.translate_incoming import translate_incoming
+from neurodock_mcp_translation.transport import select_transport
 from neurodock_mcp_translation.types import (
     BriefMeetingInput,
     CheckToneInput,
@@ -206,14 +208,30 @@ app: FastMCP[Any] = build_server()
 
 
 def main() -> None:
-    """Console-script entrypoint: run the server over stdio."""
+    """Console-script entrypoint.
+
+    Runs over stdio by default (ADR 0009 — byte-for-byte unchanged install
+    path). HTTP (FastMCP Streamable HTTP) is opt-in via the ``NEURODOCK_HTTP``
+    env var or a ``--http`` flag; see ``transport.select_transport``.
+    """
 
     logging.basicConfig(
         stream=sys.stderr,
         level=logging.INFO,
         format='{"logger":"%(name)s","level":"%(levelname)s","msg":"%(message)s"}',
     )
-    app.run()
+
+    config = select_transport(os.environ, sys.argv[1:])
+    if config.transport == "stdio":
+        _LOG.info("transport_selected", extra={"transport": "stdio"})
+        app.run()
+        return
+
+    _LOG.info(
+        "transport_selected",
+        extra={"transport": "http", "host": config.host, "port": config.port},
+    )
+    app.run(transport="http", host=config.host, port=config.port)
 
 
 if __name__ == "__main__":  # pragma: no cover — exercised via console script

--- a/packages/mcp-translation/src/neurodock_mcp_translation/transport.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/transport.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Transport selection for the NeuroDock stateless MCP servers (ADR 0009, Phase 2).
+
+stdio is the default and stays byte-for-byte unchanged. HTTP (FastMCP's
+Streamable HTTP transport) is opt-in via the ``NEURODOCK_HTTP`` env var (truthy:
+``1``/``true``/``yes``/``on``, case-insensitive) or a ``--http`` CLI flag, binding
+to ``NEURODOCK_HTTP_HOST`` (default ``127.0.0.1``) and ``NEURODOCK_HTTP_PORT``
+(default ``8000``). The helper is pure — env mapping + argv in, config out — so the
+selection logic is unit-testable without binding a socket. Per ADR 0009 §3 auth is
+deferred and the bare flag binds to localhost only.
+
+The three stateless servers (translation, guardrail, task-fractionator) keep an
+identical copy of this module: they are independently published packages and
+cannot share an import, so the contract is held identical by duplication.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Literal, NamedTuple
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+DEFAULT_HTTP_HOST = "127.0.0.1"
+DEFAULT_HTTP_PORT = 8000
+
+
+class TransportConfig(NamedTuple):
+    """The chosen transport and (for HTTP) its bind target.
+
+    ``host`` and ``port`` are ``None`` for stdio.
+    """
+
+    transport: Literal["stdio", "http"]
+    host: str | None = None
+    port: int | None = None
+
+
+def _is_truthy(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in _TRUTHY
+
+
+def _parse_port(raw: str | None) -> int:
+    """Parse a port override, falling back to the default on missing/invalid input."""
+    if raw is None or raw.strip() == "":
+        return DEFAULT_HTTP_PORT
+    try:
+        port = int(raw.strip())
+    except ValueError:
+        return DEFAULT_HTTP_PORT
+    return port if 1 <= port <= 65535 else DEFAULT_HTTP_PORT
+
+
+def select_transport(env: Mapping[str, str], argv: Sequence[str]) -> TransportConfig:
+    """Decide the transport from an env mapping and argv, without side effects.
+
+    HTTP is selected when ``NEURODOCK_HTTP`` is truthy OR ``--http`` is present in
+    ``argv``; otherwise stdio. ``argv`` excludes the program name (``sys.argv[1:]``).
+    """
+    http_requested = _is_truthy(env.get("NEURODOCK_HTTP")) or ("--http" in argv)
+    if not http_requested:
+        return TransportConfig(transport="stdio")
+    host = env.get("NEURODOCK_HTTP_HOST", "").strip() or DEFAULT_HTTP_HOST
+    port = _parse_port(env.get("NEURODOCK_HTTP_PORT"))
+    return TransportConfig(transport="http", host=host, port=port)

--- a/packages/mcp-translation/tests/test_transport.py
+++ b/packages/mcp-translation/tests/test_transport.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Transport selection (ADR 0009, Phase 2 scaffolding).
+
+Covers the pure ``select_transport`` helper plus the ``main()`` wiring. No test
+binds a real socket: ``app.run`` is intercepted via monkeypatch so HTTP mode is
+verified by the kwargs passed, not by a listening server.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from neurodock_mcp_translation import server
+from neurodock_mcp_translation.transport import (
+    DEFAULT_HTTP_HOST,
+    DEFAULT_HTTP_PORT,
+    TransportConfig,
+    select_transport,
+)
+
+
+def test_default_selects_stdio() -> None:
+    """No env signal and no flag → stdio, with no host/port."""
+
+    config = select_transport(env={}, argv=[])
+
+    assert config == TransportConfig(transport="stdio", host=None, port=None)
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on", "  on  "])
+def test_neurodock_http_truthy_selects_http_defaults(value: str) -> None:
+    """A truthy NEURODOCK_HTTP (case-insensitive) → http on localhost:8000."""
+
+    config = select_transport(env={"NEURODOCK_HTTP": value}, argv=[])
+
+    assert config.transport == "http"
+    assert config.host == DEFAULT_HTTP_HOST == "127.0.0.1"
+    assert config.port == DEFAULT_HTTP_PORT == 8000
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "maybe"])
+def test_neurodock_http_falsy_stays_stdio(value: str) -> None:
+    """A non-truthy NEURODOCK_HTTP value must not flip to http."""
+
+    config = select_transport(env={"NEURODOCK_HTTP": value}, argv=[])
+
+    assert config.transport == "stdio"
+
+
+def test_host_and_port_overrides_respected() -> None:
+    """NEURODOCK_HTTP_HOST / NEURODOCK_HTTP_PORT override the defaults."""
+
+    config = select_transport(
+        env={
+            "NEURODOCK_HTTP": "1",
+            "NEURODOCK_HTTP_HOST": "0.0.0.0",
+            "NEURODOCK_HTTP_PORT": "9123",
+        },
+        argv=[],
+    )
+
+    assert config == TransportConfig(transport="http", host="0.0.0.0", port=9123)
+
+
+def test_http_flag_selects_http() -> None:
+    """A --http argument selects http even without any env signal."""
+
+    config = select_transport(env={}, argv=["--http"])
+
+    assert config.transport == "http"
+    assert config.host == DEFAULT_HTTP_HOST
+    assert config.port == DEFAULT_HTTP_PORT
+
+
+def test_invalid_port_falls_back_to_default() -> None:
+    """A non-integer port string degrades to the 8000 default, not a crash."""
+
+    config = select_transport(
+        env={"NEURODOCK_HTTP": "1", "NEURODOCK_HTTP_PORT": "not-a-number"},
+        argv=[],
+    )
+
+    assert config.port == DEFAULT_HTTP_PORT
+
+
+def test_main_default_runs_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() with no signal calls app.run() with no transport kwargs."""
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(server.app, "run", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(server.sys, "argv", ["neurodock-mcp-translation"])
+    monkeypatch.delenv("NEURODOCK_HTTP", raising=False)
+
+    server.main()
+
+    assert calls == [{}]
+
+
+def test_main_http_env_runs_streamable_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() with NEURODOCK_HTTP=1 calls app.run(transport='http', host, port)."""
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(server.app, "run", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(server.sys, "argv", ["neurodock-mcp-translation"])
+    monkeypatch.setenv("NEURODOCK_HTTP", "1")
+    monkeypatch.delenv("NEURODOCK_HTTP_HOST", raising=False)
+    monkeypatch.delenv("NEURODOCK_HTTP_PORT", raising=False)
+
+    server.main()
+
+    assert calls == [{"transport": "http", "host": "127.0.0.1", "port": 8000}]
+
+
+def test_main_http_flag_runs_streamable_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() with a --http argv flag calls app.run in http mode."""
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(server.app, "run", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(server.sys, "argv", ["neurodock-mcp-translation", "--http"])
+    monkeypatch.delenv("NEURODOCK_HTTP", raising=False)
+
+    server.main()
+
+    assert calls == [{"transport": "http", "host": "127.0.0.1", "port": 8000}]


### PR DESCRIPTION
Phases 1–2 of the distribution roadmap (ADR 0008, ADR 0009). **Additive — no change to the existing npm/stdio install path.**

## Phase 1 — local recognition (commit 1)
- **MCP Registry:** `server.json` for all 5 servers (`io.github.tlennon-ie/*`, PyPI, `uvx`, stdio), validated against the `2025-12-11` schema; `mcp-name` ownership markers added to each package README.
- **Claude Code plugin** at `claude-code/neurodock/` + `.claude-plugin/marketplace.json`, bundling the 5 servers (via `uvx`) and 6 ND-aware skills adapted for distribution.
- **5 `.mcpb` desktop-extension manifests** (thin `uvx` launchers) + build/privacy README.
- ADR 0008, README "Other ways to install", `*.mcpb` gitignore.

## Phase 2 — remote transport scaffolding (commit 2)
- Opt-in HTTP (FastMCP Streamable HTTP) on **translation, guardrail, task-fractionator**. **stdio stays the default** (byte-for-byte unchanged).
- Opt-in via `NEURODOCK_HTTP` (`1/true/yes/on`) or `--http`; binds `NEURODOCK_HTTP_HOST`/`NEURODOCK_HTTP_PORT` (default `127.0.0.1:8000`). No auth yet — localhost only (ADR 0009 §3).
- **Remote boundary enforced in code:** task-fractionator's HTTP build exposes **`decompose` only**; `next_one` (reads the local cognitive graph) is stdio-only.
- All three carry an identical, pure `transport.py` `select_transport` helper with robust port fallback.
- ADR 0009 records the deferred auth/hosting plan (container host fronted by Cloudflare; Workers rejected for the Python servers).

## Test plan
- [x] `server.json` ×5 validate against the live registry schema (`check-jsonschema`).
- [x] `claude plugin validate` (plugin + marketplace) — pass.
- [x] `mcpb validate` ×5 + a `pack` smoke-test — pass.
- [x] Per-package suites green: translation 48, guardrail 72, task-fractionator 61.
- [x] `ruff` + `mypy --strict` clean on changed Python; pre-commit (prettier/commitlint) green.
- [x] stdio-default preserved — asserted by `main()`-wiring tests in all three packages.
- [ ] CodeQL (this PR) — watching.

## Not in this PR (follow-ups)
- Registry publish (needs a PyPI patch-release per server so the `mcp-name` markers go live, then `mcp-publisher`).
- Phase 2 auth (OAuth 2.1) + container hosting + `mcp.neurodock.org` + Connectors Directory submission.
