### PR TITLE
docs: correct the release skill and refresh the readme status to v0.7.3

### DIFF
--- a/.claude/skills/release-mcp-server/SKILL.md
+++ b/.claude/skills/release-mcp-server/SKILL.md
@@ -8,46 +8,83 @@ description: Walk through cutting a PyPI release of one of the five MCP servers 
 A checklist for releasing any of the five Python MCP servers published to
 PyPI:
 
-- `packages/mcp-chronometric/` → `neurodock-mcp-chronometric`
-- `packages/mcp-cognitive-graph/` → `neurodock-mcp-cognitive-graph`
-- `packages/mcp-guardrail/` → `neurodock-mcp-guardrail`
-- `packages/mcp-task-fractionator/` → `neurodock-mcp-task-fractionator`
-- `packages/mcp-translation/` → `neurodock-mcp-translation`
+- `packages/mcp-chronometric/` to `neurodock-mcp-chronometric`
+- `packages/mcp-cognitive-graph/` to `neurodock-mcp-cognitive-graph`
+- `packages/mcp-guardrail/` to `neurodock-mcp-guardrail`
+- `packages/mcp-task-fractionator/` to `neurodock-mcp-task-fractionator`
+- `packages/mcp-translation/` to `neurodock-mcp-translation`
 
-The contributor reading this should already have decided the version bump
-via the `version-impact` skill.
+Releases are CI-driven. You bump versions in a PR, merge it, then push a
+single `v*` tag. The Release workflow does the publishing. The contributor
+reading this should already have decided the version bump via the
+`version-impact` skill.
 
 ## When to use
 
-- After a PR has been merged that warrants a release of one of the
+- After a PR has been merged that warrants a release of one or more of the
   servers above.
-- When `version-impact` flagged `needs-bump` against a server and you
-  are picking the release up.
+- When `version-impact` flagged `needs-bump` against a server and you are
+  picking the release up.
 
 ## Prerequisites
 
-- The bump kind decision (`major` / `minor` / `patch`) — run
-  `version-impact` first if unsure.
-- PyPI API token configured locally (kept out of the repo).
-- `uv` available (the project uses `uv` for Python tooling).
+- The bump kind decision (`major` / `minor` / `patch`) for each affected
+  server, run `version-impact` first if unsure.
+- Push access to `main` and permission to push tags. No PyPI or registry
+  token is needed locally, CI holds those.
+- `uv` available for running tests and evals before you cut the release.
+
+## How releases work
+
+The whole release is triggered by pushing one `v*` tag (for example
+`v0.7.3`). That tag fires the Release workflow in
+`.github/workflows/release.yml`, which runs three jobs:
+
+1. `npm` publishes the changed TypeScript packages with `pnpm -r publish`.
+2. `pypi` builds and publishes every Python package with `uv build` and
+   `uv publish`, one package at a time.
+3. `mcp-registry` runs after `pypi` and publishes every
+   `packages/*/server.json` to `registry.modelcontextprotocol.io` using
+   GitHub OIDC. It first rewrites each `server.json` version to match that
+   package's `pyproject.toml`, so the manifest and the package stay in
+   lockstep.
+
+You do not run `uv publish` or touch the registry by hand. Your job is to
+land the version bump in a PR and push the tag.
 
 ## What it does
 
-Walks through the seven release steps in order. The skill does not
-execute them — it lists them so nothing is skipped.
+Walks through the release steps in order. The skill does not execute them,
+it lists them so nothing is skipped.
 
-### 1. Bump the version
+### 1. Bump the version (in a PR)
 
-Edit `packages/mcp-<server>/pyproject.toml` and update the `version`
-field. Follow semver; the bump kind was decided by `version-impact`.
+For each affected server, edit `packages/mcp-<server>/pyproject.toml` and
+update the `version` field. Follow semver, the bump kind was decided by
+`version-impact`.
 
-### 2. Update the local CHANGELOG
+A version bump is required even for a docs-only or README change you want
+the registry to pick up. The registry verifies PyPI ownership via the
+`mcp-name:` marker in the _published_ PyPI README, and that README only goes
+live when a new version is published. Without a bump, the marker never
+updates.
 
-Append a `## <new-version> — YYYY-MM-DD` heading to
-`packages/mcp-<server>/CHANGELOG.md`, then `### Added / Changed / Fixed`
-sub-sections with one-line bullets. Plain, factual, ND-readable.
+### 2. Update the server manifest
 
-### 3. Run tests
+The `mcp-registry` job syncs `packages/mcp-<server>/server.json` to the
+`pyproject.toml` version automatically at publish time, so you do not have
+to hand-edit the version number. Do update any other fields in
+`server.json` that the release changes (new tool descriptions, changed
+runtime arguments, and similar).
+
+### 3. Update the local CHANGELOG
+
+Append a `## [<new-version>] - YYYY-MM-DD` heading to
+`packages/mcp-<server>/CHANGELOG.md` (Keep a Changelog style, matching the
+existing entries), then `### Added / Changed / Fixed` sub-sections with
+one-line bullets. Plain, factual, ND-readable.
+
+### 4. Run tests
 
 ```bash
 uv run --directory packages/mcp-<server> pytest
@@ -55,7 +92,7 @@ uv run --directory packages/mcp-<server> pytest
 
 Must exit 0. Coverage gate per `pytest.ini` for the server.
 
-### 4. Run evals (if the server has them)
+### 5. Run evals (if the server has them)
 
 mcp-translation has evals in `packages/evals/corpora/translation/`. Any
 prompt change ships through the eval pipeline (plan.md §7):
@@ -64,33 +101,31 @@ prompt change ships through the eval pipeline (plan.md §7):
 uv run --directory packages/evals pytest -k translation
 ```
 
-Other servers have no eval corpus today — skip this step.
+Other servers have no eval corpus today, skip this step.
 
-### 5. Build the wheel
+### 6. Open the PR and merge it
 
-```bash
-uv build --directory packages/mcp-<server>
-```
+Open a PR with the version bumps, the `server.json` edits, and the CHANGELOG
+entries. Get it reviewed and merged into `main`. Nothing publishes from the
+PR itself, the publish happens on the tag.
 
-Artefacts land in `packages/mcp-<server>/dist/`.
+### 7. Tag the release and let CI publish
 
-### 6. Tag the release
-
-```bash
-git tag mcp-<server>/<new-version>
-git push origin mcp-<server>/<new-version>
-```
-
-The per-package tag prefix prevents collisions with other packages
-releasing on the same day.
-
-### 7. Publish to PyPI
+From an up-to-date `main`:
 
 ```bash
-uv publish --directory packages/mcp-<server> --token "$PYPI_TOKEN"
+git tag vX.Y.Z
+git push origin vX.Y.Z
 ```
 
-Confirm at `https://pypi.org/project/neurodock-mcp-<server>/<new-version>/`.
+A single repo-wide `v*` tag triggers the Release workflow. The `pypi` job
+publishes every package whose version is not yet on PyPI, then the
+`mcp-registry` job publishes every `server.json`. Both jobs skip versions
+that already exist, so an unchanged package is a clean no-op.
+
+Confirm the run in the Actions tab, then check
+`https://pypi.org/project/neurodock-mcp-<server>/<new-version>/` and the
+server's listing on the MCP registry.
 
 ## Post-release
 
@@ -99,19 +134,23 @@ Confirm at `https://pypi.org/project/neurodock-mcp-<server>/<new-version>/`.
 - If the release added a tool or changed a schema, regenerate any
   downstream client bindings.
 - Note the version in the root `CHANGELOG.md` under the next repo-wide
-  release entry (batched, not per-PR — see version-impact skill).
+  release entry (batched, not per-PR, see version-impact skill).
 
 ## Limitations
 
-- No CI-driven release pipeline today. The PyPI push is manual; do not
-  forget step 7 after tagging.
-- Yanking a bad release requires `uv` + manual PyPI dashboard action; the
-  skill does not cover rollback.
-- The skill assumes a clean working tree on `main`. Releasing from a
-  branch is possible but not documented here.
+- Publishing is CI-driven and version-gated. If you forget to bump a
+  version, the `pypi` and `mcp-registry` jobs skip that package and nothing
+  ships, no error tells you the bump was missing.
+- The registry publish depends on the PyPI publish, the `mcp-registry` job
+  needs `pypi` because ownership is verified via the `mcp-name:` marker in
+  the published PyPI README (ADR 0008 / 0009).
+- Yanking a bad release requires manual PyPI dashboard action, the skill
+  does not cover rollback.
+- Releases are cut from a `v*` tag on `main`. Tagging from a branch is
+  possible but not documented here.
 
 ## Voice
 
-A release is a procedure. List the steps, say what to verify between
-them, and stop. Resist the urge to write release-note copy in this
-checklist — that belongs in the CHANGELOG itself.
+A release is a procedure. List the steps, say what to verify between them,
+and stop. Resist the urge to write release-note copy in this checklist, that
+belongs in the CHANGELOG itself.

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ neurodock/
 
 **Public preview shipped.** All three substrate pillars (cognitive,
 communication, guardrails) are built, on `main`, and installable from
-npm + PyPI. Latest substrate tag: `v0.2.4`.
+npm + PyPI. Latest substrate tag: `v0.7.3`.
 
 ### MCP servers (PyPI)
 


### PR DESCRIPTION
## What

Two small doc-accuracy fixes.

### 1. `release-mcp-server` skill rewritten to match reality

The skill body described a manual per-package `uv publish` with
`mcp-<server>/<version>` tags and claimed there was no CI-driven release
pipeline. That has been stale since the Release workflow landed.

Rewrote the body to describe the actual flow in `.github/workflows/release.yml`:

- Releases are triggered by pushing one repo-wide `v*` tag (for example `v0.7.3`).
- The tag fires three jobs: `npm` (`pnpm -r publish`), `pypi` (`uv build` + `uv publish` per package), then `mcp-registry` (publishes every `packages/*/server.json` to `registry.modelcontextprotocol.io` via GitHub OIDC, syncing each `server.json` version to its `pyproject.toml`).
- The contributor's job is to land version bumps + `server.json` + CHANGELOG in a PR, merge, then `git tag vX.Y.Z && git push origin vX.Y.Z`. CI does the rest.
- Documented the registry gate: it verifies PyPI ownership via the `mcp-name:` marker in the published PyPI README, so a version bump is required for the marker to go live.

Frontmatter and section structure preserved. Also corrected the CHANGELOG heading example to the real Keep a Changelog format (`## [<version>] - YYYY-MM-DD`), which doubled as removing the body's only em dash.

### 2. README Status line refreshed

The Status line said the latest substrate tag was `v0.2.4`. The actual latest `v*` tag is now `v0.7.3` (confirmed via `git tag -l "v*" | sort -V | tail`). Updated that one line. The README does not list explicit per-server version numbers near it, so nothing else changed.

## Scope

- `.claude/skills/release-mcp-server/SKILL.md`
- `README.md`

No code, CI, or other files touched.

## Test plan

- [x] Verified actual release flow by reading `.github/workflows/release.yml`
- [x] Confirmed latest substrate tag is `v0.7.3`
- [x] Pre-commit hooks pass (mixed-line-ending, prettier, commitlint)
- [ ] Maintainer sanity-check of the rewritten skill wording
