### PR TITLE
feat: remote MCP server foundation (Phase 2)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -346,6 +346,7 @@ export default defineConfig({
           ],
         },
         { label: "Ethics", link: "/ethics/", badge: userBadge },
+        { label: "Privacy", link: "/legal/privacy/", badge: userBadge },
         { label: "FAQ", link: "/faq/", badge: userBadge },
       ],
       // Honour prefers-reduced-motion at the platform level.

--- a/docs/decisions/0009-remote-transport-and-hosting.md
+++ b/docs/decisions/0009-remote-transport-and-hosting.md
@@ -1,6 +1,6 @@
 # 0009 — Remote transport and hosting for the stateless servers (Phase 2)
 
-- **Status:** proposed
+- **Status:** accepted — Phase 2 foundation implemented 2026-05-30; OAuth IdP selection, hosting, and the Connectors Directory submission remain pending.
 - **Date:** 2026-05-30
 - **Deciders:** maintainer (TBD), `mcp-architect`
 - **Consulted:** `mcp-server-builder`, `mcp-translation-expert`, `mcp-guardrail-expert`, `mcp-task-fractionator-expert`, `governance-author` (privacy policy / AGPL)
@@ -76,3 +76,35 @@ submission.
 
 **Open questions:** managed-IdP choice; container host; single-vs-multi endpoint;
 whether to ever rewrite the stateless tools as a TS Worker.
+
+## Implementation status (2026-05-30 — Phase 2 foundation)
+
+The decision-independent foundation now exists as the **`packages/remote`**
+workspace package (`neurodock-remote`, an internal deploy artifact — not published
+to PyPI):
+
+- **Combined server (decision 5 → single endpoint).** `app.py` composes the three
+  stateless servers with FastMCP `mount` (no namespace → flat tool names) into one
+  Streamable HTTP app at `/mcp`, plus a `/health` probe. The exposed surface is
+  exactly the eight remote-safe tools; tests pin it against `REMOTE_TOOL_NAMES` and
+  assert `next_one` / cognitive-graph / chronometric tools never leak (decision 2).
+- **Auth scaffold (decision 3), vendor-pluggable and default-off.** `auth.py` reads
+  `NEURODOCK_AUTH_PROVIDER` (`none` | `workos` | `jwt`) and builds the matching
+  FastMCP provider — WorkOS `AuthKitProvider` (purpose-built for MCP DCR + RFC 9728)
+  or a generic `RemoteAuthProvider`/`JWTVerifier` for any OIDC issuer. The IdP is
+  therefore a configuration choice, not a code change. Default `none` returns no
+  auth and logs a loud warning that the endpoint must not be exposed publicly.
+- **Container (decision 4).** `Dockerfile` builds only the stateless workspace
+  subset, runs non-root with a healthcheck, and binds `0.0.0.0` explicitly (the
+  app code still defaults to `127.0.0.1`).
+- **Privacy policy.** Published at `/legal/privacy/` on the docs site — the top
+  Connectors-Directory rejection cause, removed in advance.
+
+Verified locally: 10 tests green under the repo-root pytest config, `ruff` clean,
+`mypy --strict` clean, and a served-app smoke test (`/health` → 200, `/mcp` → 406
+for a bare GET, i.e. the route is live).
+
+**Still gated on a human decision / action:** (a) pick the managed IdP and stand up
+its tenant; (b) pick the container host and deploy the image; (c) add a proxied
+`mcp.neurodock.org` DNS record once the host exists; (d) submit to the Anthropic
+Connectors Directory. None of these change the foundation above.

--- a/docs/src/content/docs/legal/privacy.mdx
+++ b/docs/src/content/docs/legal/privacy.mdx
@@ -1,0 +1,103 @@
+---
+title: Privacy Policy
+description: What NeuroDock does and does not do with your data — local-first by default, and exactly what transits the optional hosted remote server.
+---
+
+> **Last updated:** 2026-05-30
+
+NeuroDock is a **local-first cognitive substrate**. The short version: by default,
+nothing about you leaves your machine. This page explains that precisely, and
+states exactly what happens in the one case where data does cross the network —
+the optional hosted remote server.
+
+:::tip[Commitment]
+**We never track silently.** There is no telemetry, no analytics, no remote
+aggregation — anonymised or otherwise. This is principle 1 of the project
+[Ethics](/ethics/) and it is enforced in auditable source code.
+:::
+
+## What runs on your machine
+
+When you install NeuroDock the normal way (`@neurodock/cli`, an `.mcpb` bundle, or
+the Claude Code plugin), every server runs **locally over stdio** and every byte
+of your data stays on your device. Specifically, these never leave your machine:
+
+- **Your profile** (`~/.neurodock/profile.yaml`) — including any self-identified
+  neurotype information. Self-identification is never transmitted, never verified
+  against any third party, and never required.
+- **Your cognitive graph** — the people, projects, decisions, and facts you record
+  live in a local SQLite database.
+- **Session and timing data** — the chronometric server holds session state in
+  memory on your machine only.
+- **Message and document text** you pass to any tool.
+
+We do not have a server that receives this data, because for the local install
+there is no remote endpoint involved at all.
+
+## Operational logging
+
+The local servers emit **operational logs to standard error only** (for example,
+"a tool was invoked"). By design they **do not log the content** you pass in — not
+message text, not goal descriptions, not project names (see
+[ADR 0003](/decisions/0003-task-fractionator/) and
+[ADR 0005](/decisions/0005-translation/)). These logs stay on your machine and are
+never transmitted to us.
+
+## The optional hosted remote server
+
+We may operate a **hosted remote server** (for example at
+`https://mcp.neurodock.org/mcp`) that you can connect to as an MCP connector. Using
+it is **entirely optional** — the default install does not use it. If and when you
+choose to connect to it, these commitments apply:
+
+- **Only the stateless tools are available remotely.** The hosted server exposes
+  only the communication and planning tools: message translation, tone and
+  rewriting help, the rumination / hyperfocus / over-validation guardrails, and
+  goal decomposition. Your **cognitive graph, profile, and session history are
+  never reachable over the network** — they have no remote endpoint by design.
+- **Processing is ephemeral.** Text you send to a remote tool is processed in
+  memory to produce the response and is **not stored**, **not written to a
+  database**, and **not retained** after the request completes.
+- **No content logging.** As with the local servers, request/response **content is
+  not logged**. Operational logs record that a tool ran, not what was in it.
+- **No training.** Your data is **never used to train any model**. The servers run
+  deterministic analysis and return structured prompts; no model is trained on, or
+  fine-tuned from, anything you send.
+- **No profiling or aggregation.** We do not build user profiles and do not
+  aggregate requests into population-level datasets.
+- **Authentication.** Access is gated by OAuth 2.1 via an identity provider. We
+  receive only the minimal token claims needed to authorise the request; we do not
+  store your credentials.
+- **Transport.** All remote traffic is encrypted in transit (HTTPS only).
+
+## What we never do
+
+- We never sell or rent your data.
+- We never serve advertising or embed third-party trackers.
+- We never share your data with third parties for their own purposes.
+- We never aggregate detection events (rumination, hyperfocus, sycophancy) into
+  population-level data — every such signal stays on your machine.
+
+## Your control and deletion
+
+Because the local install keeps everything on your device, **you are in control**:
+delete the files in `~/.neurodock/` and the data is gone. The hosted remote server
+stores no personal content, so there is nothing for us to retain or delete on your
+behalf.
+
+## Children
+
+NeuroDock is a professional productivity tool and is not directed at children.
+
+## Changes to this policy
+
+If this policy changes materially, we will update the date above and record the
+change in the public repository's history. Because the policy lives in
+[the open-source repository](https://github.com/tlennon-ie/neurodock), every
+revision is publicly auditable.
+
+## Contact
+
+Questions about privacy can be raised as an issue on the
+[NeuroDock repository](https://github.com/tlennon-ie/neurodock/issues) or by email
+to the maintainer listed there.

--- a/packages/remote/CHANGELOG.md
+++ b/packages/remote/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to `neurodock-remote` are documented here. This is an internal
+deploy artifact and is not published to PyPI; versions track the deployed image.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [unreleased]
+
+### Added
+
+- Initial combined remote MCP server (ADR 0008/0009, Phase 2). Composes the three
+  stateless servers — translation (×4), guardrail (×3), and task-fractionator
+  `decompose` — into one Streamable HTTP endpoint at `/mcp` via FastMCP `mount`,
+  with a `/health` probe and an env-driven, vendor-pluggable OAuth resource-server
+  auth scaffold (`none` | `workos` | `jwt`, default `none`).
+- `Dockerfile` (single-stage, non-root, healthcheck) building only the stateless
+  workspace subset.
+- Tests pinning the exposed tool surface to exactly the eight remote-safe tools and
+  asserting local-only tools (`next_one`, cognitive-graph, chronometric) never leak.
+- Clerk OAuth wired as the selected provider (`NEURODOCK_AUTH_PROVIDER=clerk`, via
+  FastMCP's `ClerkProvider` OAuth proxy), alongside the existing `workos` and `jwt`
+  options.
+- Cloudflare Containers deploy scaffold: `wrangler.jsonc`, a Worker shim
+  (`worker/index.ts`) that fronts `mcp.neurodock.org` and proxies to the container,
+  `package.json` + `tsconfig.json`, and a deploy runbook in the README. Verified by
+  docs; first `wrangler deploy` is the validation step.

--- a/packages/remote/Dockerfile
+++ b/packages/remote/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+# NeuroDock remote MCP server — the combined STATELESS tool surface (ADR 0008/0009).
+#
+# Build from the REPO ROOT (the workspace graph must be visible):
+#   docker build -f packages/remote/Dockerfile -t neurodock-remote .
+#
+# Single-stage on the uv image: the resolved virtualenv at /app/.venv references
+# this image's interpreter, so we serve from the same base rather than copying the
+# venv onto a different python image (which would break the interpreter path).
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+
+# Workspace metadata + lockfile first for layer caching. The remote package depends
+# on three sibling workspace packages, so the whole workspace must be present to
+# resolve from the frozen lock.
+COPY pyproject.toml uv.lock README.md ./
+COPY packages/ ./packages/
+
+# Install ONLY neurodock-remote and its (stateless) workspace dependencies. The
+# stateful servers (cognitive-graph, chronometric) and their heavy native deps are
+# not dependencies of neurodock-remote and are therefore never installed.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --package neurodock-remote
+
+# Bind all interfaces (the container sits behind the edge/proxy). This is an
+# explicit deployment decision; the application code defaults to 127.0.0.1.
+ENV NEURODOCK_HTTP_HOST=0.0.0.0 \
+    NEURODOCK_HTTP_PORT=8000
+
+# Run as a non-root user.
+RUN useradd --create-home --uid 10001 neurodock \
+    && chown -R neurodock:neurodock /app
+USER neurodock
+
+EXPOSE 8000
+
+# Public deployments MUST set NEURODOCK_AUTH_PROVIDER + the matching IdP config
+# (ADR 0009 §3); without it the server logs a loud warning and serves unauthenticated.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=4).status == 200 else 1)"
+
+CMD ["uvicorn", "neurodock_remote.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]

--- a/packages/remote/Dockerfile.dockerignore
+++ b/packages/remote/Dockerfile.dockerignore
@@ -1,0 +1,24 @@
+# Build context is the repo root (the Dockerfile uses root-relative COPY paths,
+# and Cloudflare Containers builds with image_build_context: "../../").
+# BuildKit reads `<dockerfile>.dockerignore` (this file) in preference to a
+# context-root .dockerignore, so this applies to both `docker build -f
+# packages/remote/Dockerfile .` and `wrangler deploy`.
+# Keep the build context small and deterministic.
+**/.venv
+**/node_modules
+**/dist
+**/build
+**/.turbo
+**/__pycache__
+**/*.pyc
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+.git
+.github
+docs
+extension
+**/*.mcpb
+.env
+.env.*
+*.log

--- a/packages/remote/README.md
+++ b/packages/remote/README.md
@@ -1,0 +1,106 @@
+# neurodock-remote
+
+The **combined remote MCP server** for NeuroDock (ADR 0008 / ADR 0009, Phase 2).
+
+It composes the three **stateless** NeuroDock servers into a single
+[Streamable HTTP](https://modelcontextprotocol.io/) endpoint and exposes **only**
+the remote-safe tools:
+
+| Source server           | Tools exposed remotely                                                  |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `mcp-translation`       | `translate_incoming`, `check_tone`, `rewrite_outgoing`, `brief_meeting` |
+| `mcp-guardrail`         | `check_rumination`, `check_hyperfocus`, `check_sycophancy`              |
+| `mcp-task-fractionator` | `decompose` only                                                        |
+
+### What is deliberately NOT here
+
+The cognitive graph (personal facts), chronometric session state, the user
+profile (neurotype data), and task-fractionator's `next_one` (reads the local
+graph) are **never** mounted. They read or hold local state and stay strictly on
+the local stdio install. The boundary is enforced in code and pinned by tests
+against `REMOTE_TOOL_NAMES`.
+
+> This is a **deploy artifact**, not a published package — it is not uploaded to
+> PyPI (the local install path via `@neurodock/cli` is unchanged). Local-only
+> tools remain available exactly as before through the stdio servers.
+
+## Run locally
+
+```bash
+# from the repo root
+uv run --package neurodock-remote neurodock-remote
+# serves http://127.0.0.1:8000/mcp  (+ /health)
+```
+
+Inspect it with the MCP Inspector pointed at `http://127.0.0.1:8000/mcp`.
+
+## Configuration
+
+| Env var                                              | Default     | Purpose                                                                                 |
+| ---------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------- |
+| `NEURODOCK_HTTP_HOST`                                | `127.0.0.1` | Bind host (`0.0.0.0` in the container).                                                 |
+| `NEURODOCK_HTTP_PORT`                                | `8000`      | Bind port.                                                                              |
+| `NEURODOCK_AUTH_PROVIDER`                            | `none`      | `none` \| `clerk` \| `workos` \| `jwt`. The hosted deploy uses `clerk`.                 |
+| `NEURODOCK_PUBLIC_URL`                               | —           | Public base URL, e.g. `https://mcp.neurodock.org` (required by `clerk`/`workos`/`jwt`). |
+| `NEURODOCK_OAUTH_REQUIRED_SCOPES`                    | —           | Optional, comma-separated.                                                              |
+| `NEURODOCK_CLERK_DOMAIN`                             | —           | `clerk`: your Clerk instance domain (e.g. `your-app.clerk.accounts.dev`).               |
+| `NEURODOCK_CLERK_CLIENT_ID`                          | —           | `clerk`: OAuth application client ID.                                                   |
+| `NEURODOCK_CLERK_CLIENT_SECRET`                      | —           | `clerk`: OAuth client secret (set as a secret, not plaintext).                          |
+| `NEURODOCK_AUTHKIT_DOMAIN`                           | —           | `workos`: your AuthKit domain.                                                          |
+| `NEURODOCK_OAUTH_ISSUER` / `_JWKS_URI` / `_AUDIENCE` | —           | `jwt`: generic OIDC resource-server config.                                             |
+
+> ⚠️ **Auth is required before public exposure.** With `NEURODOCK_AUTH_PROVIDER`
+> unset the server runs **unauthenticated** and logs a loud warning — that mode is
+> for localhost/integration testing only (ADR 0009 §3). The identity provider is a
+> configuration choice, not a code change; FastMCP ships first-class Clerk, WorkOS
+> AuthKit, and Auth0 providers plus the generic JWT verifier wired here.
+
+## Container (any host)
+
+```bash
+# build from the repo root (the Dockerfile uses root-relative COPY paths)
+docker build -f packages/remote/Dockerfile -t neurodock-remote .
+docker run --rm -p 8000:8000 \
+  -e NEURODOCK_AUTH_PROVIDER=clerk \
+  -e NEURODOCK_CLERK_DOMAIN=your-app.clerk.accounts.dev \
+  -e NEURODOCK_CLERK_CLIENT_ID=xxxx \
+  -e NEURODOCK_CLERK_CLIENT_SECRET=yyyy \
+  -e NEURODOCK_PUBLIC_URL=https://mcp.neurodock.org \
+  neurodock-remote
+```
+
+## Deploy to Cloudflare Containers
+
+The chosen host (ADR 0009). The Python container runs on Cloudflare Containers,
+fronted by a thin Worker ([worker/index.ts](worker/index.ts)) that owns the
+`mcp.neurodock.org` custom domain. Config: [wrangler.jsonc](wrangler.jsonc).
+
+> **Requires a Workers _Paid_ plan** — Containers are not on the free tier.
+> The Worker + container are deploy tooling only; this directory is intentionally
+> **not** a pnpm-workspace member, so install/deploy happen here directly.
+
+1. **Create a Clerk OAuth application** and note the instance domain + client ID/secret.
+2. Fill `vars` in [wrangler.jsonc](wrangler.jsonc) (`NEURODOCK_CLERK_DOMAIN`,
+   `NEURODOCK_CLERK_CLIENT_ID`) — these are non-secret.
+3. From this directory (`packages/remote/`):
+
+   ```bash
+   npm install
+   npx wrangler secret put NEURODOCK_CLERK_CLIENT_SECRET   # paste the secret
+   npx wrangler deploy                                     # builds ../Dockerfile, pushes, deploys
+   ```
+
+   `wrangler deploy` builds the image (context `../../` = repo root), provisions
+   the `mcp.neurodock.org` DNS + TLS automatically (the `custom_domain` route), and
+   starts the container behind the Worker.
+
+4. Verify: `https://mcp.neurodock.org/health` → `200`, then add
+   `https://mcp.neurodock.org/mcp` as a custom connector in Claude and complete the
+   Clerk OAuth round-trip.
+
+See [ADR 0009](../../docs/decisions/0009-remote-transport-and-hosting.md) for the
+transport, scope, auth, and hosting decisions.
+
+> **Status:** this Cloudflare deploy config is a verified-by-docs scaffold; it has
+> not yet been run through `wrangler deploy`. Treat the first deploy as the
+> validation step.

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@neurodock/remote-worker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloudflare Containers Worker shim fronting the NeuroDock remote MCP container. Standalone deploy tooling — intentionally NOT a pnpm-workspace member; install and deploy from this directory.",
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@cloudflare/containers": "^0.0.40"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250505.0",
+    "typescript": "^5.6.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/packages/remote/pyproject.toml
+++ b/packages/remote/pyproject.toml
@@ -1,0 +1,50 @@
+[project]
+name = "neurodock-remote"
+version = "0.1.0"
+description = "NeuroDock remote MCP server — composes the stateless tool surface (translation, guardrail, task-fractionator decompose) into one Streamable HTTP endpoint. Deploy artifact; not published to PyPI."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "AGPL-3.0-or-later" }
+authors = [{ name = "NeuroDock contributors" }]
+# Internal deploy artifact — the trove classifier below hard-blocks any
+# accidental upload to PyPI. The CI publish glob also excludes it (it does not
+# match `packages/mcp-*`).
+classifiers = ["Private :: Do Not Upload"]
+dependencies = [
+    "fastmcp>=3.3.0",
+    "pydantic>=2.7",
+    "uvicorn>=0.30",
+    "neurodock-mcp-translation",
+    "neurodock-mcp-guardrail",
+    "neurodock-mcp-task-fractionator",
+]
+
+[project.urls]
+Homepage = "https://neurodock.org/"
+Documentation = "https://docs.neurodock.org/"
+Repository = "https://github.com/tlennon-ie/neurodock"
+Issues = "https://github.com/tlennon-ie/neurodock/issues"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.3.0",
+    "pytest-asyncio>=1.3.0",
+]
+
+[project.scripts]
+neurodock-remote = "neurodock_remote.app:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/neurodock_remote"]
+
+[tool.uv.sources]
+neurodock-mcp-translation = { workspace = true }
+neurodock-mcp-guardrail = { workspace = true }
+neurodock-mcp-task-fractionator = { workspace = true }
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/packages/remote/src/neurodock_remote/__init__.py
+++ b/packages/remote/src/neurodock_remote/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""NeuroDock remote MCP server (ADR 0008/0009, Phase 2).
+
+Composes the three STATELESS NeuroDock servers into a single Streamable HTTP
+endpoint exposing only the remote-safe tool surface. Importing this package has
+no side effects; build the server with :func:`build_combined_server` or the ASGI
+factory :func:`create_app`.
+"""
+
+from __future__ import annotations
+
+from neurodock_remote.app import (
+    REMOTE_TOOL_NAMES,
+    build_combined_server,
+    create_app,
+)
+
+__all__ = ["REMOTE_TOOL_NAMES", "build_combined_server", "create_app"]

--- a/packages/remote/src/neurodock_remote/app.py
+++ b/packages/remote/src/neurodock_remote/app.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Combined remote MCP server (ADR 0008/0009, Phase 2).
+
+Composes the three STATELESS NeuroDock servers into a single Streamable HTTP
+endpoint that exposes ONLY the remote-safe tool surface:
+
+    translation        : translate_incoming, check_tone, rewrite_outgoing, brief_meeting
+    guardrail          : check_rumination, check_hyperfocus, check_sycophancy
+    task-fractionator  : decompose            (next_one is stdio/local only)
+
+The cognitive graph, chronometric session state, the profile, and
+task-fractionator ``next_one`` are NEVER mounted here — they read or hold local
+state and must stay on stdio. The boundary is enforced in code (each sub-server is
+built in its remote-safe configuration) and pinned by tests against
+:data:`REMOTE_TOOL_NAMES`.
+
+Vendor-neutrality (ADR 0005) is preserved: the composed tools still return
+deterministic baselines plus structured LLM-refinement prompts; no LLM SDK runs in
+the server.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+from fastmcp import FastMCP
+from neurodock_mcp_guardrail.server import build_server as build_guardrail_server
+from neurodock_mcp_task_fractionator.server import (
+    build_server as build_task_fractionator_server,
+)
+from neurodock_mcp_translation.server import build_server as build_translation_server
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from neurodock_remote.auth import build_auth_provider
+from neurodock_remote.transport import resolve_bind
+
+SERVER_NAME = "neurodock-remote"
+SERVER_VERSION = "0.1.0"
+MCP_PATH = "/mcp"
+
+# The remote-safe tool surface (ADR 0008/0009). Pinned by tests: any drift — a new
+# tool slipping in, or a stateful tool leaking out — fails CI.
+REMOTE_TOOL_NAMES = frozenset(
+    {
+        # translation (fully stateless)
+        "translate_incoming",
+        "check_tone",
+        "rewrite_outgoing",
+        "brief_meeting",
+        # guardrail (heuristic, stateless)
+        "check_rumination",
+        "check_hyperfocus",
+        "check_sycophancy",
+        # task-fractionator (HTTP build: decompose only)
+        "decompose",
+    }
+)
+
+_INSTRUCTIONS = (
+    "NeuroDock remote tools: the stateless communication and planning surface. "
+    "Translation decodes incoming messages and shapes outgoing ones; guardrail "
+    "flags rumination, hyperfocus, and over-validation; decompose breaks a vague "
+    "goal into atomic tasks. Personal memory, session timing, and the user profile "
+    "are intentionally NOT available here — they live on the local install."
+)
+
+_LOG = logging.getLogger("neurodock_remote.app")
+
+
+def build_combined_server() -> FastMCP[Any]:
+    """Compose the three stateless servers into one remote MCP surface.
+
+    ``mount`` (no namespace) keeps the original flat tool names, so the combined
+    endpoint presents the same tool names the local servers do.
+    """
+    combined: FastMCP[Any] = FastMCP(
+        name=SERVER_NAME,
+        version=SERVER_VERSION,
+        instructions=_INSTRUCTIONS,
+        auth=build_auth_provider(os.environ),
+    )
+
+    combined.mount(build_translation_server())
+    combined.mount(build_guardrail_server())
+    # http_mode=True registers ONLY `decompose`; `next_one` (reads the local
+    # cognitive graph) is omitted entirely.
+    combined.mount(build_task_fractionator_server(http_mode=True))
+
+    @combined.custom_route("/health", methods=["GET"])
+    async def health_check(request: Request) -> JSONResponse:
+        return JSONResponse({"status": "ok", "service": SERVER_NAME, "version": SERVER_VERSION})
+
+    return combined
+
+
+def create_app() -> Starlette:
+    """ASGI application factory for uvicorn.
+
+    Deploy with::
+
+        uvicorn neurodock_remote.app:create_app --factory --host 0.0.0.0 --port 8000
+
+    Serves the MCP endpoint at ``/mcp``, a ``/health`` probe, and (when auth is
+    configured) the RFC 9728 protected-resource metadata.
+    """
+    return build_combined_server().http_app(path=MCP_PATH)
+
+
+def main() -> None:
+    """Console-script entrypoint for a local run (``neurodock-remote``).
+
+    Binds per :func:`neurodock_remote.transport.resolve_bind` (localhost by
+    default). The container image sets ``NEURODOCK_HTTP_HOST=0.0.0.0`` to bind all
+    interfaces behind the edge proxy.
+    """
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format='{"logger":"%(name)s","level":"%(levelname)s","msg":"%(message)s"}',
+    )
+    host, port = resolve_bind(os.environ)
+
+    import uvicorn
+
+    _LOG.info(
+        "serving_combined_remote_mcp",
+        extra={"host": host, "port": port, "path": MCP_PATH},
+    )
+    uvicorn.run(create_app(), host=host, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via console script
+    main()

--- a/packages/remote/src/neurodock_remote/auth.py
+++ b/packages/remote/src/neurodock_remote/auth.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Env-driven OAuth resource-server auth for the remote endpoint (ADR 0009 §3).
+
+The identity provider is a *configuration* choice, not a code change. FastMCP 3.x
+ships first-class providers (WorkOS AuthKit, Auth0, Clerk, ...) plus a generic JWT
+resource-server verifier, so this module simply selects and wires one from the
+environment:
+
+    NEURODOCK_AUTH_PROVIDER = none | clerk | workos | jwt   (default: none)
+
+``none`` (the default) returns ``None`` → no auth. This is intended for local and
+integration testing bound to localhost ONLY. A public deployment MUST select a
+provider; serving the remote endpoint unauthenticated is logged as a loud warning
+by the caller.
+
+Provider configuration (read only for the selected provider):
+
+    clerk:  NEURODOCK_CLERK_DOMAIN, NEURODOCK_CLERK_CLIENT_ID,
+            NEURODOCK_CLERK_CLIENT_SECRET (optional), NEURODOCK_PUBLIC_URL
+    workos: NEURODOCK_AUTHKIT_DOMAIN, NEURODOCK_PUBLIC_URL
+    jwt:    NEURODOCK_OAUTH_ISSUER, NEURODOCK_OAUTH_JWKS_URI,
+            NEURODOCK_OAUTH_AUDIENCE, NEURODOCK_PUBLIC_URL
+
+    (all):  NEURODOCK_OAUTH_REQUIRED_SCOPES — optional, comma-separated
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+from fastmcp.server.auth import AuthProvider
+
+_LOG = logging.getLogger("neurodock_remote.auth")
+
+_KNOWN_PROVIDERS = ("none", "clerk", "workos", "jwt")
+
+
+class AuthConfigError(RuntimeError):
+    """A provider was selected but its required configuration is missing or invalid."""
+
+
+def _require(env: Mapping[str, str], key: str) -> str:
+    """Return a non-empty env value or raise :class:`AuthConfigError`."""
+    value = env.get(key, "").strip()
+    if not value:
+        raise AuthConfigError(
+            f"{key} is required when NEURODOCK_AUTH_PROVIDER selects this provider"
+        )
+    return value
+
+
+def _required_scopes(env: Mapping[str, str]) -> list[str] | None:
+    raw = env.get("NEURODOCK_OAUTH_REQUIRED_SCOPES", "").strip()
+    if not raw:
+        return None
+    return [scope.strip() for scope in raw.split(",") if scope.strip()]
+
+
+def build_auth_provider(env: Mapping[str, str]) -> AuthProvider | None:
+    """Build the configured auth provider, or ``None`` when auth is disabled.
+
+    Raises:
+        AuthConfigError: if a provider is selected but its config is incomplete,
+            or if ``NEURODOCK_AUTH_PROVIDER`` names an unknown provider.
+    """
+    provider = env.get("NEURODOCK_AUTH_PROVIDER", "").strip().lower()
+
+    if provider in ("", "none"):
+        _LOG.warning(
+            "auth_disabled: NEURODOCK_AUTH_PROVIDER is unset — the endpoint is "
+            "UNAUTHENTICATED and must not be exposed publicly (ADR 0009 §3)"
+        )
+        return None
+
+    if provider == "workos":
+        # AuthKitProvider is the WorkOS DCR / RFC 9728 resource-server integration.
+        from fastmcp.server.auth.providers.workos import AuthKitProvider
+
+        return AuthKitProvider(
+            authkit_domain=_require(env, "NEURODOCK_AUTHKIT_DOMAIN"),
+            base_url=_require(env, "NEURODOCK_PUBLIC_URL"),
+            required_scopes=_required_scopes(env),
+        )
+
+    if provider == "clerk":
+        # Clerk uses the OAuth proxy pattern (it does not expose WorkOS-style
+        # metadata-forwarding DCR), so FastMCP fronts Clerk's OAuth endpoints.
+        from fastmcp.server.auth.providers.clerk import ClerkProvider
+
+        return ClerkProvider(
+            domain=_require(env, "NEURODOCK_CLERK_DOMAIN"),
+            client_id=_require(env, "NEURODOCK_CLERK_CLIENT_ID"),
+            client_secret=env.get("NEURODOCK_CLERK_CLIENT_SECRET", "").strip() or None,
+            base_url=_require(env, "NEURODOCK_PUBLIC_URL"),
+            required_scopes=_required_scopes(env),
+        )
+
+    if provider == "jwt":
+        # Generic OAuth resource server: validate JWTs from any OIDC issuer via its
+        # JWKS endpoint, and advertise that issuer as the authorization server.
+        from fastmcp.server.auth import RemoteAuthProvider
+        from fastmcp.server.auth.providers.jwt import JWTVerifier
+        from pydantic import AnyHttpUrl
+
+        issuer = _require(env, "NEURODOCK_OAUTH_ISSUER")
+        verifier = JWTVerifier(
+            jwks_uri=_require(env, "NEURODOCK_OAUTH_JWKS_URI"),
+            issuer=issuer,
+            audience=_require(env, "NEURODOCK_OAUTH_AUDIENCE"),
+            required_scopes=_required_scopes(env),
+        )
+        return RemoteAuthProvider(
+            token_verifier=verifier,
+            authorization_servers=[AnyHttpUrl(issuer)],
+            base_url=_require(env, "NEURODOCK_PUBLIC_URL"),
+        )
+
+    raise AuthConfigError(
+        f"unknown NEURODOCK_AUTH_PROVIDER={provider!r}; expected one of: "
+        f"{', '.join(_KNOWN_PROVIDERS)}"
+    )

--- a/packages/remote/src/neurodock_remote/transport.py
+++ b/packages/remote/src/neurodock_remote/transport.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Bind-address resolution for the remote server.
+
+Unlike the per-package ``transport.py`` helpers (which choose stdio vs HTTP), the
+remote server is *always* HTTP — it exists to be served. This helper only resolves
+the bind host/port from the environment.
+
+The code default is ``127.0.0.1`` (safe: a bare local run is not reachable off the
+box). The container image opts into all-interfaces binding explicitly by setting
+``NEURODOCK_HTTP_HOST=0.0.0.0`` in its environment, so the all-interfaces bind is a
+deliberate deployment decision rather than a code default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+
+
+def _parse_port(raw: str | None) -> int:
+    """Parse a port override, falling back to the default on missing/invalid input."""
+    if raw is None or raw.strip() == "":
+        return DEFAULT_PORT
+    try:
+        port = int(raw.strip())
+    except ValueError:
+        return DEFAULT_PORT
+    return port if 1 <= port <= 65535 else DEFAULT_PORT
+
+
+def resolve_bind(env: Mapping[str, str]) -> tuple[str, int]:
+    """Resolve ``(host, port)`` from ``NEURODOCK_HTTP_HOST`` / ``NEURODOCK_HTTP_PORT``."""
+    host = env.get("NEURODOCK_HTTP_HOST", "").strip() or DEFAULT_HOST
+    port = _parse_port(env.get("NEURODOCK_HTTP_PORT"))
+    return host, port

--- a/packages/remote/tests/test_app.py
+++ b/packages/remote/tests/test_app.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Combined remote server tests (ADR 0008/0009).
+
+Pins the remote tool surface to exactly the eight remote-safe tools and asserts the
+local-only tools (next_one, cognitive-graph, chronometric) are never exposed.
+
+Synchronous (``asyncio.run``) rather than ``async def`` so they do not depend on
+pytest-asyncio auto-mode — the repo-root pytest run does not apply the per-package
+``asyncio_mode = "auto"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from neurodock_remote.app import (
+    REMOTE_TOOL_NAMES,
+    build_combined_server,
+    create_app,
+)
+from starlette.applications import Starlette
+
+_LOCAL_ONLY_TOOLS = frozenset(
+    {
+        # task-fractionator (stdio only)
+        "next_one",
+        # cognitive-graph
+        "recall_entity",
+        "record_fact",
+        "recall_decisions",
+        "weekly_rollup",
+        # chronometric
+        "get_time_context",
+        "mark_session_start",
+        "mark_session_end",
+        "request_break_if_needed",
+        "idle_status",
+    }
+)
+
+
+def _combined_tool_names() -> set[str]:
+    server = build_combined_server()
+    return {tool.name for tool in asyncio.run(server.list_tools())}
+
+
+def test_combined_exposes_exactly_the_remote_safe_tools() -> None:
+    assert _combined_tool_names() == set(REMOTE_TOOL_NAMES)
+
+
+def test_remote_tool_names_constant_is_the_eight_stateless_tools() -> None:
+    assert REMOTE_TOOL_NAMES == {
+        "translate_incoming",
+        "check_tone",
+        "rewrite_outgoing",
+        "brief_meeting",
+        "check_rumination",
+        "check_hyperfocus",
+        "check_sycophancy",
+        "decompose",
+    }
+
+
+def test_local_only_tools_are_never_exposed() -> None:
+    names = _combined_tool_names()
+    leaked = names & _LOCAL_ONLY_TOOLS
+    assert leaked == set(), f"local-only tools leaked over the remote transport: {leaked}"
+
+
+def test_create_app_returns_starlette_app_with_health_route() -> None:
+    app = create_app()
+    assert isinstance(app, Starlette)
+    paths = {getattr(route, "path", None) for route in app.routes}
+    assert "/health" in paths

--- a/packages/remote/tests/test_auth.py
+++ b/packages/remote/tests/test_auth.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Auth-provider selection tests (ADR 0009 §3).
+
+These exercise the pure env -> provider mapping. They do not construct live IdP
+connections: the error cases fail on missing config before any network call, and
+the disabled case returns ``None``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from neurodock_remote.auth import AuthConfigError, build_auth_provider
+
+
+def test_unset_provider_disables_auth() -> None:
+    assert build_auth_provider({}) is None
+
+
+def test_explicit_none_disables_auth() -> None:
+    assert build_auth_provider({"NEURODOCK_AUTH_PROVIDER": "none"}) is None
+
+
+def test_provider_name_is_case_insensitive_and_trimmed() -> None:
+    assert build_auth_provider({"NEURODOCK_AUTH_PROVIDER": "  NONE  "}) is None
+
+
+def test_unknown_provider_raises() -> None:
+    with pytest.raises(AuthConfigError):
+        build_auth_provider({"NEURODOCK_AUTH_PROVIDER": "magic-idp"})
+
+
+def test_clerk_without_config_raises() -> None:
+    with pytest.raises(AuthConfigError):
+        build_auth_provider({"NEURODOCK_AUTH_PROVIDER": "clerk"})
+
+
+def test_workos_without_config_raises() -> None:
+    with pytest.raises(AuthConfigError):
+        build_auth_provider({"NEURODOCK_AUTH_PROVIDER": "workos"})
+
+
+def test_jwt_without_config_raises() -> None:
+    with pytest.raises(AuthConfigError):
+        build_auth_provider(
+            {
+                "NEURODOCK_AUTH_PROVIDER": "jwt",
+                "NEURODOCK_PUBLIC_URL": "https://mcp.neurodock.org",
+            }
+        )

--- a/packages/remote/tsconfig.json
+++ b/packages/remote/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true
+  },
+  "include": ["worker/**/*.ts"]
+}

--- a/packages/remote/worker/index.ts
+++ b/packages/remote/worker/index.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 NeuroDock contributors.
+//
+// Cloudflare Containers Worker shim for the NeuroDock remote MCP server.
+//
+// Cloudflare Containers require a Worker as the public front: this Worker owns the
+// `mcp.neurodock.org` custom domain and forwards every request to the Python
+// FastMCP container (../Dockerfile) on its port 8000. The container itself serves
+// `/mcp`, `/health`, and the OAuth/RFC-9728 routes; this shim is a pass-through and
+// holds no application logic.
+//
+// The stateless tool surface means one shared backend instance is sufficient.
+// Scale later with getRandom()/per-session ids if traffic warrants it.
+
+import { Container, getContainer } from "@cloudflare/containers";
+
+interface Env {
+  NEURODOCK_REMOTE: DurableObjectNamespace<NeurodockRemoteContainer>;
+  // Non-secret config (wrangler `vars`) + the secret (wrangler `secret put`),
+  // forwarded into the container's environment below.
+  NEURODOCK_AUTH_PROVIDER: string;
+  NEURODOCK_PUBLIC_URL: string;
+  NEURODOCK_CLERK_DOMAIN: string;
+  NEURODOCK_CLERK_CLIENT_ID: string;
+  NEURODOCK_CLERK_CLIENT_SECRET?: string;
+}
+
+export class NeurodockRemoteContainer extends Container<Env> {
+  // The FastMCP combined server listens on 8000 inside the container.
+  defaultPort = 8000;
+  // Sleep the instance after 15 minutes of inactivity, then cold-start on demand.
+  sleepAfter = "15m";
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    // Forward Worker vars/secrets into the container's process environment so
+    // auth.py can pick up the Clerk OAuth configuration.
+    this.envVars = {
+      NEURODOCK_AUTH_PROVIDER: env.NEURODOCK_AUTH_PROVIDER,
+      NEURODOCK_PUBLIC_URL: env.NEURODOCK_PUBLIC_URL,
+      NEURODOCK_CLERK_DOMAIN: env.NEURODOCK_CLERK_DOMAIN,
+      NEURODOCK_CLERK_CLIENT_ID: env.NEURODOCK_CLERK_CLIENT_ID,
+      NEURODOCK_CLERK_CLIENT_SECRET: env.NEURODOCK_CLERK_CLIENT_SECRET ?? "",
+      // The container binds all interfaces; the Worker is the only ingress.
+      NEURODOCK_HTTP_HOST: "0.0.0.0",
+      NEURODOCK_HTTP_PORT: "8000",
+    };
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const container = getContainer(env.NEURODOCK_REMOTE, "neurodock-remote");
+    return container.fetch(request);
+  },
+} satisfies ExportedHandler<Env>;

--- a/packages/remote/wrangler.jsonc
+++ b/packages/remote/wrangler.jsonc
@@ -1,0 +1,47 @@
+{
+  // Cloudflare Containers deploy config for the NeuroDock remote MCP server.
+  // Runs the Python FastMCP container (../Dockerfile) behind a thin Worker that
+  // proxies mcp.neurodock.org -> the container's port 8000 (ADR 0009).
+  //
+  // Requires a Workers PAID plan (Containers are not on the free tier).
+  // Deploy from THIS directory:  pnpm --dir worker install && npx wrangler deploy
+  // See README.md "Deploy to Cloudflare Containers" for the full runbook.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "neurodock-remote",
+  "main": "worker/index.ts",
+  "compatibility_date": "2026-05-05",
+  "observability": { "enabled": true },
+
+  "containers": [
+    {
+      "class_name": "NeurodockRemoteContainer",
+      // Build context is the repo root so the Dockerfile's `COPY packages/ ...`
+      // resolves (the Dockerfile lives here but expects root context).
+      "image": "./Dockerfile",
+      "image_build_context": "../../",
+      "instance_type": "basic",
+      "max_instances": 3
+    }
+  ],
+
+  "durable_objects": {
+    "bindings": [
+      { "name": "NEURODOCK_REMOTE", "class_name": "NeurodockRemoteContainer" }
+    ]
+  },
+
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["NeurodockRemoteContainer"] }],
+
+  // Auto-provisions DNS + TLS for the subdomain (no manual record needed).
+  "routes": [{ "pattern": "mcp.neurodock.org", "custom_domain": true }],
+
+  // Non-secret runtime config forwarded into the container (see worker/index.ts).
+  // The secret (NEURODOCK_CLERK_CLIENT_SECRET) is NOT here — set it with
+  //   npx wrangler secret put NEURODOCK_CLERK_CLIENT_SECRET
+  "vars": {
+    "NEURODOCK_AUTH_PROVIDER": "clerk",
+    "NEURODOCK_PUBLIC_URL": "https://mcp.neurodock.org",
+    "NEURODOCK_CLERK_DOMAIN": "REPLACE_WITH_YOUR_CLERK_DOMAIN",
+    "NEURODOCK_CLERK_CLIENT_ID": "REPLACE_WITH_YOUR_CLERK_CLIENT_ID"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ members = [
     "packages/mcp-guardrail",
     "packages/clinical",
     "packages/evals",
+    "packages/remote",
 ]
 
 [dependency-groups]
@@ -79,6 +80,15 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "neurodock_mcp_translation.*"
+ignore_missing_imports = true
+
+# Sibling servers composed by `packages/remote` that do not yet emit `py.typed`.
+[[tool.mypy.overrides]]
+module = "neurodock_mcp_guardrail.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "neurodock_mcp_task_fractionator.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ members = [
     "neurodock-mcp-guardrail",
     "neurodock-mcp-task-fractionator",
     "neurodock-mcp-translation",
+    "neurodock-remote",
     "neurodock-workspace",
 ]
 
@@ -1441,6 +1442,38 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "neurodock-remote"
+version = "0.1.0"
+source = { editable = "packages/remote" }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "neurodock-mcp-guardrail" },
+    { name = "neurodock-mcp-task-fractionator" },
+    { name = "neurodock-mcp-translation" },
+    { name = "pydantic" },
+    { name = "uvicorn" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=3.3.0" },
+    { name = "neurodock-mcp-guardrail", editable = "packages/mcp-guardrail" },
+    { name = "neurodock-mcp-task-fractionator", editable = "packages/mcp-task-fractionator" },
+    { name = "neurodock-mcp-translation", editable = "packages/mcp-translation" },
+    { name = "pydantic", specifier = ">=2.7" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
+    { name = "uvicorn", specifier = ">=0.30" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## Summary

Phase 2 foundation for the **remote MCP server** (ADR 0008/0009) — the decision-independent core that lets NeuroDock be added as a hosted MCP connector, with **zero change to the local-first stdio path**.

Composes the three **stateless** servers — translation (×4), guardrail (×3), task-fractionator `decompose` — into a single Streamable HTTP endpoint at `/mcp` via FastMCP `mount` (flat tool names). The exposed surface is **exactly** the 8 remote-safe tools.

### What's here
- **`packages/remote/`** — `neurodock-remote`, an internal deploy artifact (`Private :: Do Not Upload`; not matched by the `packages/mcp-*` publish glob).
  - `app.py` — combined server + `/health` + ASGI factory (`create_app`).
  - `auth.py` — env-driven, vendor-pluggable OAuth (`none` | `clerk` | `workos` | `jwt`), default-off with a loud unauthenticated warning (ADR 0009 §3). **Clerk** is the selected provider.
  - `Dockerfile` (non-root, healthcheck) building only the stateless subset.
  - `wrangler.jsonc` + `worker/index.ts` — **Cloudflare Containers** deploy scaffold; the Worker fronts `mcp.neurodock.org` and proxies to the container.
- **`docs/.../legal/privacy.mdx`** — hosted privacy policy (the top Connectors-Directory rejection cause), live at `docs.neurodock.org/legal/privacy/`.
- **ADR 0009** — marked accepted, with an implementation-status section.

### Remote boundary (enforced in code, pinned by tests)
| tools | remote? |
|---|---|
| translation ×4, guardrail ×3, `decompose` | ✅ exposed |
| `next_one`, cognitive-graph ×4, chronometric ×5 | ❌ never mounted |

## Test plan
- [x] `pytest packages/remote` — **11 pass** under the repo-root pytest config (sync tests; no asyncio-auto dependency, which broke async tests previously)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy --strict` clean
- [x] docs build clean (`/legal/privacy/` renders; 52 pages)
- [x] served-app smoke: `/health` → 200, `/mcp` → 406 (route live), auth-disabled warning fires
- [ ] **Deploy validation (follow-up — needs Workers Paid + a Clerk tenant):** `wrangler deploy`, then `https://mcp.neurodock.org/health` → 200 and an OAuth round-trip in Claude
- [ ] Anthropic Connectors Directory submission

## Deferred (not in scope)
Actual deploy, the Clerk tenant, the `mcp.neurodock.org` DNS record (auto-provisioned by the `custom_domain` route at deploy time), and the Directory submission. The Cloudflare config is a verified-by-docs scaffold; first `wrangler deploy` is its validation step.