### PR TITLE
feat: add per-user statestore foundation (adr 0010 phase b)

### DIFF
--- a/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/server.py
+++ b/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/server.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from collections.abc import Callable
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -43,13 +44,46 @@ def _serialise(model: Any) -> dict[str, Any]:
     return parsed
 
 
+# A store provider is resolved per tool call. This is the seam ADR 0010 Phase B
+# introduces: the local stdio path passes a provider that always returns the one
+# on-disk store, while a future per-user resolver returns the caller's store.
+StoreProvider = Callable[[], Storage]
+
+
+def _coerce_provider(store_or_provider: Storage | StoreProvider) -> StoreProvider:
+    """Return a :data:`StoreProvider` from either a provider or a bare ``Storage``.
+
+    Back-compat: existing callers (and the current test suite) pass a ``Storage``
+    *instance*. A ``Storage`` exposes ``initialise``; a provider is a zero-arg
+    callable that is *not* itself a ``Storage``. We detect the instance case by
+    duck-typing on a ``Storage`` method and wrap it in ``lambda: storage`` so the
+    one bound store is returned on every call — byte-for-byte the old behaviour.
+    """
+    if callable(store_or_provider) and not hasattr(store_or_provider, "initialise"):
+        # A zero-arg provider callable — mypy narrows to StoreProvider here.
+        return store_or_provider
+    # A bound Storage instance — wrap so each call returns the same store.
+    storage: Storage = store_or_provider  # type: ignore[assignment]
+    return lambda: storage
+
+
 def build_app(
-    storage: Storage,
+    store: Storage | StoreProvider,
     clock: Clock | None = None,
     name: str = "neurodock-mcp-cognitive-graph",
 ) -> FastMCP:
-    """Construct a FastMCP server bound to the given storage/clock."""
+    """Construct a FastMCP server bound to a storage provider/clock.
+
+    ``store`` may be either:
+
+    - a ``Callable[[], Storage]`` **store provider** resolved on every tool call
+      (the ADR 0010 Phase B seam — e.g. a per-user resolver on the hosted path);
+      or
+    - a bare ``Storage`` **instance** (back-compat) — it is wrapped so every tool
+      call resolves the same bound store, preserving the prior behaviour exactly.
+    """
     active_clock = clock or SystemClock()
+    store_provider = _coerce_provider(store)
     app = FastMCP(name)
 
     @app.tool(
@@ -60,6 +94,7 @@ def build_app(
         ),
     )
     def recall_entity(name_or_alias: str) -> dict[str, Any]:
+        storage = store_provider()
         try:
             result = recall_entity_tool(storage, name_or_alias)
         except ToolError as exc:
@@ -88,6 +123,7 @@ def build_app(
         # type schema from FastMCP itself for these args — but in exchange
         # they get one-shot, actionable error messages. See record_fact UX
         # friction note (MEMORY.md, 2026-05-22).
+        storage = store_provider()
         try:
             result = record_fact_tool(
                 storage,
@@ -114,6 +150,7 @@ def build_app(
         ),
     )
     def recall_decisions(project: str, since: str | None = None) -> dict[str, Any]:
+        storage = store_provider()
         try:
             result = recall_decisions_tool(storage, project, since)
         except ToolError as exc:
@@ -130,6 +167,7 @@ def build_app(
         ),
     )
     def weekly_rollup(project: str | None = None) -> dict[str, Any]:
+        storage = store_provider()
         try:
             result = weekly_rollup_tool(storage, active_clock, project)
         except ToolError as exc:
@@ -163,7 +201,10 @@ def main() -> None:
     logger.info("starting neurodock-mcp-cognitive-graph v%s", __version__)
     storage = _build_default_storage()
     try:
-        real_app = build_app(storage)
+        # Local stdio path: one on-disk store, returned by a fixed provider on
+        # every tool call. Behaviour is identical to passing the bound store —
+        # the per-user resolver seam (ADR 0010 Phase B) is reserved for hosted.
+        real_app = build_app(lambda: storage)
         real_app.run()
     finally:
         storage.close()

--- a/packages/mcp-cognitive-graph/tests/test_protocol_conformance.py
+++ b/packages/mcp-cognitive-graph/tests/test_protocol_conformance.py
@@ -40,7 +40,7 @@ async def _call(app: Any, tool: str, args: dict[str, Any]) -> dict[str, Any]:
 def _output_schema(schemas: dict[str, dict[str, Any]], tool: str) -> dict[str, Any]:
     """Extract the output sub-schema and inline ``$defs`` for validation."""
     full = schemas[tool]
-    output = full["properties"]["output"]
+    output: dict[str, Any] = full["properties"]["output"]
     if "$defs" in full:
         output = {**output, "$defs": full["$defs"]}
     return output
@@ -53,7 +53,9 @@ async def test_lists_all_four_tools() -> None:
     # Initialise the clock directly with a tz-aware instant for the test.
     from datetime import datetime
 
-    clock._now = datetime(2026, 5, 15, 9, 14, 22, tzinfo=UTC)  # type: ignore[attr-defined]
+    # The attr-defined ignore is only needed when mypy treats the package as
+    # untyped (CI's whole-tree run); unused-ignore keeps it valid otherwise.
+    clock._now = datetime(2026, 5, 15, 9, 14, 22, tzinfo=UTC)  # type: ignore[attr-defined, unused-ignore]
     app = build_app(storage, clock)
     tools = await app.list_tools()
     names = {t.name for t in tools}

--- a/packages/mcp-cognitive-graph/tests/test_store_provider.py
+++ b/packages/mcp-cognitive-graph/tests/test_store_provider.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""``build_app`` store-provider seam (ADR 0010 Phase B).
+
+``build_app`` accepts either a bound ``Storage`` (back-compat) or a
+``Callable[[], Storage]`` store provider that is resolved on *every* tool call.
+These tests pin both behaviours.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from neurodock_mcp_cognitive_graph.clock import FixedClock
+from neurodock_mcp_cognitive_graph.server import build_app
+from neurodock_mcp_cognitive_graph.storage.memory import InMemoryStorage
+
+NOW = datetime(2026, 5, 15, 9, 14, 22, tzinfo=UTC)
+
+
+async def _call(app: Any, tool: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Invoke a tool through FastMCP and return the parsed JSON payload."""
+    result = await app.call_tool(tool, args)
+    content_list = result[0] if isinstance(result, tuple) else result
+    first = content_list[0]
+    text = getattr(first, "text", None)
+    if text is None:
+        raise AssertionError(f"Unexpected tool result shape: {result!r}")
+    parsed = json.loads(text)
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+@pytest.mark.asyncio
+async def test_store_provider_is_resolved_on_every_call() -> None:
+    """The provider is invoked per tool call, so swapping the returned store
+    between calls routes each call to a different backing."""
+    # Arrange: two independent stores; a provider that returns whichever is
+    # currently "active". This models a per-user resolver picking a backing.
+    store_a = InMemoryStorage()
+    store_b = InMemoryStorage()
+    active = {"store": store_a}
+    clock = FixedClock(NOW)
+    app = build_app(lambda: active["store"], clock)
+
+    # Act 1: record a fact while store_a is active.
+    await _call(
+        app,
+        "record_fact",
+        {
+            "subject": {"type": "person", "name": "Ada"},
+            "predicate": "depends_on",
+            "object": {"type": "concept", "name": "analysis"},
+        },
+    )
+
+    # Assert: store_a has the entity, store_b is empty.
+    payload_a = await _call(app, "recall_entity", {"name_or_alias": "Ada"})
+    assert payload_a["entity"] is not None
+    assert payload_a["entity"]["name"] == "Ada"
+
+    # Act 2: flip the active store, then recall through the SAME app.
+    active["store"] = store_b
+    payload_b = await _call(app, "recall_entity", {"name_or_alias": "Ada"})
+
+    # Assert: store_b never saw Ada — proving per-call resolution.
+    assert payload_b["entity"] is None
+
+
+@pytest.mark.asyncio
+async def test_provider_called_once_per_tool_invocation() -> None:
+    # Arrange
+    store = InMemoryStorage()
+    calls = {"n": 0}
+
+    def provider() -> InMemoryStorage:
+        calls["n"] += 1
+        return store
+
+    app = build_app(provider, FixedClock(NOW))
+
+    # Act
+    await _call(app, "recall_entity", {"name_or_alias": "nobody"})
+    await _call(app, "weekly_rollup", {})
+
+    # Assert: build_app itself must not resolve the store; only tool calls do.
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_bare_storage_instance_still_supported() -> None:
+    """Back-compat: passing a ``Storage`` instance behaves as before."""
+    # Arrange
+    store = InMemoryStorage()
+    app = build_app(store, FixedClock(NOW))
+
+    # Act
+    await _call(
+        app,
+        "record_fact",
+        {
+            "subject": {"type": "person", "name": "Grace"},
+            "predicate": "depends_on",
+            "object": {"type": "concept", "name": "compilers"},
+        },
+    )
+    payload = await _call(app, "recall_entity", {"name_or_alias": "Grace"})
+
+    # Assert: the one bound store is used across calls.
+    assert payload["entity"]["name"] == "Grace"

--- a/packages/mcp-state/README.md
+++ b/packages/mcp-state/README.md
@@ -1,0 +1,38 @@
+# `neurodock-state`
+
+Per-user **state foundation** for the NeuroDock substrate (ADR 0010 Phase B).
+
+This package holds the abstractions that let the stateful tools — cognitive
+graph, chronometric session state, and the profile — be backed by a **per-user**
+store, keyed by the authenticated user's identity, **without changing the tool
+logic**. It is the seam ADR 0010 Phase C (hosted per-user storage) and Phase D
+(bring-your-own-storage) plug into.
+
+It defines, deliberately, only _contracts_ plus _in-memory reference
+implementations_:
+
+- `identity.py` — `UserKey` (a hashed, opaque per-user key derived from the
+  Clerk token `sub`) and `user_key_from_context()`, which reads the validated
+  FastMCP access token. Returns `None` when unauthenticated.
+- `session_store.py` — the `SessionStore` protocol (open/close/current/touch a
+  session, keyed by `UserKey`) plus `InMemorySessionStore`.
+- `profile_store.py` — the `ProfileStore` protocol (get/put a profile dict) plus
+  `InMemoryProfileStore`.
+- `registry.py` — the `StateBackingResolver` protocol (resolve a graph store,
+  session store, profile store, and storage mode for a `UserKey`) plus
+  `MemoryBackingResolver`, which hands each distinct user its own isolated set of
+  in-memory backings.
+
+## Scope (Phase B only)
+
+This package is **wiring-free**. Nothing here is connected to the chronometric
+or cognitive-graph servers yet, and there is **no external infrastructure**
+(no libSQL/Turso, no Durable Objects). The local stdio path is unchanged. Hosted
+and BYOS backings (Phases C/D) land later behind the same contracts.
+
+## Privacy
+
+The raw token subject is **never** used as a storage key. `UserKey.storage_key`
+returns the SHA-256 hex digest of the subject, so a leaked key reveals nothing
+about the underlying identity. This mirrors ADR 0010's commitment that hosted
+state is per-user isolated and never aggregated.

--- a/packages/mcp-state/pyproject.toml
+++ b/packages/mcp-state/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "neurodock-state"
+version = "0.0.1"
+description = "NeuroDock per-user state foundation — identity, session, profile, and graph backing abstractions (ADR 0010 Phase B)."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "AGPL-3.0-or-later" }
+authors = [{ name = "NeuroDock contributors" }]
+dependencies = [
+    "fastmcp>=3.3.0",
+]
+
+[project.urls]
+Homepage = "https://neurodock.org/"
+Documentation = "https://docs.neurodock.org/"
+Repository = "https://github.com/tlennon-ie/neurodock"
+Issues = "https://github.com/tlennon-ie/neurodock/issues"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.3.0",
+    "pytest-asyncio>=1.3.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/neurodock_state"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/packages/mcp-state/src/neurodock_state/__init__.py
+++ b/packages/mcp-state/src/neurodock_state/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""NeuroDock per-user state foundation (ADR 0010 Phase B).
+
+This package defines the abstractions that let the stateful tools (cognitive
+graph, chronometric session state, and the profile) be backed by a **per-user**
+store keyed by the authenticated user's identity, without changing tool logic.
+
+It ships only *contracts* plus *in-memory reference implementations*. No tool is
+wired to these yet, and there is no external infrastructure — that is the
+explicit boundary of Phase B. Hosted (Phase C) and BYOS (Phase D) backings plug
+in behind the same protocols later.
+"""
+
+from __future__ import annotations
+
+from neurodock_state.identity import UserKey, user_key_from_context
+from neurodock_state.profile_store import InMemoryProfileStore, ProfileStore
+from neurodock_state.registry import (
+    GraphStore,
+    MemoryBackingResolver,
+    StateBackingResolver,
+    StorageMode,
+)
+from neurodock_state.session_store import InMemorySessionStore, Session, SessionStore
+
+__version__ = "0.0.1"
+
+__all__ = [
+    "GraphStore",
+    "InMemoryProfileStore",
+    "InMemorySessionStore",
+    "MemoryBackingResolver",
+    "ProfileStore",
+    "Session",
+    "SessionStore",
+    "StateBackingResolver",
+    "StorageMode",
+    "UserKey",
+    "__version__",
+    "user_key_from_context",
+]

--- a/packages/mcp-state/src/neurodock_state/identity.py
+++ b/packages/mcp-state/src/neurodock_state/identity.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Per-user identity derived from the validated FastMCP access token.
+
+A :class:`UserKey` is the opaque, per-user handle that every backing store is
+keyed by. It is built from the authenticated user's subject (the Clerk token
+``sub``, per ADR 0010 §3), but the raw subject is **never** used directly as a
+storage key — :attr:`UserKey.storage_key` returns its SHA-256 digest so a leaked
+key reveals nothing about the underlying identity.
+
+``user_key_from_context()`` reads the access token from the active FastMCP
+request. The import and use of FastMCP's ``get_access_token`` are wrapped
+defensively so that importing this module never fails outside a request context
+(e.g. at tool-registration time, in the local stdio path, or in unit tests).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Callable
+
+# Resolve FastMCP's request-scoped access-token accessor at import time, but
+# defensively: if FastMCP is unavailable for any reason, fall back to a stub
+# that behaves exactly like "no token". Importing this module must never raise.
+_get_access_token: Callable[[], Any] | None
+try:
+    from fastmcp.server.dependencies import get_access_token as _get_access_token
+except Exception:  # pragma: no cover - exercised only without fastmcp installed
+    _get_access_token = None
+
+
+@dataclass(frozen=True)
+class UserKey:
+    """An authenticated user's stable identity within NeuroDock state.
+
+    ``sub`` is the verified token subject (Clerk ``sub``). Treat it as
+    sensitive: persist and index on :attr:`storage_key`, not on ``sub`` itself.
+    """
+
+    sub: str
+
+    @property
+    def storage_key(self) -> str:
+        """A stable, opaque key safe to use for storage partitioning.
+
+        Returns the SHA-256 hex digest of :attr:`sub`. Two :class:`UserKey`
+        instances with the same ``sub`` produce the same ``storage_key``;
+        distinct subjects produce distinct keys with overwhelming probability.
+        """
+        return hashlib.sha256(self.sub.encode("utf-8")).hexdigest()
+
+
+def user_key_from_context() -> UserKey | None:
+    """Return the current request's :class:`UserKey`, or ``None``.
+
+    Reads the validated access token from the active FastMCP request and
+    derives a :class:`UserKey` from its ``sub`` claim. Returns ``None`` when:
+
+    - FastMCP is not importable;
+    - there is no active request / no authenticated token; or
+    - the token carries no usable ``sub`` claim.
+
+    Never raises: unauthenticated and out-of-request callers simply get
+    ``None``, which the caller maps to the stateless / local surface.
+    """
+    if _get_access_token is None:
+        return None
+
+    try:
+        token = _get_access_token()
+    except Exception:
+        # No active request context (e.g. local stdio, registration, tests).
+        return None
+
+    if token is None:
+        return None
+
+    claims = getattr(token, "claims", None)
+    if not isinstance(claims, dict):
+        return None
+
+    sub = claims.get("sub")
+    if not isinstance(sub, str) or not sub:
+        return None
+
+    return UserKey(sub=sub)

--- a/packages/mcp-state/src/neurodock_state/profile_store.py
+++ b/packages/mcp-state/src/neurodock_state/profile_store.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Per-user profile contract (ADR 0010 Phase B — definition only).
+
+The NeuroDock profile (``~/.neurodock/profile.yaml`` locally) holds the user's
+neurotype-aware preferences. To make that per-user on the hosted/BYOS path, this
+module defines the :class:`ProfileStore` protocol. The profile is treated as an
+opaque ``dict`` here — schema validation stays in the layers that own it. Phase B
+ships the contract plus :class:`InMemoryProfileStore` for tests.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Protocol, runtime_checkable
+
+from neurodock_state.identity import UserKey
+
+
+@runtime_checkable
+class ProfileStore(Protocol):
+    """The contract a per-user profile backing must satisfy.
+
+    Implementations isolate profiles per :class:`UserKey`.
+    """
+
+    def get_profile(self, user: UserKey) -> dict[str, Any] | None:
+        """Return ``user``'s profile dict, or ``None`` if none is stored."""
+        ...
+
+    def put_profile(self, user: UserKey, profile: dict[str, Any]) -> None:
+        """Store (replacing any existing) ``user``'s profile dict."""
+        ...
+
+
+class InMemoryProfileStore:
+    """Dict-backed reference :class:`ProfileStore`. Per-user, no persistence.
+
+    Stores defensive deep copies so callers cannot mutate stored state through
+    a retained reference (the project's immutability convention).
+    """
+
+    def __init__(self) -> None:
+        self._profiles: dict[str, dict[str, Any]] = {}
+
+    def get_profile(self, user: UserKey) -> dict[str, Any] | None:
+        stored = self._profiles.get(user.storage_key)
+        if stored is None:
+            return None
+        return deepcopy(stored)
+
+    def put_profile(self, user: UserKey, profile: dict[str, Any]) -> None:
+        self._profiles[user.storage_key] = deepcopy(profile)

--- a/packages/mcp-state/src/neurodock_state/registry.py
+++ b/packages/mcp-state/src/neurodock_state/registry.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Per-user backing resolution (ADR 0010 Phase B).
+
+A :class:`StateBackingResolver` maps a :class:`UserKey` to the concrete backings
+the stateful tools need: a cognitive-graph store, a session store, a profile
+store, and the user's effective storage mode. The hosted (Phase C) and BYOS
+(Phase D) resolvers will implement this protocol; Phase B ships the protocol
+plus :class:`MemoryBackingResolver`, an infra-free implementation that proves
+per-user isolation entirely in memory.
+
+To keep this package dependency-light, the graph store is typed against a
+minimal **structural** :class:`GraphStore` protocol declared here rather than
+importing the cognitive-graph package. The cognitive-graph ``Storage`` protocol
+is a structural superset of :class:`GraphStore`, so a real ``Storage`` satisfies
+this return type without any import-time coupling.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Protocol, runtime_checkable
+
+from neurodock_state.identity import UserKey
+from neurodock_state.profile_store import InMemoryProfileStore, ProfileStore
+from neurodock_state.session_store import InMemorySessionStore, SessionStore
+
+StorageMode = Literal["hosted", "byos", "none"]
+"""Where a user's stateful data lives.
+
+- ``"hosted"`` — NeuroDock-managed per-user storage (ADR 0010 Phase C).
+- ``"byos"``   — the user's own libSQL/Turso connection (ADR 0010 Phase D).
+- ``"none"``   — no per-user stateful storage (anonymous / stateless surface).
+"""
+
+
+@runtime_checkable
+class GraphStore(Protocol):
+    """Minimal structural view of a cognitive-graph store.
+
+    Declared here so :mod:`neurodock_state` does not depend on the
+    cognitive-graph package. The cognitive-graph ``Storage`` protocol is a
+    superset of this, so any real ``Storage`` is a valid :class:`GraphStore`.
+    Only the lifecycle surface the resolver and tests rely on is declared.
+    """
+
+    def initialise(self) -> None:
+        """Apply schema migrations. Idempotent."""
+        ...
+
+    def close(self) -> None:
+        """Release any open resources."""
+        ...
+
+
+class _InMemoryGraphStore:
+    """Trivial infra-free :class:`GraphStore` used by :class:`MemoryBackingResolver`.
+
+    Phase B only needs to prove that distinct users receive distinct, isolated
+    graph backings. A full in-memory graph implementation lives in the
+    cognitive-graph package; duplicating it here would couple the two. This stub
+    satisfies the structural :class:`GraphStore` contract and nothing more.
+    """
+
+    def __init__(self) -> None:
+        self.initialised = False
+        self.closed = False
+
+    def initialise(self) -> None:
+        self.initialised = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@runtime_checkable
+class StateBackingResolver(Protocol):
+    """Resolve the per-user backings for the stateful tools."""
+
+    def graph_store(self, user: UserKey) -> GraphStore:
+        """Return ``user``'s cognitive-graph store."""
+        ...
+
+    def session_store(self, user: UserKey) -> SessionStore:
+        """Return ``user``'s session store."""
+        ...
+
+    def profile_store(self, user: UserKey) -> ProfileStore:
+        """Return ``user``'s profile store."""
+        ...
+
+    def storage_mode(self, user: UserKey) -> StorageMode:
+        """Return ``user``'s effective storage mode."""
+        ...
+
+
+class _Backing:
+    """The triple of stores held for one user by :class:`MemoryBackingResolver`."""
+
+    __slots__ = ("graph", "profile", "session")
+
+    def __init__(self) -> None:
+        self.graph: GraphStore = _InMemoryGraphStore()
+        self.session: SessionStore = InMemorySessionStore()
+        self.profile: ProfileStore = InMemoryProfileStore()
+
+
+class MemoryBackingResolver:
+    """In-memory :class:`StateBackingResolver`: one isolated backing per user.
+
+    Backings are created lazily and cached by :attr:`UserKey.storage_key`, so
+    repeated calls for the same user return the *same* store instances, and two
+    distinct users always receive *distinct* instances. No external
+    infrastructure is touched — this is the Phase B isolation proof.
+
+    Reports :data:`StorageMode` ``"hosted"`` for every authenticated user: the
+    backing is NeuroDock-managed (in-process), matching the Phase C semantics it
+    stands in for.
+    """
+
+    def __init__(self) -> None:
+        self._backings: dict[str, _Backing] = {}
+
+    def _backing_for(self, user: UserKey) -> _Backing:
+        backing = self._backings.get(user.storage_key)
+        if backing is None:
+            backing = _Backing()
+            self._backings[user.storage_key] = backing
+        return backing
+
+    def graph_store(self, user: UserKey) -> GraphStore:
+        return self._backing_for(user).graph
+
+    def session_store(self, user: UserKey) -> SessionStore:
+        return self._backing_for(user).session
+
+    def profile_store(self, user: UserKey) -> ProfileStore:
+        return self._backing_for(user).profile
+
+    def storage_mode(self, user: UserKey) -> StorageMode:
+        return "hosted"

--- a/packages/mcp-state/src/neurodock_state/session_store.py
+++ b/packages/mcp-state/src/neurodock_state/session_store.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Per-user session-state contract (ADR 0010 Phase B — definition only).
+
+The chronometric server tracks an open "session" (a span of focused work). To
+make that state per-user on the hosted/BYOS path, this module defines the
+:class:`SessionStore` protocol it will eventually sit behind. Nothing is wired to
+chronometric yet — Phase B ships the contract plus :class:`InMemorySessionStore`,
+a reference implementation used by tests to prove per-user isolation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+from neurodock_state.identity import UserKey
+
+
+@dataclass(frozen=True)
+class Session:
+    """A single tracked work session for one user.
+
+    Immutable: lifecycle transitions (touch/close) return a new instance rather
+    than mutating in place, per the project's immutability convention.
+    """
+
+    session_id: str
+    user_key: str
+    intent: str
+    started_at: datetime
+    last_touched_at: datetime
+    ended_at: datetime | None = None
+
+    @property
+    def is_open(self) -> bool:
+        """True while the session has not been closed."""
+        return self.ended_at is None
+
+
+@runtime_checkable
+class SessionStore(Protocol):
+    """The contract a per-user session backing must satisfy.
+
+    Implementations isolate sessions per :class:`UserKey`: one user can never
+    observe or close another user's session.
+    """
+
+    def open_session(
+        self,
+        user: UserKey,
+        session_id: str,
+        intent: str,
+        *,
+        now: datetime,
+    ) -> Session:
+        """Open (or replace the current) session for ``user`` and return it."""
+        ...
+
+    def current_session(self, user: UserKey) -> Session | None:
+        """Return ``user``'s open session, or ``None`` if none is open."""
+        ...
+
+    def touch_session(self, user: UserKey, *, now: datetime) -> Session | None:
+        """Bump the open session's ``last_touched_at``; return it (or ``None``)."""
+        ...
+
+    def close_session(self, user: UserKey, *, now: datetime) -> Session | None:
+        """Close ``user``'s open session; return the closed session (or ``None``)."""
+        ...
+
+
+class InMemorySessionStore:
+    """Dict-backed reference :class:`SessionStore`. Per-user, no persistence."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, Session] = {}
+
+    def open_session(
+        self,
+        user: UserKey,
+        session_id: str,
+        intent: str,
+        *,
+        now: datetime,
+    ) -> Session:
+        session = Session(
+            session_id=session_id,
+            user_key=user.storage_key,
+            intent=intent,
+            started_at=now,
+            last_touched_at=now,
+        )
+        self._sessions[user.storage_key] = session
+        return session
+
+    def current_session(self, user: UserKey) -> Session | None:
+        session = self._sessions.get(user.storage_key)
+        if session is None or not session.is_open:
+            return None
+        return session
+
+    def touch_session(self, user: UserKey, *, now: datetime) -> Session | None:
+        session = self.current_session(user)
+        if session is None:
+            return None
+        touched = replace(session, last_touched_at=now)
+        self._sessions[user.storage_key] = touched
+        return touched
+
+    def close_session(self, user: UserKey, *, now: datetime) -> Session | None:
+        session = self.current_session(user)
+        if session is None:
+            return None
+        closed = replace(session, last_touched_at=now, ended_at=now)
+        self._sessions[user.storage_key] = closed
+        return closed

--- a/packages/mcp-state/tests/test_identity.py
+++ b/packages/mcp-state/tests/test_identity.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for per-user identity derivation."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+import neurodock_state.identity as identity
+from neurodock_state.identity import UserKey, user_key_from_context
+
+
+def test_storage_key_is_sha256_of_sub_and_never_the_raw_subject() -> None:
+    # Arrange
+    user = UserKey(sub="user_2abcDEF")
+
+    # Act
+    key = user.storage_key
+
+    # Assert
+    assert key == hashlib.sha256(b"user_2abcDEF").hexdigest()
+    assert user.sub not in key  # raw subject never leaks into the key
+
+
+def test_storage_key_is_stable_and_distinct_per_subject() -> None:
+    # Arrange / Act / Assert
+    assert UserKey(sub="a").storage_key == UserKey(sub="a").storage_key
+    assert UserKey(sub="a").storage_key != UserKey(sub="b").storage_key
+
+
+def test_user_key_from_context_returns_none_when_no_token() -> None:
+    # Arrange: the real fastmcp accessor raises outside a request; the module
+    # maps any failure to "no token".
+    # Act
+    result = user_key_from_context()
+
+    # Assert
+    assert result is None
+
+
+@dataclass
+class _StubToken:
+    claims: dict[str, Any]
+
+
+def test_user_key_from_context_returns_hashed_key_with_stubbed_token(
+    monkeypatch: Any,
+) -> None:
+    # Arrange: stub the request-scoped accessor to return a token carrying a sub.
+    monkeypatch.setattr(
+        identity,
+        "_get_access_token",
+        lambda: _StubToken(claims={"sub": "user_99"}),
+    )
+
+    # Act
+    result = user_key_from_context()
+
+    # Assert
+    assert result == UserKey(sub="user_99")
+    assert result is not None
+    assert result.storage_key == hashlib.sha256(b"user_99").hexdigest()
+
+
+def test_user_key_from_context_returns_none_when_accessor_unavailable(
+    monkeypatch: Any,
+) -> None:
+    # Arrange: simulate fastmcp not being importable.
+    monkeypatch.setattr(identity, "_get_access_token", None)
+
+    # Act / Assert
+    assert user_key_from_context() is None
+
+
+def test_user_key_from_context_returns_none_when_token_has_no_sub(
+    monkeypatch: Any,
+) -> None:
+    # Arrange
+    monkeypatch.setattr(
+        identity,
+        "_get_access_token",
+        lambda: _StubToken(claims={"not_sub": "x"}),
+    )
+
+    # Act / Assert
+    assert user_key_from_context() is None
+
+
+def test_user_key_from_context_returns_none_when_accessor_raises(
+    monkeypatch: Any,
+) -> None:
+    # Arrange: no active request context surfaces as an exception in fastmcp.
+    def _raise() -> Any:
+        raise RuntimeError("no active request")
+
+    monkeypatch.setattr(identity, "_get_access_token", _raise)
+
+    # Act / Assert
+    assert user_key_from_context() is None

--- a/packages/mcp-state/tests/test_registry.py
+++ b/packages/mcp-state/tests/test_registry.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the in-memory per-user backing resolver."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from neurodock_state.identity import UserKey
+from neurodock_state.registry import (
+    GraphStore,
+    MemoryBackingResolver,
+    StateBackingResolver,
+)
+from neurodock_state.session_store import SessionStore
+
+NOW = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
+
+
+def test_resolver_satisfies_protocol() -> None:
+    # Arrange / Act
+    resolver = MemoryBackingResolver()
+
+    # Assert — structural conformance to the published contract.
+    assert isinstance(resolver, StateBackingResolver)
+
+
+def test_distinct_users_get_distinct_isolated_graph_stores() -> None:
+    # Arrange
+    resolver = MemoryBackingResolver()
+    alice = UserKey(sub="alice")
+    bob = UserKey(sub="bob")
+
+    # Act
+    alice_graph = resolver.graph_store(alice)
+    bob_graph = resolver.graph_store(bob)
+
+    # Assert — two distinct users, two distinct backing instances.
+    assert alice_graph is not bob_graph
+    assert isinstance(alice_graph, GraphStore)
+    assert isinstance(bob_graph, GraphStore)
+
+
+def test_distinct_users_get_isolated_session_state() -> None:
+    # Arrange
+    resolver = MemoryBackingResolver()
+    alice = UserKey(sub="alice")
+    bob = UserKey(sub="bob")
+
+    # Act: open a session for Alice only.
+    alice_sessions: SessionStore = resolver.session_store(alice)
+    alice_sessions.open_session(alice, "sess-1", "ship phase b", now=NOW)
+
+    # Assert: Bob's store knows nothing of Alice's session.
+    bob_sessions = resolver.session_store(bob)
+    assert bob_sessions.current_session(bob) is None
+    assert alice_sessions.current_session(alice) is not None
+    assert alice_sessions is not bob_sessions
+
+
+def test_distinct_users_get_isolated_profile_state() -> None:
+    # Arrange
+    resolver = MemoryBackingResolver()
+    alice = UserKey(sub="alice")
+    bob = UserKey(sub="bob")
+
+    # Act
+    resolver.profile_store(alice).put_profile(alice, {"theme": "calm"})
+
+    # Assert
+    assert resolver.profile_store(alice).get_profile(alice) == {"theme": "calm"}
+    assert resolver.profile_store(bob).get_profile(bob) is None
+
+
+def test_same_user_gets_the_same_cached_backing() -> None:
+    # Arrange
+    resolver = MemoryBackingResolver()
+    alice = UserKey(sub="alice")
+
+    # Act / Assert — repeated calls return the same instances (state persists).
+    assert resolver.graph_store(alice) is resolver.graph_store(alice)
+    assert resolver.session_store(alice) is resolver.session_store(alice)
+    assert resolver.profile_store(alice) is resolver.profile_store(alice)
+
+
+def test_two_userkeys_with_same_sub_share_a_backing() -> None:
+    # Arrange — equal subjects must collapse to one tenant.
+    resolver = MemoryBackingResolver()
+
+    # Act / Assert
+    assert resolver.graph_store(UserKey(sub="alice")) is resolver.graph_store(UserKey(sub="alice"))
+
+
+def test_memory_resolver_reports_hosted_mode() -> None:
+    # Arrange / Act / Assert
+    resolver = MemoryBackingResolver()
+    assert resolver.storage_mode(UserKey(sub="alice")) == "hosted"

--- a/packages/mcp-state/tests/test_stores.py
+++ b/packages/mcp-state/tests/test_stores.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the in-memory reference session and profile stores."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from neurodock_state.identity import UserKey
+from neurodock_state.profile_store import InMemoryProfileStore, ProfileStore
+from neurodock_state.session_store import (
+    InMemorySessionStore,
+    Session,
+    SessionStore,
+)
+
+NOW = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
+USER = UserKey(sub="alice")
+
+
+def test_in_memory_session_store_satisfies_protocol() -> None:
+    assert isinstance(InMemorySessionStore(), SessionStore)
+
+
+def test_open_then_current_returns_open_session() -> None:
+    # Arrange
+    store = InMemorySessionStore()
+
+    # Act
+    opened = store.open_session(USER, "s1", "deep work", now=NOW)
+
+    # Assert
+    assert opened.is_open
+    assert store.current_session(USER) == opened
+    assert opened.user_key == USER.storage_key
+
+
+def test_touch_bumps_last_touched_without_mutating_original() -> None:
+    # Arrange
+    store = InMemorySessionStore()
+    opened = store.open_session(USER, "s1", "deep work", now=NOW)
+    later = NOW + timedelta(minutes=5)
+
+    # Act
+    touched = store.touch_session(USER, now=later)
+
+    # Assert — immutability: the original instance is unchanged.
+    assert touched is not None
+    assert touched.last_touched_at == later
+    assert opened.last_touched_at == NOW
+    assert touched.started_at == NOW
+
+
+def test_close_ends_session_and_current_returns_none() -> None:
+    # Arrange
+    store = InMemorySessionStore()
+    store.open_session(USER, "s1", "deep work", now=NOW)
+    later = NOW + timedelta(minutes=30)
+
+    # Act
+    closed = store.close_session(USER, now=later)
+
+    # Assert
+    assert closed is not None
+    assert not closed.is_open
+    assert closed.ended_at == later
+    assert store.current_session(USER) is None
+
+
+def test_touch_and_close_on_no_session_return_none() -> None:
+    # Arrange
+    store = InMemorySessionStore()
+
+    # Act / Assert
+    assert store.touch_session(USER, now=NOW) is None
+    assert store.close_session(USER, now=NOW) is None
+    assert store.current_session(USER) is None
+
+
+def test_session_is_frozen_dataclass() -> None:
+    session = Session(
+        session_id="s1",
+        user_key=USER.storage_key,
+        intent="x",
+        started_at=NOW,
+        last_touched_at=NOW,
+    )
+    try:
+        session.intent = "y"  # type: ignore[misc]
+    except AttributeError:
+        return
+    raise AssertionError("Session should be immutable")
+
+
+def test_in_memory_profile_store_satisfies_protocol() -> None:
+    assert isinstance(InMemoryProfileStore(), ProfileStore)
+
+
+def test_profile_get_returns_none_before_put() -> None:
+    store = InMemoryProfileStore()
+    assert store.get_profile(USER) is None
+
+
+def test_profile_put_then_get_roundtrips_a_copy() -> None:
+    # Arrange
+    store = InMemoryProfileStore()
+    original = {"theme": "calm", "nested": {"a": 1}}
+
+    # Act
+    store.put_profile(USER, original)
+    fetched = store.get_profile(USER)
+
+    # Assert — value-equal but defensively copied (no shared references).
+    assert fetched == original
+    assert fetched is not original
+
+    # Mutating the input after put must not change stored state.
+    original["theme"] = "loud"
+    assert store.get_profile(USER) == {"theme": "calm", "nested": {"a": 1}}
+
+    # Mutating a fetched copy must not change stored state either.
+    assert fetched is not None
+    fetched["theme"] = "loud"
+    assert store.get_profile(USER) == {"theme": "calm", "nested": {"a": 1}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ members = [
     "packages/mcp-task-fractionator",
     "packages/mcp-translation",
     "packages/mcp-guardrail",
+    "packages/mcp-state",
     "packages/clinical",
     "packages/evals",
     "packages/remote",

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,7 @@ members = [
     "neurodock-mcp-task-fractionator",
     "neurodock-mcp-translation",
     "neurodock-remote",
+    "neurodock-state",
     "neurodock-workspace",
 ]
 
@@ -1301,7 +1302,7 @@ provides-extras = ["test", "translation"]
 
 [[package]]
 name = "neurodock-mcp-chronometric"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "packages/mcp-chronometric" }
 dependencies = [
     { name = "fastmcp" },
@@ -1331,7 +1332,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "neurodock-mcp-cognitive-graph"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "packages/mcp-cognitive-graph" }
 dependencies = [
     { name = "fastembed" },
@@ -1369,7 +1370,7 @@ provides-extras = ["test", "vec"]
 
 [[package]]
 name = "neurodock-mcp-guardrail"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "packages/mcp-guardrail" }
 dependencies = [
     { name = "fastmcp" },
@@ -1395,7 +1396,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "neurodock-mcp-task-fractionator"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "packages/mcp-task-fractionator" }
 dependencies = [
     { name = "fastmcp" },
@@ -1421,7 +1422,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "neurodock-mcp-translation"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/mcp-translation" }
 dependencies = [
     { name = "fastmcp" },
@@ -1474,6 +1475,28 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
     { name = "uvicorn", specifier = ">=0.30" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "neurodock-state"
+version = "0.0.1"
+source = { editable = "packages/mcp-state" }
+dependencies = [
+    { name = "fastmcp" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=3.3.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## Summary

Implements **ADR 0010 Phase B only** — the per-user `StateStore` foundation. This introduces the abstraction seam that the hosted (Phase C) and BYOS (Phase D) backings will later plug into, and refactors the cognitive-graph server to resolve its store per tool call. **No infrastructure, no remote tool-gating change, no chronometric wiring** — contracts plus in-memory reference implementations only.

## What's in scope (Phase B)

### New workspace package `packages/mcp-state` (`neurodock-state`, module `neurodock_state`)

Mirrors the existing package conventions (hatchling, src layout, AGPL header on every `.py`, `from __future__ import annotations`, full type annotations, ships `py.typed`, ruff/mypy-strict clean).

- **`identity.py`** — frozen `UserKey(sub)` dataclass. `UserKey.storage_key` returns `sha256(sub).hexdigest()` so the raw token subject is **never** used as a storage key. `user_key_from_context()` reads FastMCP's validated access token and returns `UserKey(sub=claims["sub"])`, or `None` when unauthenticated / outside a request. The import and use of `get_access_token` are wrapped defensively so importing the module never raises outside a request context.
- **`session_store.py`** — `SessionStore` protocol (open/close/current/touch, keyed by `UserKey`) + `InMemorySessionStore` reference impl. **Definition only** — not wired to chronometric.
- **`profile_store.py`** — `ProfileStore` protocol (`get_profile`/`put_profile`) + `InMemoryProfileStore` (defensive deep-copy). **Definition only.**
- **`registry.py`** — `StateBackingResolver` protocol (`graph_store`, `session_store`, `profile_store`, `storage_mode`). To avoid depending on the cognitive-graph package, `graph_store`'s return type is a **minimal structural `GraphStore` protocol** declared locally (the real `Storage` is a structural superset of it). `MemoryBackingResolver` hands each distinct `UserKey.storage_key` its own isolated in-memory backing — the Phase B isolation proof, with **no external DB**.

### Cognitive-graph store-provider refactor

`build_app` now accepts a **store provider** (`Callable[[], Storage]`) and each tool resolves `storage = store_provider()` at call time — the seam a per-user resolver will use on the hosted path.

**Preserved-local-behaviour guarantee:**
- A back-compat shim (`_coerce_provider`) detects a bare `Storage` instance vs a callable and wraps the instance in `lambda: storage`, so **every existing caller and the entire current test suite pass unchanged**.
- The local stdio `main()` builds one on-disk store and passes `lambda: storage`, so each tool call resolves the same store — **byte-for-byte identical** to the prior behaviour.

### Workspace wiring

- Added `packages/mcp-state` to `[tool.uv.workspace] members`; refreshed `uv.lock`.
- `neurodock-state` ships `py.typed`. Cognitive-graph does **not** import `neurodock_state` at runtime (the provider refactor is self-contained `Callable[[], Storage]`), so **no cross-package dependency** is added — keeping coupling minimal as the task requires.

## Tests (all unit, no external infra)

- **mcp-state** — `user_key_from_context()` returns `None` with no token and a hashed key with a stubbed token (plus no-`sub`, accessor-unavailable, and accessor-raises paths); `MemoryBackingResolver` hands two distinct users isolated graph/session/profile stores; same-`sub` users collapse to one backing.
- **cognitive-graph** — new `test_store_provider.py` proves `build_app` with a store provider resolves the store on **every** call (flipping the active store between calls routes each call to a different backing), that the provider is not invoked at `build_app` time, and that the bare-`Storage` back-compat path still works.

## Verification (run from repo root)

```
ruff check packages/mcp-state packages/mcp-cognitive-graph      -> All checks passed!
ruff format --check packages/mcp-state packages/mcp-cognitive-graph -> 42 files already formatted
mypy packages/mcp-state packages/mcp-cognitive-graph            -> Success: no issues found in 42 source files
pytest packages/mcp-state packages/mcp-cognitive-graph -q       -> 80 passed
```

Pre-commit hooks (`mixed-line-ending`, `ruff`, `mypy --strict`, `prettier`, `commitlint`) all pass on the commit.

> Note: two pre-existing mypy findings in `tests/test_protocol_conformance.py` (an unannotated dict access and an environment-dependent unused-ignore) surfaced under the package-scoped `mypy` verification command and were fixed with type-annotation-only edits (no behavioural change), so the verification command is green.

## Out of scope (deliberately not touched)

Remote app tool-gating; libSQL/Turso; hosted/BYOS storage (Phases C/D); chronometric server wiring; CI; Dockerfiles.

## Test plan

- [x] `mcp-state` unit tests pass
- [x] cognitive-graph store-provider test passes
- [x] existing cognitive-graph suite passes unchanged
- [x] ruff / mypy-strict clean on both packages
- [ ] Phase C/D backings to implement `StateBackingResolver` in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
