### PR TITLE
feat: annotate stateless tools as read-only for the connectors directory

### DIFF
--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/server.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/server.py
@@ -10,6 +10,7 @@ import sys
 from typing import Any
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import ValidationError
 
 from neurodock_mcp_guardrail.tools.check_hyperfocus import (
@@ -53,6 +54,12 @@ def build_server() -> FastMCP[Any]:
             "Detect whether the user's current prompt is a semantic repeat of recent prompts "
             "within a rolling window. Stateless; returns a structured advisory signal."
         ),
+        annotations=ToolAnnotations(
+            title="Check rumination",
+            readOnlyHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
     )
     def _check_rumination(
         current_prompt: str,
@@ -88,6 +95,12 @@ def build_server() -> FastMCP[Any]:
             "Classify hyperfocus escalation from a caller-supplied chronometric snapshot "
             "into one of (none, gentle, nudge, hard). Stateless; quotes prior_intent verbatim."
         ),
+        annotations=ToolAnnotations(
+            title="Check hyperfocus",
+            readOnlyHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
     )
     def _check_hyperfocus(
         chronometric_snapshot: dict[str, Any],
@@ -120,6 +133,12 @@ def build_server() -> FastMCP[Any]:
         description=(
             "Detect over-validation in a candidate response or repeated reassurance-seeking "
             "in recent user messages. Returns a counter_prompt the caller MAY surface."
+        ),
+        annotations=ToolAnnotations(
+            title="Check sycophancy",
+            readOnlyHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
         ),
     )
     def _check_sycophancy(

--- a/packages/mcp-guardrail/tests/test_tool_annotations.py
+++ b/packages/mcp-guardrail/tests/test_tool_annotations.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tool annotations: every guardrail tool is advertised as read-only.
+
+The Anthropic Connectors Directory rejects tools that lack a ``title`` and a
+``readOnlyHint``. All three guardrail tools are advisory and have no side
+effects, so each must carry ``readOnlyHint == True`` plus a human ``title``.
+
+Synchronous (``asyncio.run``) rather than ``async def`` so they do not depend on
+pytest-asyncio auto-mode — the repo-root pytest run does not apply the
+per-package ``asyncio_mode = "auto"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from neurodock_mcp_guardrail.server import build_server
+
+_EXPECTED_TITLES = {
+    "check_rumination": "Check rumination",
+    "check_hyperfocus": "Check hyperfocus",
+    "check_sycophancy": "Check sycophancy",
+}
+
+
+def _tools_by_name() -> dict[str, object]:
+    server = build_server()
+    return {tool.name: tool for tool in asyncio.run(server.list_tools())}
+
+
+def test_all_tools_are_marked_read_only() -> None:
+    tools = _tools_by_name()
+    assert set(tools) == set(_EXPECTED_TITLES)
+    for name in _EXPECTED_TITLES:
+        annotations = tools[name].annotations
+        assert annotations is not None, f"{name} is missing annotations"
+        assert annotations.readOnlyHint is True, f"{name} must be read-only"
+
+
+def test_all_tools_carry_a_human_title() -> None:
+    tools = _tools_by_name()
+    for name, expected_title in _EXPECTED_TITLES.items():
+        assert tools[name].annotations.title == expected_title

--- a/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/server.py
+++ b/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/server.py
@@ -22,6 +22,7 @@ import sys
 from typing import Any
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from neurodock_mcp_task_fractionator.decomposer import (
     AcceptanceCriteriaRequiredError,
@@ -94,6 +95,12 @@ def build_server(
             "Break a vague goal into a small ordered list of atomic 5-90 minute "
             "tasks with explicit acceptance criteria and dependency edges. "
             "Stateless: returns tasks but does NOT persist them."
+        ),
+        annotations=ToolAnnotations(
+            title="Decompose goal into tasks",
+            readOnlyHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
         ),
     )
     def _decompose(goal: str, time_budget: str | None = None) -> dict[str, Any]:

--- a/packages/mcp-task-fractionator/tests/test_tool_annotations.py
+++ b/packages/mcp-task-fractionator/tests/test_tool_annotations.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tool annotations: ``decompose`` is advertised as read-only.
+
+The Anthropic Connectors Directory rejects tools that lack a ``title`` and a
+``readOnlyHint``. ``decompose`` is the stateless, remote-safe tool (ADR
+0008/0009): it returns tasks but does NOT persist them, so it carries
+``readOnlyHint == True`` plus a human ``title``.
+
+``next_one`` reads the local cognitive graph and is local-only; it is left
+unannotated for now and is not part of the directory submission.
+
+Synchronous (``asyncio.run``) rather than ``async def`` so they do not depend on
+pytest-asyncio auto-mode — the repo-root pytest run does not apply the
+per-package ``asyncio_mode = "auto"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from neurodock_mcp_task_fractionator.server import build_server
+from neurodock_mcp_task_fractionator.sources import InMemoryPendingTaskSource
+
+
+def _tools_by_name() -> dict[str, object]:
+    server = build_server(source=InMemoryPendingTaskSource())
+    return {tool.name: tool for tool in asyncio.run(server.list_tools())}
+
+
+def test_decompose_is_marked_read_only_with_a_title() -> None:
+    tools = _tools_by_name()
+    annotations = tools["decompose"].annotations
+    assert annotations is not None, "decompose is missing annotations"
+    assert annotations.readOnlyHint is True
+    assert annotations.title == "Decompose goal into tasks"
+
+
+def test_next_one_is_left_unannotated_for_now() -> None:
+    tools = _tools_by_name()
+    annotations = tools["next_one"].annotations
+    # next_one is local-only and not part of the directory submission, so it
+    # must NOT yet be marked read-only.
+    assert annotations is None or annotations.readOnlyHint is not True

--- a/packages/mcp-translation/src/neurodock_mcp_translation/server.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/server.py
@@ -16,6 +16,7 @@ import sys
 from typing import Any
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import ValidationError
 
 from neurodock_mcp_translation.tools.brief_meeting import (
@@ -87,6 +88,12 @@ def build_server() -> FastMCP[Any]:
             "structured prompt the caller's MCP client MAY execute to refine "
             "the baseline against its own LLM."
         ),
+        annotations=ToolAnnotations(
+            title="Translate incoming message",
+            readOnlyHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
     )
     def _translate_incoming(
         text: str,
@@ -116,6 +123,12 @@ def build_server() -> FastMCP[Any]:
             "baseline or from a target register. Returns deterministic axes plus "
             "an LLM-refinement prompt."
         ),
+        annotations=ToolAnnotations(
+            title="Check tone",
+            readOnlyHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
     )
     def _check_tone(
         text: str,
@@ -144,6 +157,12 @@ def build_server() -> FastMCP[Any]:
             "baseline applies register-specific surface transforms; the LLM "
             "refinement prompt produces a stronger rewrite while keeping the "
             "same preservation contract."
+        ),
+        annotations=ToolAnnotations(
+            title="Rewrite outgoing",
+            readOnlyHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
         ),
     )
     def _rewrite_outgoing(
@@ -176,6 +195,12 @@ def build_server() -> FastMCP[Any]:
             "my_asks, others_asks, decisions, ambiguous_items. Every "
             "ambiguous_item is anchored to a verbatim transcript span; the "
             "server rejects responses where the anchor cannot be located."
+        ),
+        annotations=ToolAnnotations(
+            title="Brief meeting",
+            readOnlyHint=True,
+            idempotentHint=True,
+            openWorldHint=False,
         ),
     )
     def _brief_meeting(

--- a/packages/mcp-translation/tests/test_tool_annotations.py
+++ b/packages/mcp-translation/tests/test_tool_annotations.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tool annotations: every translation tool is advertised as read-only.
+
+The Anthropic Connectors Directory rejects tools that lack a ``title`` and a
+``readOnlyHint``. All four translation tools are advisory and have no side
+effects, so each must carry ``readOnlyHint == True`` plus a human ``title``.
+
+Synchronous (``asyncio.run``) rather than ``async def`` so they do not depend on
+pytest-asyncio auto-mode — the repo-root pytest run does not apply the
+per-package ``asyncio_mode = "auto"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from neurodock_mcp_translation.server import build_server
+
+_EXPECTED_TITLES = {
+    "translate_incoming": "Translate incoming message",
+    "check_tone": "Check tone",
+    "rewrite_outgoing": "Rewrite outgoing",
+    "brief_meeting": "Brief meeting",
+}
+
+
+def _tools_by_name() -> dict[str, object]:
+    server = build_server()
+    return {tool.name: tool for tool in asyncio.run(server.list_tools())}
+
+
+def test_all_tools_are_marked_read_only() -> None:
+    tools = _tools_by_name()
+    assert set(tools) == set(_EXPECTED_TITLES)
+    for name in _EXPECTED_TITLES:
+        annotations = tools[name].annotations
+        assert annotations is not None, f"{name} is missing annotations"
+        assert annotations.readOnlyHint is True, f"{name} must be read-only"
+
+
+def test_all_tools_carry_a_human_title() -> None:
+    tools = _tools_by_name()
+    for name, expected_title in _EXPECTED_TITLES.items():
+        assert tools[name].annotations.title == expected_title


### PR DESCRIPTION
## Summary

Adds MCP tool **annotations** marking the eight stateless, advisory NeuroDock tools as read-only, so the hosted remote server passes the Anthropic Connectors Directory review. A missing `readOnlyHint` / `title` is the directory's #1 rejection cause.

Each tool now carries an `mcp.types.ToolAnnotations` with:
- `title` — a short human label
- `readOnlyHint=True` — no side effects, no persistence
- `idempotentHint=True` — repeat calls are equivalent
- `openWorldHint=False` — no external/open-world interaction

### Tools annotated (8)
- **mcp-translation**: `translate_incoming`, `check_tone`, `rewrite_outgoing`, `brief_meeting`
- **mcp-guardrail**: `check_rumination`, `check_hyperfocus`, `check_sycophancy`
- **mcp-task-fractionator**: `decompose`

`next_one` (task-fractionator) is intentionally left **unannotated** — it reads the local cognitive graph, is local-only (ADR 0008/0009), and is not part of the directory submission.

### What did NOT change
- No tool behaviour, signatures, or descriptions.
- No version bumps. The annotations ride the next release and take effect on the hosted server at its next redeploy.
- The remote app and its gating are untouched.

### FastMCP API used (verified against 3.3.1)
`@mcp.tool(...)` accepts `annotations=` as `mcp.types.ToolAnnotations | dict | None`. The `ToolAnnotations` fields are `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. Resolved in tests via `asyncio.run(server.list_tools())` then `tool.annotations.readOnlyHint` / `tool.annotations.title`.

## Tests
Each of the three packages gains a sync `asyncio.run(...)`-style `test_tool_annotations.py` asserting the read-only annotation and human title. The fractionator test additionally asserts `next_one` is still left unannotated.

## Test plan
- [x] `uv run --no-sync ruff check packages/mcp-translation packages/mcp-guardrail packages/mcp-task-fractionator` — All checks passed
- [x] `uv run --no-sync ruff format --check ...` — 68 files already formatted
- [x] `uv run --no-sync mypy packages/mcp-translation/src packages/mcp-guardrail/src packages/mcp-task-fractionator/src` — Success: no issues found in 43 source files (the combined `mypy <pkg> <pkg> <pkg>` form hits a pre-existing duplicate-`conftest` module collision, present identically on untouched `main`, tolerated in CI via `continue-on-error`)
- [x] `uv run --no-sync pytest packages/mcp-translation packages/mcp-guardrail packages/mcp-task-fractionator packages/remote -c pyproject.toml -q` — 201 passed
- [x] Pre-commit `mypy --strict` hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
