### PR TITLE
docs: amend ethics + privacy for opt-in hosted state (ADR 0010)

### DIFF
--- a/ETHICS.md
+++ b/ETHICS.md
@@ -31,9 +31,16 @@ fired.
 
 ### 4. We do not aggregate detection events
 
-Guardrail firings stay on the user's machine. We do not phone home, we do
-not build population statistics from real users, and we do not publish
-dashboards of detector activity. Local-first by design.
+This commitment is absolute and is not affected by any hosted option. We do
+not phone home, we do not build population statistics from real users, and we
+do not publish dashboards of detector activity. Detection events are never
+pooled across users — not in the local install, and not in any hosted mode.
+
+Guardrail firings stay on the user's machine by default. A user may opt in to
+hosted state (see "On data" below), in which case that user's own data is
+stored for that user alone — isolated per identity, encrypted at rest, and
+deletable by them. Even then, nothing is aggregated: one user's events are
+never combined with another's. Local-first remains the default.
 
 ### 5. False positives are defects
 
@@ -44,10 +51,25 @@ the changelog and the relevant ADR.
 
 ## On data
 
-NeuroDock is local-first. No telemetry runs by default; no detection event
-leaves the user's machine without an explicit per-scope consent action.
-Heuristics, thresholds, and rule sets are part of the source tree — not
-hidden weights and not server-side configuration.
+NeuroDock is local-first by default. No telemetry runs; no detection event
+and no personal data leaves the user's machine without an explicit per-scope
+consent action. Heuristics, thresholds, and rule sets are part of the source
+tree — not hidden weights and not server-side configuration.
+
+Hosted state is strictly opt-in (a forthcoming option; the default is, and
+remains, local). A user who wants the full tool suite without a local install
+may opt in to hosted stateful tools (cognitive graph, session state, profile),
+and chooses where that state lives:
+
+- Hosted per-user storage — isolated per user identity, encrypted at rest,
+  and deletable by the user at any time.
+- Bring-your-own-storage — the user supplies their own database; NeuroDock
+  stores nothing.
+
+Neither mode changes principle 4: hosted state is per-user and is never
+aggregated across users. Opting in requires explicit, informed consent that
+states what is stored, where, and how to delete it. The default — and the
+recommended path — remains local-first, with data on the user's device.
 
 ## On self-identification
 

--- a/docs/src/content/docs/ethics.mdx
+++ b/docs/src/content/docs/ethics.mdx
@@ -8,7 +8,7 @@ description: How NeuroDock approaches clinical safety, consent, and the limits o
 NeuroDock's clinical guardrails layer prevents AI from amplifying rumination, hyperfocus, and sycophancy. Those interventions sit on top of five ethics principles that govern the whole project.
 
 :::tip[Commitment]
-**We never track silently.** Every signal stays on the user's machine. There is no remote aggregation, anonymised or otherwise.
+**We never track silently.** Every signal stays on your machine by default. Hosted state is strictly opt-in, isolated per user, and never aggregated — there is no remote aggregation of detection events, anonymised or otherwise.
 :::
 
 ## The five principles
@@ -16,7 +16,7 @@ NeuroDock's clinical guardrails layer prevents AI from amplifying rumination, hy
 1. **We never claim to treat any condition.** NeuroDock is infrastructure. It is not therapy, not medical advice, not a substitute for clinical care.
 2. **We never block a user's action without their pre-configured consent.** Guardrails surface signals and slow things down; they do not refuse. Every detector is overridable.
 3. **Detection heuristics are public and auditable.** Anyone can read the source, the thresholds, and the test fixtures. There is no "AI safety" black box that the user cannot inspect.
-4. **We do not aggregate detection events into population-level data.** Every signal stays on the user's machine.
+4. **We do not aggregate detection events into population-level data.** This is absolute. Every signal stays on your machine by default; hosted state, if you opt in, is stored per-user and is never pooled across users.
 5. **False positives are sometimes harmful; we log when surfaced and adjust with the clinical advisory board.** A nudge that fires when it should not be silent costs trust. The clinical advisory board reviews thresholds quarterly.
 
 :::tip[Commitment]

--- a/docs/src/content/docs/legal/privacy.mdx
+++ b/docs/src/content/docs/legal/privacy.mdx
@@ -3,12 +3,13 @@ title: Privacy Policy
 description: What NeuroDock does and does not do with your data — local-first by default, and exactly what transits the optional hosted remote server.
 ---
 
-> **Last updated:** 2026-05-30
+> **Last updated:** 2026-05-31
 
 NeuroDock is a **local-first cognitive substrate**. The short version: by default,
 nothing about you leaves your machine. This page explains that precisely, and
-states exactly what happens in the one case where data does cross the network —
-the optional hosted remote server.
+states exactly what happens in the two cases where data can cross the network: the
+optional hosted remote server, and — only if you choose it — optional hosted storage
+for your own data.
 
 :::tip[Commitment]
 **We never track silently.** There is no telemetry, no analytics, no remote
@@ -70,6 +71,51 @@ choose to connect to it, these commitments apply:
   store your credentials.
 - **Transport.** All remote traffic is encrypted in transit (HTTPS only).
 
+## Optional hosted storage for your own data
+
+By default, NeuroDock stores nothing about you anywhere but your own device, and
+anonymous or non-opted-in sessions store nothing at all. The stateful tools — your
+cognitive graph, your session and timing state, and your profile — are local-only
+unless you explicitly opt in.
+
+This hosted-storage option is being introduced. Until it is available to you,
+everything stays on the stateless, local-first path described above. When it is
+available, opting in is a deliberate, separate step that asks for your explicit
+consent and states what will be stored, where, and how to delete it. If you do
+nothing, nothing changes.
+
+When you opt in, you choose where your data lives:
+
+- **Hosted per-user storage.** Your cognitive graph, session state, and profile are
+  stored on our server, kept separate from every other user's, tied to your sign-in
+  identity, and encrypted at rest. No other user can read it, and we never combine it
+  with anyone else's.
+- **Bring-your-own-storage.** You connect your own database (a libSQL or
+  Turso-compatible URL and token). Your data lives in your database; we store none of
+  it and only read and write to the database you point us at.
+
+### Neurotype data and consent
+
+Self-identified neurotype information is sensitive personal data — under the GDPR it
+is special-category data. We do not store it on our server unless you opt in to hosted
+per-user storage and give explicit consent for that purpose. With bring-your-own-storage
+it never reaches us; with the default local install it never leaves your device. We do
+not require a diagnosis and never verify your neurotype against any third party.
+
+### Keeping or deleting your data
+
+- **Hosted per-user storage:** you can delete your stored data at any time, and on
+  account deletion; we then drop it from our server and keep no aggregate copy.
+- **Bring-your-own-storage:** disconnect at any time. We store nothing, so there is
+  nothing on our side to delete; your data stays in your database.
+- **Local install:** delete the files in `~/.neurodock/` and the data is gone.
+
+### Where hosted data is held
+
+If you use hosted per-user storage, your data is held in a defined region, stated
+alongside the consent step at opt-in time. Any change to data residency will be
+recorded in this policy and in the public repository history.
+
 ## What we never do
 
 - We never sell or rent your data.
@@ -81,9 +127,10 @@ choose to connect to it, these commitments apply:
 ## Your control and deletion
 
 Because the local install keeps everything on your device, **you are in control**:
-delete the files in `~/.neurodock/` and the data is gone. The hosted remote server
-stores no personal content, so there is nothing for us to retain or delete on your
-behalf.
+delete the files in `~/.neurodock/` and the data is gone. The stateless hosted remote
+server stores no personal content, so there is nothing for us to retain or delete on
+your behalf. If you opt in to hosted storage (a forthcoming option), see "Optional
+hosted storage for your own data" above for what is kept and how to remove it.
 
 ## Children
 


### PR DESCRIPTION
The governance framework for ADR 0010's opt-in hosted state. **Policy text only** — the stateful storage *code* (Phases C/D) still gates on the clinical/governance sign-off checklist in the ADR.

## Changes
- **ETHICS.md** — amend principle 4 and the "On data" section: the no-aggregation guarantee is restated as **absolute** ("never pooled across users — not local, not hosted"), and the location-of-state claim is qualified to "on your machine **by default**; hosted state is strictly opt-in, per-user isolated, encrypted at rest, deletable, never aggregated."
- **docs ethics.mdx** — matching qualifier on the two commitment lines so the docs site is consistent with ETHICS.md.
- **privacy.mdx** — new **"Optional hosted storage for your own data"** section: hosted per-user storage vs bring-your-own-storage, GDPR special-category (neurotype) consent, retention + right-to-erasure, data residency, and an explicit statement that anonymous / non-opted-in sessions store nothing. Framed as a **forthcoming opt-in** — the default stays local/stateless, so no current user is misled.

## Truthfulness
Hosted storage isn't built yet, so the new privacy section is worded as a forthcoming option ("this option is being introduced; until it is available, everything stays on the stateless, local-first path"). Nothing claims a live feature.

## Test plan
- [x] `pnpm -C docs build` clean (52 pages; privacy.mdx + ethics.mdx render)
- [x] Principle 4 (no population-level aggregation) preserved as absolute
- [ ] Clinical-board review of the wording (the ADR's sign-off checklist still gates the Phase C/D code)

Per your instruction, merging once the scanners/CI pass.