### PR TITLE
feat: add libsql storage backend for the cognitive graph

### DIFF
--- a/packages/mcp-cognitive-graph/pyproject.toml
+++ b/packages/mcp-cognitive-graph/pyproject.toml
@@ -38,6 +38,14 @@ test = [
 vec = [
     "sqlite-vec>=0.1.6",
 ]
+# libsql is an optional backing for the hosted (ADR 0010 Phase C) and
+# bring-your-own-store (Phase D) deployments. The default local stdio install
+# uses SQLite and does NOT require this client; it is imported lazily inside
+# LibSqlStorage so the network DB client is only pulled when this extra is
+# installed.
+libsql = [
+    "libsql>=0.1.0",
+]
 
 [project.scripts]
 neurodock-mcp-cognitive-graph = "neurodock_mcp_cognitive_graph.server:main"

--- a/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/libsql.py
+++ b/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/libsql.py
@@ -1,0 +1,472 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""libSQL/Turso-backed storage for the cognitive graph (ADR 0010 Phases C/D).
+
+This backing mirrors :class:`SQLiteStorage` byte-for-byte at the SQL level:
+libSQL is a SQLite fork, so the dialect and the on-disk embedding BLOB layout
+are identical. The same migrations apply, and the same NumPy cosine fallback
+in :mod:`vector_search` reads embedding rows out of it unchanged.
+
+Two connection shapes are supported by the same class:
+
+* a **local** ``file:`` path (or bare path) — used by the test-suite and any
+  single-process embedded deployment; and
+* a **remote** ``libsql://`` / ``https://`` URL with an auth token — the hosted
+  (Phase C) and bring-your-own-store (Phase D) deployments.
+
+The ``libsql`` client is imported **lazily** inside :meth:`initialise` so the
+default local stdio install (which uses :class:`SQLiteStorage`) never pulls a
+network database client. Install the optional ``libsql`` extra to use this
+backing.
+
+Implementation notes
+--------------------
+* The libsql DB-API client returns plain tuples and does **not** implement
+  ``row_factory``. We therefore map each result row to a dict keyed by the
+  cursor's ``description`` column names, then reuse the exact same row-shaping
+  logic as :class:`SQLiteStorage`.
+* Vector search goes through the storage-agnostic :class:`NumpySearcher`
+  (read every embedding for the graph, cosine in Python). This works over any
+  libSQL connection without requiring a vector-capable build or the sqlite-vec
+  extension. FUTURE optimisation: when running against a libSQL build with
+  native vector support, the ``vector_top_k`` table function could replace the
+  full table scan for large graphs — but the NumPy path is correct and
+  sufficient for v1, and keeps results identical to the SQLite backing.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from importlib import resources
+from typing import TYPE_CHECKING, Any, cast
+
+from neurodock_mcp_cognitive_graph.storage.base import (
+    DEFAULT_FACTS_CAP,
+    DEFAULT_RELATED_CAP,
+    EmbeddingRow,
+    EntityRow,
+    FactRow,
+    SurfaceKind,
+)
+from neurodock_mcp_cognitive_graph.types import EntityType, Predicate
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from collections.abc import Iterable
+
+MIGRATIONS_PACKAGE = "neurodock_mcp_cognitive_graph.migrations"
+
+# Row = a mapping of column name -> value, reconstructed from the libsql
+# cursor's positional tuples plus its ``description``.
+Row = dict[str, Any]
+
+
+def _new_entity_id() -> str:
+    return f"ent_{uuid.uuid4().hex[:24]}"
+
+
+def _row_to_entity(row: Row) -> EntityRow:
+    aliases_raw = row["aliases"]
+    aliases = tuple(json.loads(aliases_raw)) if aliases_raw else ()
+    created_at_raw = row["created_at"]
+    created_at = datetime.fromisoformat(created_at_raw) if created_at_raw else None
+    return EntityRow(
+        id=row["id"],
+        type=cast(EntityType, row["type"]),
+        name=row["name"],
+        aliases=aliases,
+        created_at=created_at,
+    )
+
+
+def _row_to_fact(row: Row) -> FactRow:
+    return FactRow(
+        id=row["id"],
+        subject_id=row["subject_id"],
+        predicate=cast(Predicate, row["predicate"]),
+        object_kind=row["object_kind"],
+        object_id=row["object_id"],
+        object_literal=row["object_literal"],
+        source=row["source"],
+        confidence=float(row["confidence"]),
+        recorded_at=datetime.fromisoformat(row["recorded_at"]),
+    )
+
+
+class LibSqlStorage:
+    """libSQL/Turso-backed store. Synchronous; safe for the FastMCP loop.
+
+    Construct with a local ``file:`` path *or* a remote ``libsql://`` URL.
+    Call :meth:`initialise` before use to open the connection and apply the
+    schema migrations (idempotent).
+    """
+
+    def __init__(self, url: str, auth_token: str | None = None) -> None:
+        self._url = url
+        self._auth_token = auth_token
+        self._conn: Any | None = None
+
+    # -- lifecycle --------------------------------------------------------
+
+    def initialise(self) -> None:
+        # Lazy import so the default local install never requires the network
+        # database client. Install the ``libsql`` extra to use this backing.
+        try:
+            import libsql
+        except ImportError as exc:  # pragma: no cover - exercised via skip in tests
+            raise RuntimeError(
+                "The 'libsql' package is required for LibSqlStorage. "
+                "Install it with the optional extra: "
+                "`pip install neurodock-mcp-cognitive-graph[libsql]`."
+            ) from exc
+
+        # A remote URL takes an auth token; a local file path does not. We pass
+        # the token through only when present so a local file connection is not
+        # rejected for receiving an unexpected keyword argument.
+        if self._auth_token is not None:
+            self._conn = libsql.connect(self._url, auth_token=self._auth_token)
+        else:
+            self._conn = libsql.connect(self._url)
+        self._apply_migrations()
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def _apply_migrations(self) -> None:
+        conn = self._c
+        for sql in _iter_migration_resources():
+            conn.executescript(sql)
+        conn.commit()
+
+    @property
+    def _c(self) -> Any:
+        if self._conn is None:
+            raise RuntimeError("Storage not initialised. Call initialise() first.")
+        return self._conn
+
+    # -- result shaping ---------------------------------------------------
+
+    def _query_all(self, sql: str, params: tuple[Any, ...] = ()) -> list[Row]:
+        """Run a SELECT and return rows as column-name-keyed dicts."""
+        cur = self._c.execute(sql, params)
+        description = cur.description
+        if description is None:
+            return []
+        columns = [d[0] for d in description]
+        return [dict(zip(columns, raw, strict=False)) for raw in cur.fetchall()]
+
+    def _query_one(self, sql: str, params: tuple[Any, ...] = ()) -> Row | None:
+        rows = self._query_all(sql, params)
+        return rows[0] if rows else None
+
+    # -- entities ---------------------------------------------------------
+
+    def find_entity_by_id(self, entity_id: str) -> EntityRow | None:
+        row = self._query_one("SELECT * FROM entities WHERE id = ?", (entity_id,))
+        return _row_to_entity(row) if row else None
+
+    def find_entity_exact(self, entity_type: EntityType, name: str) -> EntityRow | None:
+        row = self._query_one(
+            "SELECT * FROM entities WHERE type = ? AND name = ?",
+            (entity_type, name),
+        )
+        return _row_to_entity(row) if row else None
+
+    def find_entity_by_name_any_type(self, name: str) -> EntityRow | None:
+        row = self._query_one(
+            "SELECT * FROM entities WHERE name = ? ORDER BY created_at ASC LIMIT 1",
+            (name,),
+        )
+        return _row_to_entity(row) if row else None
+
+    def find_entity_by_alias(self, alias: str) -> EntityRow | None:
+        # First, exact-name case-insensitive match.
+        row = self._query_one(
+            "SELECT * FROM entities WHERE lower(name) = lower(?) ORDER BY created_at ASC LIMIT 1",
+            (alias,),
+        )
+        if row is not None:
+            return _row_to_entity(row)
+        # Fall back to alias array search. SQLite/libSQL has no universally
+        # available JSON array-contains operator, so we scan; aliases are sparse.
+        needle = alias.casefold()
+        for arow in self._query_all("SELECT * FROM entities WHERE aliases != '[]'"):
+            aliases = json.loads(arow["aliases"]) if arow["aliases"] else []
+            for a in aliases:
+                if a.casefold() == needle:
+                    return _row_to_entity(arow)
+        return None
+
+    def upsert_entity(
+        self,
+        entity_type: EntityType,
+        name: str,
+        *,
+        now: datetime,
+    ) -> tuple[EntityRow, bool]:
+        existing = self.find_entity_exact(entity_type, name)
+        if existing is not None:
+            return existing, False
+        new_id = _new_entity_id()
+        self._c.execute(
+            "INSERT INTO entities (id, type, name, aliases, created_at) VALUES (?, ?, ?, '[]', ?)",
+            (new_id, entity_type, name, now.isoformat()),
+        )
+        self._c.commit()
+        row = EntityRow(
+            id=new_id,
+            type=entity_type,
+            name=name,
+            aliases=(),
+            created_at=now,
+        )
+        return row, True
+
+    def add_alias(self, entity_id: str, alias: str) -> None:
+        row = self.find_entity_by_id(entity_id)
+        if row is None:
+            return
+        if alias == row.name or alias in row.aliases:
+            return
+        new_aliases = [*row.aliases, alias]
+        self._c.execute(
+            "UPDATE entities SET aliases = ? WHERE id = ?",
+            (json.dumps(new_aliases), entity_id),
+        )
+        self._c.commit()
+
+    # -- facts ------------------------------------------------------------
+
+    def find_fact_canonical(
+        self,
+        subject_id: str,
+        predicate: Predicate,
+        object_id: str | None,
+        object_literal: str | None,
+    ) -> FactRow | None:
+        if object_id is not None:
+            row = self._query_one(
+                "SELECT * FROM facts WHERE subject_id = ? AND predicate = ? "
+                "AND object_kind = 'entity' AND object_id = ? "
+                "ORDER BY recorded_at ASC LIMIT 1",
+                (subject_id, predicate, object_id),
+            )
+        else:
+            row = self._query_one(
+                "SELECT * FROM facts WHERE subject_id = ? AND predicate = ? "
+                "AND object_kind = 'literal' AND object_literal = ? "
+                "ORDER BY recorded_at ASC LIMIT 1",
+                (subject_id, predicate, object_literal),
+            )
+        return _row_to_fact(row) if row else None
+
+    def insert_fact(self, fact: FactRow) -> None:
+        self._c.execute(
+            "INSERT INTO facts (id, subject_id, predicate, object_kind, object_id, "
+            "object_literal, source, confidence, recorded_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                fact.id,
+                fact.subject_id,
+                fact.predicate,
+                fact.object_kind,
+                fact.object_id,
+                fact.object_literal,
+                fact.source,
+                fact.confidence,
+                fact.recorded_at.isoformat(),
+            ),
+        )
+        self._c.commit()
+
+    def insert_provenance(
+        self,
+        canonical_fact_id: str,
+        source: str | None,
+        confidence: float,
+        recorded_at: datetime,
+    ) -> None:
+        self._c.execute(
+            "INSERT INTO fact_provenance (canonical_fact_id, source, confidence, recorded_at) "
+            "VALUES (?, ?, ?, ?)",
+            (canonical_fact_id, source, confidence, recorded_at.isoformat()),
+        )
+        self._c.commit()
+
+    def facts_touching_entity(
+        self,
+        entity_id: str,
+        limit: int = DEFAULT_FACTS_CAP,
+    ) -> tuple[list[FactRow], bool]:
+        rows = [
+            _row_to_fact(r)
+            for r in self._query_all(
+                "SELECT * FROM facts WHERE subject_id = ? OR object_id = ? "
+                "ORDER BY recorded_at DESC LIMIT ?",
+                (entity_id, entity_id, limit + 1),
+            )
+        ]
+        truncated = len(rows) > limit
+        return rows[:limit], truncated
+
+    def neighbour_counts(
+        self,
+        entity_id: str,
+        limit: int = DEFAULT_RELATED_CAP,
+    ) -> list[tuple[str, int]]:
+        rows = self._query_all(
+            "SELECT neighbour_id, COUNT(*) AS c FROM ("
+            "  SELECT object_id AS neighbour_id FROM facts "
+            "    WHERE subject_id = ? AND object_id IS NOT NULL "
+            "  UNION ALL "
+            "  SELECT subject_id AS neighbour_id FROM facts "
+            "    WHERE object_id = ? "
+            ") GROUP BY neighbour_id ORDER BY c DESC LIMIT ?",
+            (entity_id, entity_id, limit),
+        )
+        return [(r["neighbour_id"], int(r["c"])) for r in rows]
+
+    def facts_for_project_decisions(self, project_id: str) -> list[FactRow]:
+        rows = self._query_all(
+            "SELECT * FROM facts WHERE predicate = 'decided_in' "
+            "AND (subject_id = ? OR object_id = ?)",
+            (project_id, project_id),
+        )
+        return [_row_to_fact(r) for r in rows]
+
+    def decisions_for_project(self, project_id: str) -> list[EntityRow]:
+        rows = self._query_all(
+            "SELECT DISTINCT e.* FROM entities e "
+            "JOIN facts f ON ("
+            "   (f.subject_id = e.id AND f.object_id = ?) OR "
+            "   (f.object_id = e.id AND f.subject_id = ?)"
+            ") "
+            "WHERE e.type = 'decision' AND f.predicate = 'decided_in'",
+            (project_id, project_id),
+        )
+        return [_row_to_entity(r) for r in rows]
+
+    def all_decision_entities(self) -> list[EntityRow]:
+        rows = self._query_all("SELECT * FROM entities WHERE type = 'decision'")
+        return [_row_to_entity(r) for r in rows]
+
+    def facts_by_predicate(
+        self,
+        predicate: Predicate,
+        since: datetime | None = None,
+    ) -> list[FactRow]:
+        if since is None:
+            rows = self._query_all(
+                "SELECT * FROM facts WHERE predicate = ? ORDER BY recorded_at DESC",
+                (predicate,),
+            )
+        else:
+            rows = self._query_all(
+                "SELECT * FROM facts WHERE predicate = ? AND recorded_at >= ? "
+                "ORDER BY recorded_at DESC",
+                (predicate, since.isoformat()),
+            )
+        return [_row_to_fact(r) for r in rows]
+
+    def all_entities(self) -> list[EntityRow]:
+        rows = self._query_all("SELECT * FROM entities")
+        return [_row_to_entity(r) for r in rows]
+
+    # -- embeddings (v0.0.2) ---------------------------------------------
+
+    def upsert_embedding(
+        self,
+        entity_id: str,
+        surface_kind: SurfaceKind,
+        surface_text: str,
+        vector: bytes,
+        dim: int,
+        model: str,
+        *,
+        now: datetime,
+    ) -> None:
+        self._c.execute(
+            "INSERT INTO entity_embeddings "
+            "(entity_id, surface_kind, surface_text, vector, dim, model, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(entity_id, surface_kind, surface_text) DO UPDATE SET "
+            "  vector = excluded.vector, "
+            "  dim = excluded.dim, "
+            "  model = excluded.model, "
+            "  created_at = excluded.created_at",
+            (entity_id, surface_kind, surface_text, vector, dim, model, now.isoformat()),
+        )
+        self._c.commit()
+
+    def all_embeddings(self) -> list[EmbeddingRow]:
+        rows = self._query_all(
+            "SELECT entity_id, surface_kind, surface_text, vector, dim, model "
+            "FROM entity_embeddings ORDER BY entity_id, surface_kind, surface_text"
+        )
+        out: list[EmbeddingRow] = []
+        for r in rows:
+            out.append(
+                EmbeddingRow(
+                    entity_id=r["entity_id"],
+                    surface_kind=cast(SurfaceKind, r["surface_kind"]),
+                    surface_text=r["surface_text"],
+                    vector=bytes(r["vector"]),
+                    dim=int(r["dim"]),
+                    model=r["model"],
+                )
+            )
+        return out
+
+    def delete_embeddings_for_entity(self, entity_id: str) -> None:
+        self._c.execute(
+            "DELETE FROM entity_embeddings WHERE entity_id = ?",
+            (entity_id,),
+        )
+        self._c.commit()
+
+    # -- resolution cache (v0.0.2) ---------------------------------------
+
+    def get_cached_resolution(
+        self,
+        input_text: str,
+    ) -> tuple[str, str, float] | None:
+        row = self._query_one(
+            "SELECT entity_id, method, score FROM entity_resolution_cache WHERE input_text = ?",
+            (input_text,),
+        )
+        if row is None:
+            return None
+        return row["entity_id"], row["method"], float(row["score"])
+
+    def cache_resolution(
+        self,
+        input_text: str,
+        entity_id: str,
+        method: str,
+        score: float,
+        *,
+        now: datetime,
+    ) -> None:
+        self._c.execute(
+            "INSERT INTO entity_resolution_cache "
+            "(input_text, entity_id, method, score, resolved_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(input_text) DO UPDATE SET "
+            "  entity_id = excluded.entity_id, "
+            "  method = excluded.method, "
+            "  score = excluded.score, "
+            "  resolved_at = excluded.resolved_at",
+            (input_text, entity_id, method, score, now.isoformat()),
+        )
+        self._c.commit()
+
+
+def _iter_migration_resources() -> Iterable[str]:
+    """Yield migration SQL contents in filename order."""
+    files = resources.files(MIGRATIONS_PACKAGE)
+    for path in sorted(files.iterdir(), key=lambda p: p.name):
+        if path.name.endswith(".sql"):
+            yield path.read_text(encoding="utf-8")

--- a/packages/mcp-cognitive-graph/tests/test_libsql_storage.py
+++ b/packages/mcp-cognitive-graph/tests/test_libsql_storage.py
@@ -1,0 +1,547 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Behavioural parity tests for :class:`LibSqlStorage`.
+
+The libSQL backing (ADR 0010 Phases C/D) must behave identically to
+:class:`SQLiteStorage` on the same operations: libSQL is a SQLite fork, so the
+SQL dialect and the on-disk embedding BLOB layout match, and the same NumPy
+cosine fallback reads embedding rows out of it unchanged.
+
+These tests open a **local** ``file:`` libSQL database in a tmp path — no
+server, no network, no infra. They are skipped automatically if the optional
+``libsql`` client cannot be imported in this environment, so the suite never
+fakes a pass.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+from neurodock_mcp_cognitive_graph.embeddings import vector_from_bytes, vector_to_bytes
+from neurodock_mcp_cognitive_graph.storage.sqlite import SQLiteStorage
+from neurodock_mcp_cognitive_graph.vector_search import NumpySearcher
+
+# Skip the whole module if the optional libsql client is unavailable. This is
+# honest: when libsql is not installed (e.g. a default local stdio environment)
+# the live tests do not run and are reported as skipped rather than passed.
+libsql = pytest.importorskip("libsql", reason="optional 'libsql' client not installed")
+
+from neurodock_mcp_cognitive_graph.storage.libsql import (  # noqa: E402  (after importorskip)
+    LibSqlStorage,
+)
+
+NOW = datetime(2026, 5, 15, 9, 14, 22, tzinfo=UTC)
+
+
+@pytest.fixture
+def libsql_storage(tmp_path: Path) -> Iterator[LibSqlStorage]:
+    """A fresh local libSQL store anchored at a tmp-path file."""
+    db_path = tmp_path / "test-cognitive-graph.libsql.db"
+    storage = LibSqlStorage(str(db_path))
+    storage.initialise()
+    try:
+        yield storage
+    finally:
+        storage.close()
+
+
+# -- construction / schema -------------------------------------------------
+
+
+def test_initialise_creates_schema(tmp_path: Path) -> None:
+    """A fresh database picks up both migrations on first initialise."""
+    db_path = tmp_path / "schema.libsql.db"
+    storage = LibSqlStorage(str(db_path))
+    storage.initialise()
+    try:
+        # All four query surfaces should work against the empty schema.
+        assert storage.all_entities() == []
+        assert storage.all_decision_entities() == []
+        assert storage.all_embeddings() == []
+        assert storage.get_cached_resolution("nothing") is None
+    finally:
+        storage.close()
+
+
+def test_query_before_initialise_raises(tmp_path: Path) -> None:
+    """Touching storage before initialise() is a programmer error."""
+    storage = LibSqlStorage(str(tmp_path / "uninit.db"))
+    with pytest.raises(RuntimeError, match="not initialised"):
+        storage.all_entities()
+
+
+def test_auth_token_is_threaded_only_when_present(tmp_path: Path) -> None:
+    """A local file connection must still work when no auth token is given.
+
+    (The remote ``libsql://`` path threads the token through; we assert the
+    None branch here since a live remote server is out of scope for unit tests.)
+    """
+    storage = LibSqlStorage(str(tmp_path / "noauth.db"), auth_token=None)
+    storage.initialise()
+    try:
+        entity, created = storage.upsert_entity("person", "Ada", now=NOW)
+        assert created is True
+        assert entity.name == "Ada"
+    finally:
+        storage.close()
+
+
+# -- entities --------------------------------------------------------------
+
+
+def test_upsert_entity_inserts_then_fetches(libsql_storage: LibSqlStorage) -> None:
+    row, created = libsql_storage.upsert_entity("person", "Roberto", now=NOW)
+    assert created is True
+    assert row.name == "Roberto"
+    assert row.type == "person"
+    assert row.aliases == ()
+
+    # Second upsert of the same (type, name) returns the existing row.
+    row2, created2 = libsql_storage.upsert_entity("person", "Roberto", now=NOW)
+    assert created2 is False
+    assert row2.id == row.id
+
+
+def test_find_entity_by_id(libsql_storage: LibSqlStorage) -> None:
+    row, _ = libsql_storage.upsert_entity("project", "kipi-system", now=NOW)
+    found = libsql_storage.find_entity_by_id(row.id)
+    assert found is not None
+    assert found.name == "kipi-system"
+    assert libsql_storage.find_entity_by_id("ent_does_not_exist") is None
+
+
+def test_find_entity_exact_and_any_type(libsql_storage: LibSqlStorage) -> None:
+    libsql_storage.upsert_entity("person", "Priya", now=NOW)
+    assert libsql_storage.find_entity_exact("person", "Priya") is not None
+    assert libsql_storage.find_entity_exact("project", "Priya") is None
+    assert libsql_storage.find_entity_by_name_any_type("Priya") is not None
+    assert libsql_storage.find_entity_by_name_any_type("Nobody") is None
+
+
+def test_alias_add_and_resolve(libsql_storage: LibSqlStorage) -> None:
+    row, _ = libsql_storage.upsert_entity("person", "Roberto", now=NOW)
+    libsql_storage.add_alias(row.id, "Rob")
+    libsql_storage.add_alias(row.id, "Bobby")
+    # Idempotent: adding the same alias twice is a no-op.
+    libsql_storage.add_alias(row.id, "Rob")
+    # Adding the canonical name as an alias is a no-op.
+    libsql_storage.add_alias(row.id, "Roberto")
+
+    refetched = libsql_storage.find_entity_by_id(row.id)
+    assert refetched is not None
+    assert refetched.aliases == ("Rob", "Bobby")
+
+    # Case-insensitive alias resolution.
+    by_alias = libsql_storage.find_entity_by_alias("bobby")
+    assert by_alias is not None
+    assert by_alias.id == row.id
+    # Exact-name (case-insensitive) wins too.
+    by_name = libsql_storage.find_entity_by_alias("ROBERTO")
+    assert by_name is not None
+    assert by_name.id == row.id
+    # An unknown alias resolves to nothing.
+    assert libsql_storage.find_entity_by_alias("Zephyrine") is None
+
+
+# -- facts -----------------------------------------------------------------
+
+
+def _seed_fact(
+    storage: LibSqlStorage,
+    *,
+    subject: tuple[str, str],
+    predicate: str,
+    obj_entity: tuple[str, str] | None = None,
+    obj_literal: str | None = None,
+    source: str | None = None,
+    confidence: float = 1.0,
+) -> str:
+    """Create the entities and the canonical fact, returning the fact id."""
+    from neurodock_mcp_cognitive_graph.storage.libsql import _new_entity_id
+
+    subj, _ = storage.upsert_entity(subject[0], subject[1], now=NOW)  # type: ignore[arg-type]
+    object_id: str | None = None
+    object_kind = "literal"
+    if obj_entity is not None:
+        obj, _ = storage.upsert_entity(obj_entity[0], obj_entity[1], now=NOW)  # type: ignore[arg-type]
+        object_id = obj.id
+        object_kind = "entity"
+    fact_id = _new_entity_id().replace("ent_", "fact_")
+    from neurodock_mcp_cognitive_graph.storage.base import FactRow
+
+    fact = FactRow(
+        id=fact_id,
+        subject_id=subj.id,
+        predicate=predicate,  # type: ignore[arg-type]
+        object_kind=object_kind,
+        object_id=object_id,
+        object_literal=obj_literal,
+        source=source,
+        confidence=confidence,
+        recorded_at=NOW,
+    )
+    storage.insert_fact(fact)
+    return fact_id
+
+
+def test_insert_and_find_canonical_fact(libsql_storage: LibSqlStorage) -> None:
+    fact_id = _seed_fact(
+        libsql_storage,
+        subject=("person", "Roberto"),
+        predicate="decided_in",
+        obj_entity=("decision", "Adopt SQLite"),
+        source="msg://slack/C1/p1",
+    )
+    subj = libsql_storage.find_entity_exact("person", "Roberto")
+    obj = libsql_storage.find_entity_exact("decision", "Adopt SQLite")
+    assert subj is not None and obj is not None
+    found = libsql_storage.find_fact_canonical(subj.id, "decided_in", obj.id, None)
+    assert found is not None
+    assert found.id == fact_id
+    assert found.source == "msg://slack/C1/p1"
+    assert found.confidence == 1.0
+
+
+def test_provenance_insert(libsql_storage: LibSqlStorage) -> None:
+    fact_id = _seed_fact(
+        libsql_storage,
+        subject=("project", "neurodock"),
+        predicate="blocked_by",
+        obj_literal="awaiting advisor",
+    )
+    # Should not raise; provenance is append-only.
+    libsql_storage.insert_provenance(fact_id, "msg://slack/C2/p9", 0.9, NOW)
+
+
+def test_facts_touching_entity_and_truncation(libsql_storage: LibSqlStorage) -> None:
+    subj, _ = libsql_storage.upsert_entity("project", "neurodock", now=NOW)
+    from neurodock_mcp_cognitive_graph.storage.base import FactRow
+
+    for i in range(3):
+        libsql_storage.insert_fact(
+            FactRow(
+                id=f"fact_t{i}",
+                subject_id=subj.id,
+                predicate="tagged",
+                object_kind="literal",
+                object_id=None,
+                object_literal=f"tag-{i}",
+                source=None,
+                confidence=1.0,
+                recorded_at=NOW,
+            )
+        )
+    rows, truncated = libsql_storage.facts_touching_entity(subj.id, limit=10)
+    assert len(rows) == 3
+    assert truncated is False
+
+    rows2, truncated2 = libsql_storage.facts_touching_entity(subj.id, limit=2)
+    assert len(rows2) == 2
+    assert truncated2 is True
+
+
+def test_neighbour_counts(libsql_storage: LibSqlStorage) -> None:
+    _seed_fact(
+        libsql_storage,
+        subject=("project", "neurodock"),
+        predicate="depends_on",
+        obj_entity=("concept", "sqlite-vec"),
+    )
+    _seed_fact(
+        libsql_storage,
+        subject=("project", "neurodock"),
+        predicate="tagged",
+        obj_entity=("concept", "memory"),
+    )
+    nd = libsql_storage.find_entity_exact("project", "neurodock")
+    assert nd is not None
+    counts = libsql_storage.neighbour_counts(nd.id, limit=10)
+    assert len(counts) == 2
+    assert all(c == 1 for _, c in counts)
+
+
+def test_facts_by_predicate_with_since(libsql_storage: LibSqlStorage) -> None:
+    subj, _ = libsql_storage.upsert_entity("project", "neurodock", now=NOW)
+    from neurodock_mcp_cognitive_graph.storage.base import FactRow
+
+    old = datetime(2026, 4, 1, tzinfo=UTC)
+    libsql_storage.insert_fact(
+        FactRow(
+            id="fact_old",
+            subject_id=subj.id,
+            predicate="blocked_by",
+            object_kind="literal",
+            object_id=None,
+            object_literal="old blocker",
+            source=None,
+            confidence=1.0,
+            recorded_at=old,
+        )
+    )
+    libsql_storage.insert_fact(
+        FactRow(
+            id="fact_new",
+            subject_id=subj.id,
+            predicate="blocked_by",
+            object_kind="literal",
+            object_id=None,
+            object_literal="new blocker",
+            source=None,
+            confidence=1.0,
+            recorded_at=NOW,
+        )
+    )
+    all_blockers = libsql_storage.facts_by_predicate("blocked_by")
+    assert len(all_blockers) == 2
+    recent = libsql_storage.facts_by_predicate("blocked_by", since=datetime(2026, 5, 1, tzinfo=UTC))
+    assert len(recent) == 1
+    assert recent[0].object_literal == "new blocker"
+
+
+# -- decisions -------------------------------------------------------------
+
+
+def test_decisions_for_project(libsql_storage: LibSqlStorage) -> None:
+    _seed_fact(
+        libsql_storage,
+        subject=("project", "neurodock"),
+        predicate="decided_in",
+        obj_entity=("decision", "Ship rumination detector first"),
+    )
+    nd = libsql_storage.find_entity_exact("project", "neurodock")
+    assert nd is not None
+    decisions = libsql_storage.decisions_for_project(nd.id)
+    assert len(decisions) == 1
+    assert decisions[0].name == "Ship rumination detector first"
+    assert decisions[0].type == "decision"
+
+    project_facts = libsql_storage.facts_for_project_decisions(nd.id)
+    assert len(project_facts) == 1
+
+    all_decisions = libsql_storage.all_decision_entities()
+    assert len(all_decisions) == 1
+
+
+# -- embeddings / vector round-trip ---------------------------------------
+
+
+def test_embedding_roundtrip_and_upsert(libsql_storage: LibSqlStorage) -> None:
+    entity, _ = libsql_storage.upsert_entity("person", "Roberto", now=NOW)
+    vec = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+    blob = vector_to_bytes(vec)
+    libsql_storage.upsert_embedding(
+        entity_id=entity.id,
+        surface_kind="name",
+        surface_text="Roberto",
+        vector=blob,
+        dim=4,
+        model="stub",
+        now=NOW,
+    )
+    rows = libsql_storage.all_embeddings()
+    assert len(rows) == 1
+    assert rows[0].entity_id == entity.id
+    assert rows[0].vector == blob
+    restored = vector_from_bytes(rows[0].vector, rows[0].dim)
+    assert np.allclose(restored, vec, atol=1e-7)
+
+    # Upsert with a new vector replaces in place (no duplicate row).
+    vec2 = np.array([0.4, 0.3, 0.2, 0.1], dtype=np.float32)
+    libsql_storage.upsert_embedding(
+        entity_id=entity.id,
+        surface_kind="name",
+        surface_text="Roberto",
+        vector=vector_to_bytes(vec2),
+        dim=4,
+        model="stub",
+        now=NOW,
+    )
+    rows2 = libsql_storage.all_embeddings()
+    assert len(rows2) == 1
+    assert np.allclose(vector_from_bytes(rows2[0].vector, rows2[0].dim), vec2, atol=1e-7)
+
+
+def test_delete_embeddings_for_entity(libsql_storage: LibSqlStorage) -> None:
+    entity, _ = libsql_storage.upsert_entity("person", "Roberto", now=NOW)
+    libsql_storage.upsert_embedding(
+        entity_id=entity.id,
+        surface_kind="name",
+        surface_text="Roberto",
+        vector=vector_to_bytes(np.array([1.0, 0.0], dtype=np.float32)),
+        dim=2,
+        model="stub",
+        now=NOW,
+    )
+    assert len(libsql_storage.all_embeddings()) == 1
+    libsql_storage.delete_embeddings_for_entity(entity.id)
+    assert libsql_storage.all_embeddings() == []
+
+
+def test_numpy_searcher_over_libsql(libsql_storage: LibSqlStorage) -> None:
+    """The storage-agnostic NumPy searcher works over a libSQL backing,
+    proving the embedding-BLOB layout matches what the searcher expects."""
+    pg, _ = libsql_storage.upsert_entity("concept", "PostgreSQL", now=NOW)
+    kp, _ = libsql_storage.upsert_entity("concept", "kipi-system", now=NOW)
+    libsql_storage.upsert_embedding(
+        entity_id=pg.id,
+        surface_kind="name",
+        surface_text="PostgreSQL",
+        vector=vector_to_bytes(np.array([1.0, 0.0, 0.0], dtype=np.float32)),
+        dim=3,
+        model="stub",
+        now=NOW,
+    )
+    libsql_storage.upsert_embedding(
+        entity_id=kp.id,
+        surface_kind="name",
+        surface_text="kipi-system",
+        vector=vector_to_bytes(np.array([0.0, 1.0, 0.0], dtype=np.float32)),
+        dim=3,
+        model="stub",
+        now=NOW,
+    )
+    searcher = NumpySearcher(libsql_storage)
+    query = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    hits = searcher.search(query, limit=5)
+    assert hits
+    assert hits[0].surface_text == "PostgreSQL"
+    assert hits[0].score == pytest.approx(1.0, abs=1e-6)
+
+
+# -- resolution cache ------------------------------------------------------
+
+
+def test_resolution_cache_roundtrip(libsql_storage: LibSqlStorage) -> None:
+    entity, _ = libsql_storage.upsert_entity("person", "Roberto", now=NOW)
+    libsql_storage.cache_resolution(
+        input_text="Robrto",
+        entity_id=entity.id,
+        method="fuzzy",
+        score=0.86,
+        now=NOW,
+    )
+    hit = libsql_storage.get_cached_resolution("Robrto")
+    assert hit is not None
+    cached_id, method, score = hit
+    assert cached_id == entity.id
+    assert method == "fuzzy"
+    assert score == pytest.approx(0.86)
+
+    # Upsert: the same input text updates rather than duplicates.
+    libsql_storage.cache_resolution(
+        input_text="Robrto",
+        entity_id=entity.id,
+        method="embedding",
+        score=0.91,
+        now=NOW,
+    )
+    hit2 = libsql_storage.get_cached_resolution("Robrto")
+    assert hit2 is not None
+    assert hit2[1] == "embedding"
+    assert hit2[2] == pytest.approx(0.91)
+
+
+# -- cross-backend parity --------------------------------------------------
+
+
+def _exercise_backend(storage: SQLiteStorage | LibSqlStorage) -> dict[str, object]:
+    """Run an identical operation sequence and snapshot observable results.
+
+    The returned dict is compared between the SQLite and libSQL backings to
+    prove behavioural parity (entity ids differ by construction, so we compare
+    names/structure, not the random ids).
+    """
+    from neurodock_mcp_cognitive_graph.storage.base import FactRow
+
+    roberto, _ = storage.upsert_entity("person", "Roberto", now=NOW)
+    storage.add_alias(roberto.id, "Rob")
+    priya, _ = storage.upsert_entity("person", "Priya", now=NOW)
+    nd, _ = storage.upsert_entity("project", "neurodock", now=NOW)
+    decision, _ = storage.upsert_entity("decision", "Ship rumination detector first", now=NOW)
+
+    storage.insert_fact(
+        FactRow(
+            id="fact_p1",
+            subject_id=roberto.id,
+            predicate="reports_to",
+            object_kind="entity",
+            object_id=priya.id,
+            object_literal=None,
+            source=None,
+            confidence=1.0,
+            recorded_at=NOW,
+        )
+    )
+    storage.insert_fact(
+        FactRow(
+            id="fact_p2",
+            subject_id=nd.id,
+            predicate="decided_in",
+            object_kind="entity",
+            object_id=decision.id,
+            object_literal=None,
+            source="msg://x",
+            confidence=1.0,
+            recorded_at=NOW,
+        )
+    )
+    storage.insert_fact(
+        FactRow(
+            id="fact_p3",
+            subject_id=nd.id,
+            predicate="blocked_by",
+            object_kind="literal",
+            object_id=None,
+            object_literal="awaiting advisor",
+            source=None,
+            confidence=0.9,
+            recorded_at=NOW,
+        )
+    )
+
+    # Embedding + NumPy search snapshot.
+    storage.upsert_embedding(
+        entity_id=roberto.id,
+        surface_kind="name",
+        surface_text="Roberto",
+        vector=vector_to_bytes(np.array([1.0, 0.0, 0.0], dtype=np.float32)),
+        dim=3,
+        model="stub",
+        now=NOW,
+    )
+    searcher = NumpySearcher(storage)
+    top = searcher.search(np.array([1.0, 0.0, 0.0], dtype=np.float32), limit=1)
+
+    facts_touching, truncated = storage.facts_touching_entity(nd.id)
+    return {
+        "alias_resolves": storage.find_entity_by_alias("rob") is not None,
+        "decisions": sorted(d.name for d in storage.decisions_for_project(nd.id)),
+        "blockers": sorted(
+            f.object_literal or "" for f in storage.facts_by_predicate("blocked_by")
+        ),
+        "neighbour_count": len(storage.neighbour_counts(nd.id)),
+        "facts_touching_nd": sorted(f.predicate for f in facts_touching),
+        "facts_touching_truncated": truncated,
+        "top_hit_surface": top[0].surface_text if top else None,
+        "entity_count": len(storage.all_entities()),
+    }
+
+
+def test_libsql_matches_sqlite_on_same_operations(tmp_path: Path) -> None:
+    """``LibSqlStorage`` produces identical observable results to
+    ``SQLiteStorage`` for the same sequence of operations."""
+    sqlite_store = SQLiteStorage(tmp_path / "parity.sqlite")
+    sqlite_store.initialise()
+    libsql_store = LibSqlStorage(str(tmp_path / "parity.libsql.db"))
+    libsql_store.initialise()
+    try:
+        sqlite_snapshot = _exercise_backend(sqlite_store)
+        libsql_snapshot = _exercise_backend(libsql_store)
+        assert libsql_snapshot == sqlite_snapshot
+    finally:
+        sqlite_store.close()
+        libsql_store.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,12 @@ ignore_missing_imports = true
 module = "sqlite_vec.*"
 ignore_missing_imports = true
 
+# libsql is an optional backing for the cognitive graph (ADR 0010 Phases C/D)
+# and ships without a py.typed marker. Imported lazily inside LibSqlStorage.
+[[tool.mypy.overrides]]
+module = "libsql.*"
+ignore_missing_imports = true
+
 [[tool.mypy.overrides]]
 module = "fastembed.*"
 ignore_missing_imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -1040,6 +1040,28 @@ wheels = [
 ]
 
 [[package]]
+name = "libsql"
+version = "0.1.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/a2/804e533104102770b42aa0698fee944dd13654652ceb3d27e08a83404bbd/libsql-0.1.11.tar.gz", hash = "sha256:101b6e60f5333434b3e6107bfe2cf24cd5d1317286ad262cb6489941abde77d4", size = 33353, upload-time = "2025-09-02T10:13:38.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/84/cabed03c2ea93dbc1a0b8a6a37e74ecf1e1f9a9c13417e863325c6942356/libsql-0.1.11-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b5354526a555b7fd79a070e01737460fe567bb8cc9b51064aedfbea63e02a556", size = 4768363, upload-time = "2025-09-02T10:13:11.339Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/43/fbdd181bd19fa8ddeb3500005512377c94a08ef8cd3995152ffb21edfea7/libsql-0.1.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ed49b68ee9f85ba9fa212ffa3bb06e4c9ba3cc13d371e8065c66a0d0351f264e", size = 4527608, upload-time = "2025-09-02T10:13:12.866Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/b644b7aaadc296d47d491ae95139226fb67ca6128148bc5fc5f79348a95b/libsql-0.1.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d6d2c29ea9729de9b93a59618695245a230544725a7610041c46bd63fe8a7d9", size = 5106993, upload-time = "2025-09-02T10:13:14.128Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/54/96210e58e92bfc95e1532cd83b69f6c8339b9127a032b009560f166c51fe/libsql-0.1.11-cp311-cp311-win_amd64.whl", hash = "sha256:fdf438c1925f29f3ec40d6ebf2d60e60679d1e18dc2d56462bd03b64a30482a7", size = 4052605, upload-time = "2025-09-02T10:13:15.707Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e8/811fa308d42e8881ef8b206e01957c5086795af1bb46167c2107ac836c3a/libsql-0.1.11-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a9d7340f762ea6db8cdcc0345b1666a77cbaf313c28c7c6738533fc5844e8f54", size = 4768047, upload-time = "2025-09-02T10:13:17.356Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/39/68607c8a5f4841e61bf8c4ce0112182eb861140a17d937fe35b7ba3131aa/libsql-0.1.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c8c00c5e4d0906ff682ab3cad8473ef36aaa34080bcc553a2e636a73e79d9c2b", size = 4527150, upload-time = "2025-09-02T10:13:18.607Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2f/1def1065c43e23a9bab3cb51fb10a368414baaac7aa84d22637d3f2a146a/libsql-0.1.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74fde15d0cdc930da3b88a0cfcf9d7c9cafea945974d48d09394e574939f77b1", size = 5111168, upload-time = "2025-09-02T10:13:19.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/90/9df4779fc93bbd9f21ab4e14ea1beeb66c85f24e12b484a6bc0e77b86aa6/libsql-0.1.11-cp312-cp312-win_amd64.whl", hash = "sha256:28dbc0165942c57d0dcfe0115eb4fde13f52929ce18e59a59e826ac77b647e11", size = 4056792, upload-time = "2025-09-02T10:13:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e3/254d777f73a6ef985db2b030592a7eda45b2a2ac5042d9325937c90df9af/libsql-0.1.11-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0b41c9fa8fa7bfe44f4a80a99939c5c87d11d88fdb1bad8d6f0c0ac96b5f9432", size = 4768039, upload-time = "2025-09-02T10:13:22.674Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a5/de5dd7950bdc199b142a82b55fbc0049da0c7eb1639bb81a79a774f1654c/libsql-0.1.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8682d519c62daafba13df521b117a08a43af516f6d3c81337299275c66fda051", size = 4527338, upload-time = "2025-09-02T10:13:24.211Z" },
+    { url = "https://files.pythonhosted.org/packages/76/09/a36482f773943c45a6659bcb58be11ec7c1157876b908ea9eccf16c7a553/libsql-0.1.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c9ac431078a4eb82257541c764befa84782d8c5fbd1d1147e77f2906c28c444", size = 5110482, upload-time = "2025-09-02T10:13:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/7e/8496944f42f5b91a0e0938205297fc11896f6003f92caa5c53eaa2b8440f/libsql-0.1.11-cp313-cp313-win_amd64.whl", hash = "sha256:c61f6c4a73d799e4bedc49eb9b18bc8b6574267046195963684688f6a184632b", size = 4056117, upload-time = "2025-09-02T10:13:28.806Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ad/cb4e9ac36693a9f3f3f9b03f2b1f0d14cf5b1b449c66be6f9ce7845cbf02/libsql-0.1.11-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c7b39b90228637a4b26293af44833633c36c091276fc8b58f216dea38742f23", size = 5110968, upload-time = "2025-09-02T10:13:30.228Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1c/05e554a1018fd11607537ec554026bf176681e3ef89806dd4ad14f7c598d/libsql-0.1.11-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41f3f130af96b2b372c62ca7f53f4b8738c6bd6d0c8a8fa429119403654f1af2", size = 5107575, upload-time = "2025-09-02T10:13:37.188Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1344,6 +1366,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+libsql = [
+    { name = "libsql" },
+]
 test = [
     { name = "jsonschema" },
     { name = "pytest" },
@@ -1357,6 +1382,7 @@ vec = [
 requires-dist = [
     { name = "fastembed", specifier = ">=0.4" },
     { name = "jsonschema", marker = "extra == 'test'", specifier = ">=4.0" },
+    { name = "libsql", marker = "extra == 'libsql'", specifier = ">=0.1.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "pydantic", specifier = ">=2.7" },
@@ -1366,7 +1392,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.10" },
     { name = "sqlite-vec", marker = "extra == 'vec'", specifier = ">=0.1.6" },
 ]
-provides-extras = ["test", "vec"]
+provides-extras = ["test", "vec", "libsql"]
 
 [[package]]
 name = "neurodock-mcp-guardrail"


### PR DESCRIPTION
## Summary

Implements `LibSqlStorage`, a libSQL/Turso-backed `Storage` for the cognitive
graph — the core backend that **ADR 0010 Phases C (hosted)** and **D (BYOS)**
both build on. libSQL is a SQLite fork, so this backing mirrors
`SQLiteStorage` byte-for-byte at the SQL level: same migrations, same on-disk
embedding BLOB layout, same NumPy cosine fallback.

Scope is the storage backend + its tests only. The remote app, un-gating,
connect/disconnect tools, and the default local SQLite path are all untouched.

## What landed

- **`storage/libsql.py`** — `LibSqlStorage` implements the full `Storage`
  protocol, porting `SQLiteStorage`'s queries verbatim.
  - Constructor `(url: str, auth_token: str | None = None)`. `url` may be a
    local `file:`/path (tests, embedded) or a remote `libsql://` / `https://`
    URL with a token.
  - `initialise()` opens the connection and applies the same ported
    migrations (`0001_init.sql`, `0002_embeddings.sql`).
  - The `libsql` client is imported **lazily** inside `initialise()`, so the
    default local stdio install never pulls a network DB client.
  - The libsql DB-API client returns plain tuples and does **not** implement
    `row_factory`, so rows are mapped to column-name dicts via
    `cursor.description`, then shaped with the same helpers `SQLiteStorage`
    uses.
- **Vector search** goes through the existing storage-agnostic
  `NumpySearcher` (read all embeddings for the graph, cosine in Python). This
  works over any libSQL connection without sqlite-vec or a vector-capable
  libSQL build. Native `vector_top_k` is noted in a comment as a future
  optimisation.
- **Optional dependency** — `libsql` added under a new `libsql` extra in the
  package `pyproject.toml`; a `libsql.*` mypy override added at the workspace
  root. `_build_default_storage()` and the local path stay SQLite.
- **Tests** (`tests/test_libsql_storage.py`) open a local libSQL file (no
  server, no infra), port the SQLite scenarios (initialise, entities, aliases,
  facts, decisions, embeddings/vector round-trip via NumPy, resolution cache),
  and add a **cross-backend parity test** asserting `LibSqlStorage` produces
  identical observable results to `SQLiteStorage` on the same operation
  sequence. The module is skipped via `pytest.importorskip` when the libsql
  client is unavailable, so the suite never fakes a pass.

## Untouched (by design)

`Storage` protocol, `SQLiteStorage`, `InMemoryStorage`, `storage/__init__.py`
exports, `config.py`, `server.py`, and the migrations.

## Verification (from repo root)

- `uv run --no-sync ruff check packages/mcp-cognitive-graph` → **All checks passed!**
- `uv run --no-sync ruff format --check packages/mcp-cognitive-graph` → **36 files already formatted**
- `uv run --no-sync mypy packages/mcp-cognitive-graph` → **Success: no issues found in 36 source files**
- `uv run --no-sync pytest packages/mcp-cognitive-graph -c pyproject.toml -q` → **75 passed** (18 new libsql tests)

## Live libSQL tests

The live local-file libSQL tests **ran and passed** in this environment
(`libsql==0.1.11`, all 18 tests green, including the SQLite↔libSQL parity
test). They are guarded with `pytest.importorskip("libsql")` so they skip
cleanly where the optional client is not installed.

## Test plan

- [x] Local libSQL file backing exercises every `Storage` method
- [x] Embedding BLOB round-trip + NumPy searcher over the libSQL backing
- [x] Cross-backend parity vs `SQLiteStorage`
- [ ] Remote `libsql://` connection against a live Turso DB (out of scope for
      this PR — reserved for ADR 0010 Phase C wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
