### PR TITLE
feat: drop proxy consent screen + register hosted server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,10 +193,12 @@ jobs:
         run: |
           set -u
           published=0; skipped=0; failed=0
-          for sj in packages/mcp-*/server.json; do
+          # Matches the 5 stdio servers (packages/mcp-*) and the hosted remote
+          # server (packages/remote, a `remotes` entry — no PyPI package needed).
+          for sj in packages/*/server.json; do
             pkg_dir=$(dirname "$sj")
-            # Keep server.json in lockstep with the package's pyproject version
-            # (exactly what the pypi job built and published).
+            # Keep server.json in lockstep with the package's pyproject version.
+            # For the remote server this updates only .version (it has no .packages).
             ver=$(grep -m1 '^version = ' "$pkg_dir/pyproject.toml" | cut -d'"' -f2)
             tmp=$(mktemp)
             jq --arg v "$ver" '.version = $v | (.packages[]?.version) |= $v' "$sj" > "$tmp" && mv "$tmp" "$sj"

--- a/packages/remote/server.json
+++ b/packages/remote/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tlennon-ie/neurodock-remote",
+  "title": "NeuroDock (hosted)",
+  "description": "Hosted NeuroDock — stateless communication and planning tools over OAuth-secured Streamable HTTP.",
+  "version": "0.1.0",
+  "websiteUrl": "https://neurodock.org/",
+  "repository": {
+    "url": "https://github.com/tlennon-ie/neurodock",
+    "source": "github",
+    "subfolder": "packages/remote"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.neurodock.org/mcp"
+    }
+  ]
+}

--- a/packages/remote/src/neurodock_remote/auth.py
+++ b/packages/remote/src/neurodock_remote/auth.py
@@ -95,6 +95,10 @@ def build_auth_provider(env: Mapping[str, str]) -> AuthProvider | None:
             client_secret=env.get("NEURODOCK_CLERK_CLIENT_SECRET", "").strip() or None,
             base_url=_require(env, "NEURODOCK_PUBLIC_URL"),
             required_scopes=_required_scopes(env),
+            # Skip FastMCP's own (unbranded) consent screen — Clerk's NeuroDock-branded
+            # sign-in already gates access. Set True to restore the extra consent step
+            # (it confirms the client's redirect URI as an anti-phishing measure).
+            require_authorization_consent=False,
         )
 
     if provider == "jwt":


### PR DESCRIPTION
Two small remote-MCP follow-ups now that the hosted connector is live and working.

## Changes
- **Disable FastMCP's consent screen** (`require_authorization_consent=False` on `ClerkProvider`). Users now go straight through **Clerk's NeuroDock-branded sign-in** instead of FastMCP's unbranded "F"-logo consent page (that page's logo isn't customizable in the current FastMCP version). Trade-off documented in a code comment: this drops FastMCP's redirect-URI anti-phishing confirmation; flip back to `True` to restore it.
- **Register the hosted server in the official MCP Registry**: new `packages/remote/server.json` describing the endpoint as a `streamable-http` **`remotes`** entry (`io.github.tlennon-ie/neurodock-remote`). Validates clean against the `2025-12-11` schema.
- **CI**: broaden the registry-publish glob from `packages/mcp-*/server.json` to `packages/*/server.json` so the remote server publishes alongside the five stdio servers on a release tag (the version-sync `jq` already no-ops on a `remotes`-only entry).

## Test plan
- [x] `check-jsonschema` validates `packages/remote/server.json` against the MCP schema
- [x] `ruff` + `mypy --strict` + `pytest` green on `packages/remote` (11 tests)
- [x] `.mcpb` bundle packs and validates (`mcpb validate`/`pack`); marketplace + plugin manifests well-formed
- [ ] First registry publish lands on the next version-bumping release tag (CI OIDC)
- [ ] Redeploy applies the consent change (`wrangler deploy` from `packages/remote`)

## Not in scope
The opt-in remote *stateful* tools (cognitive-graph/chronometric/profile for hosted users) — that's a larger architecture + ethics decision being scoped separately (needs an ADR).