### PR TITLE
feat: skill-style MCP prompts on the hosted server (ADR 0010 Phase A)

### DIFF
--- a/packages/remote/CHANGELOG.md
+++ b/packages/remote/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`worker/index.ts`) that fronts `mcp.neurodock.org` and proxies to the container,
   `package.json` + `tsconfig.json`, and a deploy runbook in the README. Verified by
   docs; first `wrangler deploy` is the validation step.
+- Skill-style MCP **prompts** (ADR 0010, Phase A): six stateless entry points
+  (`translate-incoming`, `check-tone`, `rewrite-outgoing`, `brief-meeting`,
+  `decompose-task`, `check-rumination`) that guide the model to the matching hosted
+  tool. No personal data; pinned by tests against `REMOTE_PROMPT_NAMES`.
 
 ### Fixed
 

--- a/packages/remote/src/neurodock_remote/__init__.py
+++ b/packages/remote/src/neurodock_remote/__init__.py
@@ -15,5 +15,12 @@ from neurodock_remote.app import (
     build_combined_server,
     create_app,
 )
+from neurodock_remote.prompts import REMOTE_PROMPT_NAMES, register_prompts
 
-__all__ = ["REMOTE_TOOL_NAMES", "build_combined_server", "create_app"]
+__all__ = [
+    "REMOTE_PROMPT_NAMES",
+    "REMOTE_TOOL_NAMES",
+    "build_combined_server",
+    "create_app",
+    "register_prompts",
+]

--- a/packages/remote/src/neurodock_remote/app.py
+++ b/packages/remote/src/neurodock_remote/app.py
@@ -38,6 +38,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from neurodock_remote.auth import build_auth_provider
+from neurodock_remote.prompts import register_prompts
 from neurodock_remote.transport import resolve_bind
 
 SERVER_NAME = "neurodock-remote"
@@ -91,6 +92,10 @@ def build_combined_server() -> FastMCP[Any]:
     # http_mode=True registers ONLY `decompose`; `next_one` (reads the local
     # cognitive graph) is omitted entirely.
     combined.mount(build_task_fractionator_server(http_mode=True))
+
+    # Skill-style MCP prompts (ADR 0010, Phase A) — stateless entry points that
+    # guide the model to the matching hosted tool. No personal data.
+    register_prompts(combined)
 
     @combined.custom_route("/health", methods=["GET"])
     async def health_check(request: Request) -> JSONResponse:

--- a/packages/remote/src/neurodock_remote/prompts.py
+++ b/packages/remote/src/neurodock_remote/prompts.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Skill-style MCP prompts for the hosted server (ADR 0010, Phase A).
+
+MCP carries tools, resources, and *prompts* — not Claude-Code skills. So the ND
+skills that map onto the stateless tool surface are surfaced here as MCP
+**prompts**: reusable, ND-aware entry points a connected client shows (e.g. as
+slash commands). Each one seeds a turn that guides the model to call the matching
+hosted tool with the user's input.
+
+These are stateless and carry no personal data — they are safe on the shared
+remote endpoint. Prompts for the stateful skills (record-fact, chronometric)
+deliberately do NOT live here; they belong to the local/opt-in surface (ADR
+0008/0009/0010).
+
+The voice mirrors the skills (`.claude/skills/`): lead with the action, label
+subtext as a hypothesis, quote ambiguous spans verbatim, and never act without
+the user's confirmation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+# Pinned by tests: the prompt surface mirrors the stateless skills exactly.
+REMOTE_PROMPT_NAMES = frozenset(
+    {
+        "translate-incoming",
+        "check-tone",
+        "rewrite-outgoing",
+        "brief-meeting",
+        "decompose-task",
+        "check-rumination",
+    }
+)
+
+
+def register_prompts(mcp: FastMCP[Any]) -> None:
+    """Register the stateless skill-style prompts on the combined server."""
+
+    @mcp.prompt(
+        name="translate-incoming",
+        description="Decode the subtext, the real ask, and ambiguous phrases in an incoming message.",
+    )
+    def translate_incoming_prompt(message: str, channel: str = "generic") -> str:
+        return (
+            f"Use the translate_incoming tool on this {channel} message, then tell me: the "
+            "explicit ask in plain words; the most likely subtext (label it as a hypothesis, "
+            "not a fact); and any ambiguous phrases quoted verbatim. Finish with one recommended "
+            "next action — but do not take it without my confirmation.\n\n"
+            f"Message:\n{message}"
+        )
+
+    @mcp.prompt(
+        name="check-tone",
+        description="Score an outgoing draft on directness / warmth / urgency before I send it.",
+    )
+    def check_tone_prompt(draft: str, target_register: str = "") -> str:
+        target = f" against a '{target_register}' register" if target_register else ""
+        return (
+            f"Use the check_tone tool on this draft{target}, then show me the directness, warmth, "
+            "and urgency scores and flag any phrases that read more harshly or more softly than I "
+            "probably intend. Do not rewrite it yet — just the read.\n\n"
+            f"Draft:\n{draft}"
+        )
+
+    @mcp.prompt(
+        name="rewrite-outgoing",
+        description="Rewrite an outgoing message toward a target register, preserving technical terms.",
+    )
+    def rewrite_outgoing_prompt(draft: str, target_register: str) -> str:
+        return (
+            f"Use the rewrite_outgoing tool to rewrite this message toward a '{target_register}' "
+            "register, preserving any technical terms exactly. Show me the rewrite and what "
+            "changed; keep my meaning intact.\n\n"
+            f"Draft:\n{draft}"
+        )
+
+    @mcp.prompt(
+        name="brief-meeting",
+        description="Turn a meeting transcript into my asks, others' asks, decisions, and ambiguities.",
+    )
+    def brief_meeting_prompt(transcript: str, me: str) -> str:
+        return (
+            f"Use the brief_meeting tool on this transcript (I am '{me}'). Give me four sections: "
+            "my asks, others' asks, decisions, and ambiguous items. Quote each ambiguous item "
+            "verbatim from the transcript — do not paraphrase the anchor.\n\n"
+            f"Transcript:\n{transcript}"
+        )
+
+    @mcp.prompt(
+        name="decompose-task",
+        description="Break a vague goal into atomic 5-90 minute tasks I can start now.",
+    )
+    def decompose_task_prompt(goal: str, time_budget: str = "") -> str:
+        budget = f" Fit it within {time_budget} (ISO-8601 duration)." if time_budget else ""
+        return (
+            f"Use the decompose tool to break this goal into atomic 5-90 minute tasks, each with "
+            f"acceptance criteria I can check.{budget} Lead with task 1 — 'start here' — and keep "
+            "the rationale for a follow-up, not up front.\n\n"
+            f"Goal:\n{goal}"
+        )
+
+    @mcp.prompt(
+        name="check-rumination",
+        description="Check whether I'm going in circles on something, instead of generating new analysis.",
+    )
+    def check_rumination_prompt(topic: str) -> str:
+        return (
+            "I think I might be looping. Use the check_rumination tool to judge whether I've been "
+            f"repeating myself about this within our recent conversation:\n\n{topic}\n\n"
+            "If I am looping, surface my earlier reasoning and gently say so — do not generate a "
+            "fresh round of analysis. This is advisory; it never blocks me."
+        )

--- a/packages/remote/tests/test_prompts.py
+++ b/packages/remote/tests/test_prompts.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Skill-prompt tests (ADR 0010, Phase A).
+
+Pins the prompt surface to exactly the six stateless skill prompts and checks the
+required/optional arguments. Synchronous (``asyncio.run``) so they do not depend on
+pytest-asyncio auto-mode under the repo-root pytest run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from neurodock_remote.app import build_combined_server
+from neurodock_remote.prompts import REMOTE_PROMPT_NAMES
+
+
+def _prompts() -> dict[str, set[str]]:
+    """Return {prompt_name: {required_arg_names}} for the combined server."""
+    server = build_combined_server()
+    listed = asyncio.run(server.list_prompts())
+    return {p.name: {a.name for a in (p.arguments or []) if a.required} for p in listed}
+
+
+def test_combined_exposes_exactly_the_skill_prompts() -> None:
+    assert set(_prompts()) == set(REMOTE_PROMPT_NAMES)
+
+
+def test_prompt_names_constant_is_the_six_stateless_skills() -> None:
+    assert REMOTE_PROMPT_NAMES == {
+        "translate-incoming",
+        "check-tone",
+        "rewrite-outgoing",
+        "brief-meeting",
+        "decompose-task",
+        "check-rumination",
+    }
+
+
+def test_required_arguments_match_the_tool_inputs() -> None:
+    required = _prompts()
+    # The required (no-default) args mirror each tool's mandatory input.
+    assert required["translate-incoming"] == {"message"}
+    assert required["check-tone"] == {"draft"}
+    assert required["rewrite-outgoing"] == {"draft", "target_register"}
+    assert required["brief-meeting"] == {"transcript", "me"}
+    assert required["decompose-task"] == {"goal"}
+    assert required["check-rumination"] == {"topic"}


### PR DESCRIPTION
**ADR 0010, Phase A** — the additive, shippable piece (no personal data, no storage).

MCP carries tools/resources/**prompts**, not Claude-Code skills. So the ND skills that map onto the **stateless** tool surface are surfaced on the hosted server as MCP **prompts** — ND-aware entry points a client shows (e.g. as slash commands), each seeding a turn that guides the model to the matching hosted tool.

## What's added
- `prompts.py` — `register_prompts(mcp)` registering six prompts: `translate-incoming`, `check-tone`, `rewrite-outgoing`, `brief-meeting`, `decompose-task`, `check-rumination`. Voice mirrors the skills (lead with the action, label subtext as hypothesis, quote verbatim, never act without confirmation).
- `app.py` — registers prompts in `build_combined_server` after the tool mounts.
- `__init__.py` — exports `REMOTE_PROMPT_NAMES` + `register_prompts`.
- tests — pin the prompt surface to exactly the six names and assert each prompt's required args match the tool's mandatory inputs.

Stateful-skill prompts (record-fact, chronometric) are deliberately **not** here — they belong to the local / opt-in surface (gated by ADR 0010 Phases B–E).

## Test plan
- [x] `ruff` + `ruff format` + `mypy --strict` clean
- [x] `pytest packages/remote` — **14 pass** (3 new prompt tests)
- [x] Combined server exposes **8 tools + 6 prompts** (verified live build)
- [ ] Live after the next `wrangler deploy` (prompts affect the running container, not PyPI/registry)