### PR TITLE
chore: bump mcp server versions for the first registry publish (v0.7.3)

### DIFF
--- a/packages/mcp-chronometric/CHANGELOG.md
+++ b/packages/mcp-chronometric/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to `neurodock-mcp-chronometric` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This package follows semantic versioning.
 
+## [0.0.3] - 2026-05-31
+
+- Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.
+
 ## [0.0.2] - 2026-05-22
 
 ### Changed

--- a/packages/mcp-chronometric/pyproject.toml
+++ b/packages/mcp-chronometric/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-chronometric"
-version = "0.0.2"
+version = "0.0.3"
 description = "NeuroDock chronometric MCP server — time, idle, and break management."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/mcp-chronometric/server.json
+++ b/packages/mcp-chronometric/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.tlennon-ie/neurodock-mcp-chronometric",
   "title": "NeuroDock Chronometric",
   "description": "Externalises time-of-day, session boundaries, and break prompts for time-blind users.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "websiteUrl": "https://neurodock.org/",
   "repository": {
     "url": "https://github.com/tlennon-ie/neurodock",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "neurodock-mcp-chronometric",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp-cognitive-graph/CHANGELOG.md
+++ b/packages/mcp-cognitive-graph/CHANGELOG.md
@@ -6,6 +6,10 @@ to [semantic versioning](https://semver.org/spec/v2.0.0.html). Schemas under
 `schemas/` are versioned independently against `v0.1.0` of the contract; the
 package implements that contract.
 
+## [0.0.5] - 2026-05-31
+
+- Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.
+
 ## [0.0.4] — 2026-05-24
 
 ### Changed

--- a/packages/mcp-cognitive-graph/pyproject.toml
+++ b/packages/mcp-cognitive-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-cognitive-graph"
-version = "0.0.4"
+version = "0.0.5"
 description = "NeuroDock cognitive graph MCP server — persistent entity memory and recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/mcp-cognitive-graph/server.json
+++ b/packages/mcp-cognitive-graph/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.tlennon-ie/neurodock-mcp-cognitive-graph",
   "title": "NeuroDock Cognitive Graph",
   "description": "A local typed-edge graph of people, projects, and decisions that externalises memory.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "websiteUrl": "https://neurodock.org/",
   "repository": {
     "url": "https://github.com/tlennon-ie/neurodock",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "neurodock-mcp-cognitive-graph",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp-guardrail/CHANGELOG.md
+++ b/packages/mcp-guardrail/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to `neurodock-mcp-guardrail` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This package follows semantic versioning.
 
-## [unreleased]
+## [0.0.4] - 2026-05-31
+
+- Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.
 
 ### Added — opt-in HTTP transport (ADR 0009 Phase 2)
 

--- a/packages/mcp-guardrail/pyproject.toml
+++ b/packages/mcp-guardrail/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-guardrail"
-version = "0.0.3"
+version = "0.0.4"
 description = "NeuroDock guardrail MCP server — rumination, hyperfocus, and sycophancy detection."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/mcp-guardrail/server.json
+++ b/packages/mcp-guardrail/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.tlennon-ie/neurodock-mcp-guardrail",
   "title": "NeuroDock Guardrail",
   "description": "Advisory detectors for rumination, hyperfocus, and sycophancy. Never silently blocks.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "websiteUrl": "https://neurodock.org/",
   "repository": {
     "url": "https://github.com/tlennon-ie/neurodock",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "neurodock-mcp-guardrail",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp-task-fractionator/CHANGELOG.md
+++ b/packages/mcp-task-fractionator/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this package will be documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [0.0.4] - 2026-05-31
+
+- Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.
 
 ### Added — opt-in HTTP transport (ADR 0009 Phase 2)
 

--- a/packages/mcp-task-fractionator/pyproject.toml
+++ b/packages/mcp-task-fractionator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-task-fractionator"
-version = "0.0.3"
+version = "0.0.4"
 description = "NeuroDock task fractionator MCP server — goal decomposition and next-action selection."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/mcp-task-fractionator/server.json
+++ b/packages/mcp-task-fractionator/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.tlennon-ie/neurodock-mcp-task-fractionator",
   "title": "NeuroDock Task Fractionator",
   "description": "Decompose a vague goal into atomic 5-90 minute tasks and surface the next safe action.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "websiteUrl": "https://neurodock.org/",
   "repository": {
     "url": "https://github.com/tlennon-ie/neurodock",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "neurodock-mcp-task-fractionator",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/mcp-translation/CHANGELOG.md
+++ b/packages/mcp-translation/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to `neurodock-mcp-translation` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This package follows semantic versioning per .
 
-## [unreleased]
+## [0.2.1] - 2026-05-31
+
+- Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.
 
 ### Added — opt-in HTTP transport (ADR 0009 Phase 2)
 

--- a/packages/mcp-translation/pyproject.toml
+++ b/packages/mcp-translation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-translation"
-version = "0.2.0"
+version = "0.2.1"
 description = "NeuroDock translation MCP server — deterministic baseline analysis plus structured LLM-refinement prompts for incoming/outgoing message decoding and meeting briefing."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/mcp-translation/server.json
+++ b/packages/mcp-translation/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.tlennon-ie/neurodock-mcp-translation",
   "title": "NeuroDock Translation",
   "description": "Decode subtext, tone, and ambiguity in messages; rewrite outgoing replies; brief meetings.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "websiteUrl": "https://neurodock.org/",
   "repository": {
     "url": "https://github.com/tlennon-ie/neurodock",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "neurodock-mcp-translation",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Why

The MCP Registry verifies namespace ownership (`io.github.tlennon-ie`) by reading the `mcp-name:` marker out of each package's **published PyPI README**. The versions currently live on PyPI predate that marker, so the registry cannot verify ownership against them.

A version bump is the gate: republishing each stdio server to PyPI ships a README that now carries the `mcp-name:` marker, which unblocks the first registry publish.

## What

Bumps all five stdio MCP servers. For each package, three files change: `pyproject.toml` `[project] version`, `server.json` (both the top-level `.version` and `.packages[0].version`), and `CHANGELOG.md`.

| Package | Old | New |
|---|---|---|
| `packages/mcp-chronometric` | 0.0.2 | 0.0.3 |
| `packages/mcp-cognitive-graph` | 0.0.4 | 0.0.5 |
| `packages/mcp-task-fractionator` | 0.0.3 | 0.0.4 |
| `packages/mcp-translation` | 0.2.0 | 0.2.1 |
| `packages/mcp-guardrail` | 0.0.3 | 0.0.4 |

`packages/remote` is registry-only (no PyPI package) and needs no bump.

## After merge

Pushing the tag `v0.7.3` triggers the CI `pypi` + `mcp-registry` jobs, which publish all six `server.json` to the registry. (No tag is created in this PR — tagging happens after merge.)

## Test plan

- [x] Every edited `server.json` parses as valid JSON
- [x] Each `pyproject.toml` version matches both `server.json` version fields
- [x] Only the 15 intended files changed (3 per package × 5 packages); no workflow/README/remote edits
- [ ] CI green on this branch
