### PR TITLE
feat: byos hosted storage for the cognitive-graph tools (adr 0010 phase d)

### DIFF
--- a/packages/mcp-state/pyproject.toml
+++ b/packages/mcp-state/pyproject.toml
@@ -21,6 +21,14 @@ test = [
     "pytest>=8.3.0",
     "pytest-asyncio>=1.3.0",
 ]
+# ADR 0010 Phase D — the Clerk-metadata BYOS store. Both are imported lazily
+# inside `clerk_byos_store`, so the base package stays dependency-light and
+# importable without them; the hosted image installs this extra
+# (`neurodock-state[clerk]`). `cryptography` encrypts the BYOS auth token at rest.
+clerk = [
+    "clerk-backend-api>=2.0",
+    "cryptography>=42.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/mcp-state/src/neurodock_state/__init__.py
+++ b/packages/mcp-state/src/neurodock_state/__init__.py
@@ -14,6 +14,12 @@ in behind the same protocols later.
 
 from __future__ import annotations
 
+from neurodock_state.byos_connection_store import (
+    ByosConnectionStore,
+    Connection,
+    InMemoryByosConnectionStore,
+)
+from neurodock_state.byos_resolver import ByosResolver
 from neurodock_state.identity import UserKey, user_key_from_context
 from neurodock_state.profile_store import InMemoryProfileStore, ProfileStore
 from neurodock_state.registry import (
@@ -27,7 +33,11 @@ from neurodock_state.session_store import InMemorySessionStore, Session, Session
 __version__ = "0.0.1"
 
 __all__ = [
+    "ByosConnectionStore",
+    "ByosResolver",
+    "Connection",
     "GraphStore",
+    "InMemoryByosConnectionStore",
     "InMemoryProfileStore",
     "InMemorySessionStore",
     "MemoryBackingResolver",

--- a/packages/mcp-state/src/neurodock_state/byos_connection_store.py
+++ b/packages/mcp-state/src/neurodock_state/byos_connection_store.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Per-user BYOS connection storage (ADR 0010 Phase D).
+
+A *BYOS connection* is the libSQL/Turso endpoint a user has chosen to own their
+own cognitive-graph data. It is the **only** per-user state NeuroDock holds on
+the hosted path, and even that is intentionally minimal: a URL plus an
+(encrypted) auth token. The graph rows themselves never touch NeuroDock — they
+live in the user's database.
+
+This module defines:
+
+- :class:`Connection` — the immutable (url, token) pair for one user.
+- :class:`ByosConnectionStore` — the storage contract (``get``/``put``/``delete``).
+- :class:`InMemoryByosConnectionStore` — an infra-free reference impl for tests.
+- :class:`ClerkMetadataByosStore` — persists the connection in the user's Clerk
+  ``private_metadata`` via the Clerk Backend API, encrypting the token with a
+  master key. The Clerk SDK is imported lazily so importing this module never
+  fails on a host without it.
+
+Security posture
+----------------
+- The auth token is a **secret**. :class:`ClerkMetadataByosStore` encrypts it at
+  rest (Fernet/AES, key from ``NEURODOCK_STATE_MASTER_KEY``) before it is ever
+  written to Clerk metadata; it is decrypted only in-process when a store is
+  resolved for a call.
+- The connection is keyed by :attr:`UserKey.storage_key` (the SHA-256 of the
+  Clerk ``sub``), never by the raw subject.
+- ``delete`` removes the stored connection entirely: after a disconnect,
+  NeuroDock retains nothing about the user's storage.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from neurodock_state.identity import UserKey
+
+
+@dataclass(frozen=True)
+class Connection:
+    """One user's BYOS libSQL/Turso connection.
+
+    Immutable: rotating a connection means storing a *new* instance, never
+    mutating an existing one (the project's immutability convention).
+
+    ``auth_token`` is ``None`` for token-less endpoints (e.g. a local ``file:``
+    database used in tests). For remote ``libsql://`` / ``https://`` endpoints it
+    carries the user's secret and must be treated as such by every store.
+    """
+
+    url: str
+    auth_token: str | None = None
+
+
+@runtime_checkable
+class ByosConnectionStore(Protocol):
+    """The contract a per-user BYOS-connection backing must satisfy.
+
+    Implementations isolate connections per :class:`UserKey`: one user can never
+    read or clear another user's connection.
+    """
+
+    def get(self, user: UserKey) -> Connection | None:
+        """Return ``user``'s stored connection, or ``None`` if not connected."""
+        ...
+
+    def put(self, user: UserKey, url: str, auth_token: str | None = None) -> None:
+        """Store (replacing any existing) ``user``'s connection."""
+        ...
+
+    def delete(self, user: UserKey) -> None:
+        """Remove ``user``'s stored connection. Idempotent: a no-op if absent."""
+        ...
+
+
+class InMemoryByosConnectionStore:
+    """Dict-backed reference :class:`ByosConnectionStore`. Per-user, no persistence.
+
+    Used by the test-suite to prove the BYOS routing/isolation logic without a
+    real Clerk account. Connections are keyed by :attr:`UserKey.storage_key`, so
+    two distinct users are isolated and two :class:`UserKey` objects with the
+    same ``sub`` collapse to one tenant.
+    """
+
+    def __init__(self) -> None:
+        self._connections: dict[str, Connection] = {}
+
+    def get(self, user: UserKey) -> Connection | None:
+        return self._connections.get(user.storage_key)
+
+    def put(self, user: UserKey, url: str, auth_token: str | None = None) -> None:
+        self._connections[user.storage_key] = Connection(url=url, auth_token=auth_token)
+
+    def delete(self, user: UserKey) -> None:
+        self._connections.pop(user.storage_key, None)
+
+    def __len__(self) -> int:
+        """Number of stored connections. Lets tests assert "nothing was stored"."""
+        return len(self._connections)

--- a/packages/mcp-state/src/neurodock_state/byos_resolver.py
+++ b/packages/mcp-state/src/neurodock_state/byos_resolver.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""BYOS per-user backing resolver (ADR 0010 Phase D).
+
+:class:`ByosResolver` is the :class:`~neurodock_state.registry.StateBackingResolver`
+for the bring-your-own-storage path. It reads each user's connection from a
+:class:`~neurodock_state.byos_connection_store.ByosConnectionStore` and returns a
+cognitive-graph store pointed at the **user's own** libSQL/Turso database.
+
+- :meth:`storage_mode` is ``"byos"`` when the user has a connection on file, else
+  ``"none"``. The ``"none"`` case is the security default: a user who has not
+  opted in (no stored connection) gets no storage, and the un-gating layer turns
+  that into a structured "enable storage first" response without touching any
+  store.
+- :meth:`graph_store` builds a :class:`LibSqlStorage` from the stored connection.
+  The cognitive-graph package is imported **lazily** so :mod:`neurodock_state`
+  stays dependency-light and importable without it.
+- :meth:`session_store` / :meth:`profile_store` raise :class:`NotImplementedError`:
+  chronometric session persistence and the hosted profile are **out of scope for
+  Phase D** (tracked as a follow-up). Only the four cognitive-graph tools are
+  un-gated in this phase.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from neurodock_state.byos_connection_store import ByosConnectionStore
+from neurodock_state.identity import UserKey
+from neurodock_state.registry import GraphStore, StorageMode
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from neurodock_state.profile_store import ProfileStore
+    from neurodock_state.session_store import SessionStore
+
+_SESSION_PROFILE_DEFERRED = (
+    "BYOS session/profile persistence is out of scope for ADR 0010 Phase D; "
+    "only the four cognitive-graph tools are un-gated. This is a tracked follow-up."
+)
+
+
+class ByosResolver:
+    """Resolve per-user cognitive-graph backings from stored BYOS connections.
+
+    Stateless apart from the injected connection store: every resolution reads
+    the user's connection fresh, so a disconnect (delete) takes effect on the
+    very next call.
+    """
+
+    def __init__(self, connections: ByosConnectionStore) -> None:
+        self._connections = connections
+
+    def storage_mode(self, user: UserKey) -> StorageMode:
+        return "byos" if self._connections.get(user) is not None else "none"
+
+    def graph_store(self, user: UserKey) -> GraphStore:
+        connection = self._connections.get(user)
+        if connection is None:
+            # Callers MUST check storage_mode() first; this guards the invariant.
+            raise LookupError(
+                "no BYOS connection on file for this user; call storage_mode() before graph_store()"
+            )
+        # Lazy import: keep neurodock_state free of a hard cognitive-graph
+        # dependency. The hosted image installs the cognitive-graph package and
+        # its `libsql` extra; the resolver only needs them when actually serving.
+        from neurodock_mcp_cognitive_graph.storage.libsql import LibSqlStorage
+
+        # LibSqlStorage is a structural superset of GraphStore (it has
+        # initialise/close), but the cognitive-graph package ships without
+        # py.typed so mypy sees it as Any here; cast to the declared return type.
+        return cast(GraphStore, LibSqlStorage(connection.url, auth_token=connection.auth_token))
+
+    def session_store(self, user: UserKey) -> SessionStore:
+        raise NotImplementedError(_SESSION_PROFILE_DEFERRED)
+
+    def profile_store(self, user: UserKey) -> ProfileStore:
+        raise NotImplementedError(_SESSION_PROFILE_DEFERRED)

--- a/packages/mcp-state/src/neurodock_state/clerk_byos_store.py
+++ b/packages/mcp-state/src/neurodock_state/clerk_byos_store.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Clerk-metadata-backed BYOS connection store (ADR 0010 Phase D).
+
+Persists a user's BYOS connection (libSQL URL + encrypted auth token) in their
+Clerk ``private_metadata`` via the Clerk Backend API. This is the production
+backing for :class:`~neurodock_state.byos_connection_store.ByosConnectionStore`
+on the hosted server.
+
+Why Clerk metadata?
+-------------------
+The hosted container is stateless by design (ADR 0008/0009): it must persist
+*nothing* about a user locally. Clerk is already the identity provider and the
+user is already authenticated, so their ``private_metadata`` is the natural —
+and only — place to keep the single pointer to *their own* database. The graph
+data never touches NeuroDock; only this pointer does, and the token half of it
+is encrypted at rest.
+
+Secrets
+-------
+- ``NEURODOCK_CLERK_SECRET_KEY`` — the Clerk Backend API secret key. Required to
+  read/write a user's metadata. Without it this store cannot operate and raises
+  :class:`ByosStoreConfigError` at construction.
+- ``NEURODOCK_STATE_MASTER_KEY`` — the master key used to encrypt the auth token
+  before it is written to Clerk metadata (and to decrypt it on read). Required.
+
+Both the Clerk SDK and the ``cryptography`` package are imported **lazily** so
+importing this module never fails on a host that lacks them (e.g. the local
+stdio install, or unit tests that only exercise the in-memory store).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from neurodock_state.byos_connection_store import Connection
+from neurodock_state.identity import UserKey
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from cryptography.fernet import Fernet
+
+# The single key under which the BYOS connection lives in a user's Clerk
+# private_metadata. Namespaced so it never collides with other app metadata.
+_METADATA_KEY = "neurodock_byos"
+
+_CLERK_SECRET_ENV = "NEURODOCK_CLERK_SECRET_KEY"
+_MASTER_KEY_ENV = "NEURODOCK_STATE_MASTER_KEY"
+
+
+class ByosStoreConfigError(RuntimeError):
+    """Required configuration (a secret) is missing or unusable."""
+
+
+class ByosStoreBackendError(RuntimeError):
+    """The Clerk Backend API call failed (network, auth, or unexpected shape)."""
+
+
+def _derive_fernet(master_key: str) -> Fernet:
+    """Build a :class:`Fernet` from an arbitrary-length master-key string.
+
+    Fernet requires a 32-byte url-safe-base64 key. We derive one deterministically
+    from the operator-supplied master key with SHA-256 so the operator can use any
+    sufficiently strong secret without having to pre-format it.
+    """
+    from cryptography.fernet import Fernet
+
+    digest = hashlib.sha256(master_key.encode("utf-8")).digest()
+    return Fernet(base64.urlsafe_b64encode(digest))
+
+
+class ClerkMetadataByosStore:
+    """Store BYOS connections in Clerk ``private_metadata``, token encrypted.
+
+    Construct with the process environment (or any mapping). Both required
+    secrets are read at construction so misconfiguration fails loudly and early
+    rather than on the first user call.
+    """
+
+    def __init__(self, env: Mapping[str, str]) -> None:
+        secret = env.get(_CLERK_SECRET_ENV, "").strip()
+        if not secret:
+            raise ByosStoreConfigError(
+                f"{_CLERK_SECRET_ENV} is required for the Clerk-backed BYOS store"
+            )
+        master = env.get(_MASTER_KEY_ENV, "").strip()
+        if not master:
+            raise ByosStoreConfigError(
+                f"{_MASTER_KEY_ENV} is required to encrypt BYOS auth tokens at rest"
+            )
+        self._secret_key = secret
+        # Build the cipher eagerly so a broken `cryptography` install fails at
+        # construction, not mid-request. (Lazy import keeps module import safe.)
+        self._fernet = _derive_fernet(master)
+        self._client: Any | None = None
+
+    # -- Clerk client (lazy) ---------------------------------------------
+
+    def _clerk(self) -> Any:
+        """Return a cached Clerk Backend client, importing the SDK lazily."""
+        if self._client is not None:
+            return self._client
+        try:
+            from clerk_backend_api import Clerk
+        except ImportError as exc:  # pragma: no cover - exercised only without SDK
+            raise ByosStoreConfigError(
+                "The 'clerk-backend-api' package is required for ClerkMetadataByosStore. "
+                "Install it in the hosted image (it is a dependency of neurodock-remote)."
+            ) from exc
+        self._client = Clerk(bearer_auth=self._secret_key)
+        return self._client
+
+    # -- token encryption ------------------------------------------------
+
+    def _encrypt(self, token: str) -> str:
+        return self._fernet.encrypt(token.encode("utf-8")).decode("ascii")
+
+    def _decrypt(self, blob: str) -> str:
+        from cryptography.fernet import InvalidToken
+
+        try:
+            return self._fernet.decrypt(blob.encode("ascii")).decode("utf-8")
+        except InvalidToken as exc:
+            raise ByosStoreBackendError(
+                f"stored BYOS auth token could not be decrypted (wrong {_MASTER_KEY_ENV}?)"
+            ) from exc
+
+    # -- ByosConnectionStore ---------------------------------------------
+
+    def get(self, user: UserKey) -> Connection | None:
+        clerk = self._clerk()
+        try:
+            clerk_user = clerk.users.get(user_id=user.sub)
+        except Exception as exc:  # surface as a structured backend error
+            raise ByosStoreBackendError(f"Clerk get-user failed: {exc}") from exc
+
+        metadata = getattr(clerk_user, "private_metadata", None) or {}
+        record = metadata.get(_METADATA_KEY)
+        if not isinstance(record, dict):
+            return None
+
+        url = record.get("url")
+        if not isinstance(url, str) or not url:
+            return None
+
+        token_blob = record.get("auth_token")
+        auth_token = (
+            self._decrypt(token_blob) if isinstance(token_blob, str) and token_blob else None
+        )
+        return Connection(url=url, auth_token=auth_token)
+
+    def put(self, user: UserKey, url: str, auth_token: str | None = None) -> None:
+        clerk = self._clerk()
+        record: dict[str, Any] = {"url": url}
+        if auth_token:
+            record["auth_token"] = self._encrypt(auth_token)
+        try:
+            clerk.users.update_metadata(
+                user_id=user.sub,
+                private_metadata={_METADATA_KEY: record},
+            )
+        except Exception as exc:  # surface as a structured backend error
+            raise ByosStoreBackendError(f"Clerk update-metadata failed: {exc}") from exc
+
+    def delete(self, user: UserKey) -> None:
+        clerk = self._clerk()
+        # Setting the namespaced key to None clears it from private_metadata
+        # (Clerk merges metadata and drops null-valued keys). NeuroDock then
+        # retains nothing about the user's storage.
+        try:
+            clerk.users.update_metadata(
+                user_id=user.sub,
+                private_metadata={_METADATA_KEY: None},
+            )
+        except Exception as exc:  # surface as a structured backend error
+            raise ByosStoreBackendError(f"Clerk clear-metadata failed: {exc}") from exc

--- a/packages/mcp-state/tests/test_byos_connection_store.py
+++ b/packages/mcp-state/tests/test_byos_connection_store.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the in-memory BYOS connection store (ADR 0010 Phase D)."""
+
+from __future__ import annotations
+
+from neurodock_state.byos_connection_store import (
+    ByosConnectionStore,
+    Connection,
+    InMemoryByosConnectionStore,
+)
+from neurodock_state.identity import UserKey
+
+
+def test_in_memory_store_satisfies_protocol() -> None:
+    # Arrange / Act
+    store = InMemoryByosConnectionStore()
+
+    # Assert — structural conformance to the published contract.
+    assert isinstance(store, ByosConnectionStore)
+
+
+def test_get_returns_none_when_not_connected() -> None:
+    # Arrange
+    store = InMemoryByosConnectionStore()
+
+    # Act / Assert
+    assert store.get(UserKey(sub="alice")) is None
+
+
+def test_put_then_get_round_trips_the_connection() -> None:
+    # Arrange
+    store = InMemoryByosConnectionStore()
+    alice = UserKey(sub="alice")
+
+    # Act
+    store.put(alice, "libsql://alice.turso.io", auth_token="secret-token")
+
+    # Assert
+    assert store.get(alice) == Connection(url="libsql://alice.turso.io", auth_token="secret-token")
+
+
+def test_put_without_token_stores_none_token() -> None:
+    # Arrange
+    store = InMemoryByosConnectionStore()
+    alice = UserKey(sub="alice")
+
+    # Act
+    store.put(alice, "file:/tmp/alice.db")
+
+    # Assert
+    connection = store.get(alice)
+    assert connection is not None
+    assert connection.auth_token is None
+
+
+def test_distinct_users_are_isolated() -> None:
+    # Arrange
+    store = InMemoryByosConnectionStore()
+    alice = UserKey(sub="alice")
+    bob = UserKey(sub="bob")
+
+    # Act
+    store.put(alice, "libsql://alice.turso.io", auth_token="a")
+
+    # Assert — Bob sees nothing of Alice's connection.
+    assert store.get(bob) is None
+    assert store.get(alice) is not None
+
+
+def test_same_sub_collapses_to_one_tenant() -> None:
+    # Arrange
+    store = InMemoryByosConnectionStore()
+    store.put(UserKey(sub="alice"), "libsql://alice.turso.io")
+
+    # Act / Assert — equal subjects address the same stored connection.
+    assert store.get(UserKey(sub="alice")) is not None
+
+
+def test_delete_clears_the_connection() -> None:
+    # Arrange
+    store = InMemoryByosConnectionStore()
+    alice = UserKey(sub="alice")
+    store.put(alice, "libsql://alice.turso.io", auth_token="a")
+
+    # Act
+    store.delete(alice)
+
+    # Assert — after disconnect, nothing is retained.
+    assert store.get(alice) is None
+
+
+def test_delete_is_idempotent_when_absent() -> None:
+    # Arrange
+    store = InMemoryByosConnectionStore()
+
+    # Act / Assert — deleting a non-existent connection is a no-op, not an error.
+    store.delete(UserKey(sub="nobody"))
+    assert store.get(UserKey(sub="nobody")) is None

--- a/packages/mcp-state/tests/test_byos_resolver.py
+++ b/packages/mcp-state/tests/test_byos_resolver.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the BYOS per-user backing resolver (ADR 0010 Phase D).
+
+The graph-store round-trip exercises a real local ``file:`` libSQL database via
+the cognitive-graph ``LibSqlStorage``. Those tests skip cleanly when either the
+cognitive-graph package or the optional ``libsql`` client is not installed, so
+this package's contract tests always run while the integration coverage layers
+on in the hosted/container environment that has both.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from neurodock_state.byos_connection_store import InMemoryByosConnectionStore
+from neurodock_state.byos_resolver import ByosResolver
+from neurodock_state.identity import UserKey
+from neurodock_state.registry import StateBackingResolver
+
+_HAS_LIBSQL_STACK = (
+    importlib.util.find_spec("libsql") is not None
+    and importlib.util.find_spec("neurodock_mcp_cognitive_graph") is not None
+)
+
+_needs_libsql = pytest.mark.skipif(
+    not _HAS_LIBSQL_STACK,
+    reason="requires the cognitive-graph package and the optional libsql client",
+)
+
+
+def test_resolver_satisfies_protocol() -> None:
+    # Arrange / Act
+    resolver = ByosResolver(InMemoryByosConnectionStore())
+
+    # Assert
+    assert isinstance(resolver, StateBackingResolver)
+
+
+def test_storage_mode_is_none_when_not_connected() -> None:
+    # Arrange
+    resolver = ByosResolver(InMemoryByosConnectionStore())
+
+    # Act / Assert — the security default: no connection => no storage.
+    assert resolver.storage_mode(UserKey(sub="alice")) == "none"
+
+
+def test_storage_mode_is_byos_once_connected() -> None:
+    # Arrange
+    connections = InMemoryByosConnectionStore()
+    alice = UserKey(sub="alice")
+    connections.put(alice, "file:/tmp/alice.db")
+    resolver = ByosResolver(connections)
+
+    # Act / Assert
+    assert resolver.storage_mode(alice) == "byos"
+
+
+def test_storage_mode_is_per_user() -> None:
+    # Arrange
+    connections = InMemoryByosConnectionStore()
+    alice = UserKey(sub="alice")
+    connections.put(alice, "file:/tmp/alice.db")
+    resolver = ByosResolver(connections)
+
+    # Act / Assert — Bob never opted in, so he stays on "none".
+    assert resolver.storage_mode(alice) == "byos"
+    assert resolver.storage_mode(UserKey(sub="bob")) == "none"
+
+
+def test_graph_store_raises_when_not_connected() -> None:
+    # Arrange
+    resolver = ByosResolver(InMemoryByosConnectionStore())
+
+    # Act / Assert — graph_store guards its own invariant.
+    with pytest.raises(LookupError):
+        resolver.graph_store(UserKey(sub="alice"))
+
+
+def test_session_store_is_deferred() -> None:
+    # Arrange
+    resolver = ByosResolver(InMemoryByosConnectionStore())
+
+    # Act / Assert — out of scope for Phase D.
+    with pytest.raises(NotImplementedError):
+        resolver.session_store(UserKey(sub="alice"))
+
+
+def test_profile_store_is_deferred() -> None:
+    # Arrange
+    resolver = ByosResolver(InMemoryByosConnectionStore())
+
+    # Act / Assert — out of scope for Phase D.
+    with pytest.raises(NotImplementedError):
+        resolver.profile_store(UserKey(sub="alice"))
+
+
+@_needs_libsql
+def test_graph_store_round_trips_against_a_local_libsql_db(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Arrange — a per-user local libSQL file stands in for the user's own DB.
+    from datetime import UTC, datetime
+
+    from neurodock_mcp_cognitive_graph.clock import FixedClock
+    from neurodock_mcp_cognitive_graph.tools import recall_entity as recall_entity_tool
+    from neurodock_mcp_cognitive_graph.tools import record_fact as record_fact_tool
+
+    connections = InMemoryByosConnectionStore()
+    alice = UserKey(sub="alice")
+    db_path = tmp_path / "alice.db"
+    connections.put(alice, f"file:{db_path}")
+    resolver = ByosResolver(connections)
+    clock = FixedClock(datetime(2026, 5, 31, 12, 0, tzinfo=UTC))
+
+    # Act — write a fact through Alice's resolved store, then read it back.
+    store = resolver.graph_store(alice)
+    store.initialise()
+    try:
+        record_fact_tool(
+            store,
+            clock,
+            subject={"type": "person", "name": "Dana"},
+            predicate="tagged",
+            object={"literal": "engineer"},
+        )
+        result = recall_entity_tool(store, "Dana")
+    finally:
+        store.close()
+
+    # Assert — the fact persisted to the user's own database.
+    assert result.entity is not None
+    assert result.entity.name == "Dana"
+
+
+@_needs_libsql
+def test_two_users_get_isolated_databases(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Arrange — two users, two distinct local libSQL files.
+    from datetime import UTC, datetime
+
+    from neurodock_mcp_cognitive_graph.clock import FixedClock
+    from neurodock_mcp_cognitive_graph.tools import recall_entity as recall_entity_tool
+    from neurodock_mcp_cognitive_graph.tools import record_fact as record_fact_tool
+
+    connections = InMemoryByosConnectionStore()
+    alice = UserKey(sub="alice")
+    bob = UserKey(sub="bob")
+    connections.put(alice, f"file:{tmp_path / 'alice.db'}")
+    connections.put(bob, f"file:{tmp_path / 'bob.db'}")
+    resolver = ByosResolver(connections)
+    clock = FixedClock(datetime(2026, 5, 31, 12, 0, tzinfo=UTC))
+
+    # Act — Alice records a fact; Bob's database stays empty.
+    alice_store = resolver.graph_store(alice)
+    alice_store.initialise()
+    bob_store = resolver.graph_store(bob)
+    bob_store.initialise()
+    try:
+        record_fact_tool(
+            alice_store,
+            clock,
+            subject={"type": "person", "name": "Dana"},
+            predicate="tagged",
+            object={"literal": "engineer"},
+        )
+        bob_result = recall_entity_tool(bob_store, "Dana")
+    finally:
+        alice_store.close()
+        bob_store.close()
+
+    # Assert — cross-tenant isolation: Bob cannot see Alice's entity.
+    assert bob_result.entity is None

--- a/packages/mcp-state/tests/test_clerk_byos_store.py
+++ b/packages/mcp-state/tests/test_clerk_byos_store.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the Clerk-metadata BYOS store (ADR 0010 Phase D).
+
+NO real Clerk and NO network: the Clerk Backend client is replaced with a fake
+in-memory stand-in so we can prove the store's *own* logic — token encryption at
+rest, the private_metadata shape, get/put/delete round-trips, and config
+validation — without any external dependency. The encryption itself uses the
+real ``cryptography`` Fernet path so the at-rest guarantee is genuinely tested.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from neurodock_state.clerk_byos_store import (
+    ByosStoreConfigError,
+    ClerkMetadataByosStore,
+)
+from neurodock_state.identity import UserKey
+
+_ENV = {
+    "NEURODOCK_CLERK_SECRET_KEY": "sk_test_fake",
+    "NEURODOCK_STATE_MASTER_KEY": "a-strong-master-key-for-tests",
+}
+
+
+class _FakeUsers:
+    """Minimal stand-in for ``clerk.users`` backed by an in-memory dict."""
+
+    def __init__(self) -> None:
+        # user_id -> private_metadata dict
+        self.metadata: dict[str, dict[str, Any]] = {}
+
+    def get(self, *, user_id: str) -> Any:
+        record = self.metadata.get(user_id, {})
+        return type("ClerkUser", (), {"private_metadata": dict(record)})()
+
+    def update_metadata(self, *, user_id: str, private_metadata: dict[str, Any]) -> None:
+        # Mirror Clerk's merge semantics: keys with a None value are dropped.
+        current = self.metadata.setdefault(user_id, {})
+        for key, value in private_metadata.items():
+            if value is None:
+                current.pop(key, None)
+            else:
+                current[key] = value
+
+
+class _FakeClerk:
+    def __init__(self) -> None:
+        self.users = _FakeUsers()
+
+
+def _store_with_fake(env: dict[str, str]) -> tuple[ClerkMetadataByosStore, _FakeClerk]:
+    """Build a store with the fake Clerk client injected (no SDK / network)."""
+    impl = ClerkMetadataByosStore(env)
+    fake = _FakeClerk()
+    impl._client = fake
+    return impl, fake
+
+
+@pytest.fixture
+def store() -> ClerkMetadataByosStore:
+    impl, _ = _store_with_fake(_ENV)
+    return impl
+
+
+def test_requires_clerk_secret_key() -> None:
+    with pytest.raises(ByosStoreConfigError):
+        ClerkMetadataByosStore({"NEURODOCK_STATE_MASTER_KEY": "k"})
+
+
+def test_requires_master_key() -> None:
+    with pytest.raises(ByosStoreConfigError):
+        ClerkMetadataByosStore({"NEURODOCK_CLERK_SECRET_KEY": "sk"})
+
+
+def test_get_returns_none_when_no_connection(store: ClerkMetadataByosStore) -> None:
+    assert store.get(UserKey(sub="user_alice")) is None
+
+
+def test_put_then_get_round_trips(store: ClerkMetadataByosStore) -> None:
+    # Arrange
+    alice = UserKey(sub="user_alice")
+
+    # Act
+    store.put(alice, "libsql://alice.turso.io", auth_token="super-secret")
+    connection = store.get(alice)
+
+    # Assert — the token survives the encrypt-at-rest / decrypt-on-read trip.
+    assert connection is not None
+    assert connection.url == "libsql://alice.turso.io"
+    assert connection.auth_token == "super-secret"
+
+
+def test_token_is_encrypted_at_rest() -> None:
+    # Arrange — hold the fake directly so we can inspect what was written.
+    impl, fake = _store_with_fake(_ENV)
+    alice = UserKey(sub="user_alice")
+    impl.put(alice, "libsql://alice.turso.io", auth_token="super-secret")
+
+    # Assert — the plaintext token never appears in what was written to Clerk.
+    raw = fake.users.metadata["user_alice"]["neurodock_byos"]
+    assert raw["auth_token"] != "super-secret"
+    assert "super-secret" not in str(raw)
+
+
+def test_put_without_token_stores_no_token(store: ClerkMetadataByosStore) -> None:
+    alice = UserKey(sub="user_alice")
+    store.put(alice, "file:/tmp/alice.db")
+    connection = store.get(alice)
+    assert connection is not None
+    assert connection.auth_token is None
+
+
+def test_delete_clears_the_connection(store: ClerkMetadataByosStore) -> None:
+    alice = UserKey(sub="user_alice")
+    store.put(alice, "libsql://alice.turso.io", auth_token="t")
+    store.delete(alice)
+    assert store.get(alice) is None
+
+
+def test_wrong_master_key_cannot_decrypt() -> None:
+    # Arrange — write with one master key.
+    writer, fake = _store_with_fake(_ENV)
+    writer.put(UserKey(sub="user_alice"), "libsql://x", auth_token="t")
+
+    # A reader with a DIFFERENT master key sees the same metadata but cannot read.
+    reader = ClerkMetadataByosStore(
+        {**_ENV, "NEURODOCK_STATE_MASTER_KEY": "a-completely-different-key"}
+    )
+    reader._client = fake
+
+    # Act / Assert — decryption fails loudly rather than returning garbage.
+    from neurodock_state.clerk_byos_store import ByosStoreBackendError
+
+    with pytest.raises(ByosStoreBackendError):
+        reader.get(UserKey(sub="user_alice"))

--- a/packages/remote/Dockerfile
+++ b/packages/remote/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1
-# NeuroDock remote MCP server — the combined STATELESS tool surface (ADR 0008/0009).
+# NeuroDock remote MCP server — the stateless tool surface (ADR 0008/0009) plus the
+# opt-in BYOS memory surface (ADR 0010 Phase D). Anonymous/non-opted-in sessions stay
+# fully stateless; opted-in users' data lives in their OWN database, not on NeuroDock.
 #
 # Build from the REPO ROOT (the workspace graph must be visible):
 #   docker build -f packages/remote/Dockerfile -t neurodock-remote .
@@ -22,16 +24,24 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
 COPY packages/ ./packages/
 
-# Install ONLY neurodock-remote and its (stateless) workspace dependencies. The
-# stateful servers (cognitive-graph, chronometric) and their heavy native deps are
-# not dependencies of neurodock-remote and are therefore never installed.
+# Install neurodock-remote and its workspace dependencies. As of ADR 0010 Phase D
+# this includes neurodock-state[clerk] and neurodock-mcp-cognitive-graph[libsql]
+# (the opt-in BYOS surface). The chronometric server and task-fractionator
+# `next_one` remain stdio-only and are NOT installed. The cognitive-graph's heavy
+# fastembed dependency is never *loaded* at runtime because embeddings are
+# disabled below — the import is short-circuited by NEURODOCK_GRAPH_DISABLE_EMBEDDINGS.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --package neurodock-remote
 
 # Bind all interfaces (the container sits behind the edge/proxy). This is an
 # explicit deployment decision; the application code defaults to 127.0.0.1.
+#
+# NEURODOCK_GRAPH_DISABLE_EMBEDDINGS=1 keeps the hosted cognitive-graph lean: the
+# embedding rung is skipped and fastembed is never imported, so no model is
+# downloaded into the image or at runtime (ADR 0010 Phase D scope decision).
 ENV NEURODOCK_HTTP_HOST=0.0.0.0 \
-    NEURODOCK_HTTP_PORT=8000
+    NEURODOCK_HTTP_PORT=8000 \
+    NEURODOCK_GRAPH_DISABLE_EMBEDDINGS=1
 
 # Run as a non-root user.
 RUN useradd --create-home --uid 10001 neurodock \

--- a/packages/remote/README.md
+++ b/packages/remote/README.md
@@ -46,6 +46,9 @@ Inspect it with the MCP Inspector pointed at `http://127.0.0.1:8000/mcp`.
 | `NEURODOCK_CLERK_DOMAIN`                             | —           | `clerk`: your Clerk instance domain (e.g. `your-app.clerk.accounts.dev`).               |
 | `NEURODOCK_CLERK_CLIENT_ID`                          | —           | `clerk`: OAuth application client ID.                                                   |
 | `NEURODOCK_CLERK_CLIENT_SECRET`                      | —           | `clerk`: OAuth client secret (set as a secret, not plaintext).                          |
+| `NEURODOCK_CLERK_SECRET_KEY`                         | —           | BYOS (ADR 0010 D): Clerk Backend API key; persists the per-user connection pointer.     |
+| `NEURODOCK_STATE_MASTER_KEY`                         | —           | BYOS (ADR 0010 D): master key that encrypts the BYOS auth token at rest.                |
+| `NEURODOCK_GRAPH_DISABLE_EMBEDDINGS`                 | `1` (image) | BYOS: keeps the hosted graph lean (no fastembed). Set in the Dockerfile.                |
 | `NEURODOCK_AUTHKIT_DOMAIN`                           | —           | `workos`: your AuthKit domain.                                                          |
 | `NEURODOCK_OAUTH_ISSUER` / `_JWKS_URI` / `_AUDIENCE` | —           | `jwt`: generic OIDC resource-server config.                                             |
 
@@ -87,6 +90,10 @@ fronted by a thin Worker ([worker/index.ts](worker/index.ts)) that owns the
    ```bash
    npm install
    npx wrangler secret put NEURODOCK_CLERK_CLIENT_SECRET   # paste the secret
+   # Optional — enable the opt-in BYOS memory tools (ADR 0010 Phase D). Without
+   # these two the tools stay visible but un-backed (sign-in/connect refusal):
+   npx wrangler secret put NEURODOCK_CLERK_SECRET_KEY      # Clerk Backend API key
+   npx wrangler secret put NEURODOCK_STATE_MASTER_KEY      # token-encryption master key
    npx wrangler deploy                                     # builds ../Dockerfile, pushes, deploys
    ```
 

--- a/packages/remote/pyproject.toml
+++ b/packages/remote/pyproject.toml
@@ -17,6 +17,14 @@ dependencies = [
     "neurodock-mcp-translation",
     "neurodock-mcp-guardrail",
     "neurodock-mcp-task-fractionator",
+    # ADR 0010 Phase D — opt-in BYOS storage. The per-user state foundation (with
+    # the `clerk` extra: Clerk Backend SDK + cryptography for the encrypted
+    # connection pointer) and the cognitive-graph tools (with the libSQL backing
+    # for the user's own DB). Embeddings are disabled on the hosted path
+    # (NEURODOCK_GRAPH_DISABLE_EMBEDDINGS), so the heavy fastembed model is never
+    # loaded despite being a transitive dep.
+    "neurodock-state[clerk]",
+    "neurodock-mcp-cognitive-graph[libsql]",
 ]
 
 [project.urls]
@@ -45,6 +53,8 @@ packages = ["src/neurodock_remote"]
 neurodock-mcp-translation = { workspace = true }
 neurodock-mcp-guardrail = { workspace = true }
 neurodock-mcp-task-fractionator = { workspace = true }
+neurodock-state = { workspace = true }
+neurodock-mcp-cognitive-graph = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/remote/src/neurodock_remote/app.py
+++ b/packages/remote/src/neurodock_remote/app.py
@@ -1,23 +1,34 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 NeuroDock contributors.
-"""Combined remote MCP server (ADR 0008/0009, Phase 2).
+"""Combined remote MCP server (ADR 0008/0009 + ADR 0010 Phase D).
 
 Composes the three STATELESS NeuroDock servers into a single Streamable HTTP
-endpoint that exposes ONLY the remote-safe tool surface:
+endpoint, and (ADR 0010 Phase D) adds the OPT-IN BYOS surface:
 
     translation        : translate_incoming, check_tone, rewrite_outgoing, brief_meeting
     guardrail          : check_rumination, check_hyperfocus, check_sycophancy
     task-fractionator  : decompose            (next_one is stdio/local only)
+    storage-admin      : connect_byos_storage, disconnect_storage, storage_status
+    cognitive-graph    : recall_entity, record_fact, recall_decisions, weekly_rollup
 
-The cognitive graph, chronometric session state, the profile, and
-task-fractionator ``next_one`` are NEVER mounted here — they read or hold local
-state and must stay on stdio. The boundary is enforced in code (each sub-server is
-built in its remote-safe configuration) and pinned by tests against
-:data:`REMOTE_TOOL_NAMES`.
+The stateless surface (:data:`STATELESS_TOOL_NAMES`) is ALWAYS present and
+unchanged. The opt-in surface (:data:`OPT_IN_TOOL_NAMES`) is *visible* to every
+client, but every cognitive-graph call routes through the per-user BYOS seam:
 
-Vendor-neutrality (ADR 0005) is preserved: the composed tools still return
-deterministic baselines plus structured LLM-refinement prompts; no LLM SDK runs in
-the server.
+- an anonymous / no-token caller gets ``STORAGE_NOT_AVAILABLE`` and nothing is
+  stored or read;
+- a signed-in but not-connected caller gets ``STORAGE_NOT_CONNECTED``;
+- a connected caller's data lives in THEIR OWN libSQL/Turso database — NeuroDock
+  persists nothing beyond the connection pointer.
+
+This privacy boundary is the point of the phase: anonymous and non-opted-in
+sessions remain completely stateless. ``next_one``, chronometric session state,
+and the profile stay stdio/local only and are deferred (a tracked follow-up).
+
+Vendor-neutrality (ADR 0005) is preserved: composed tools return deterministic
+baselines plus structured LLM-refinement prompts; no LLM SDK runs in the server.
+Embeddings are disabled on the hosted path (``NEURODOCK_GRAPH_DISABLE_EMBEDDINGS``)
+so the image stays lean.
 """
 
 from __future__ import annotations
@@ -39,15 +50,18 @@ from starlette.responses import JSONResponse
 
 from neurodock_remote.auth import build_auth_provider
 from neurodock_remote.prompts import register_prompts
+from neurodock_remote.state import ByosState, build_connection_store
+from neurodock_remote.tools.graph import register_graph_tools
+from neurodock_remote.tools.storage_admin import register_storage_admin_tools
 from neurodock_remote.transport import resolve_bind
 
 SERVER_NAME = "neurodock-remote"
 SERVER_VERSION = "0.1.0"
 MCP_PATH = "/mcp"
 
-# The remote-safe tool surface (ADR 0008/0009). Pinned by tests: any drift — a new
-# tool slipping in, or a stateful tool leaking out — fails CI.
-REMOTE_TOOL_NAMES = frozenset(
+# The stateless tool surface (ADR 0008/0009). ALWAYS present and unchanged; any
+# drift — a new tool slipping in, or a stateful tool leaking out — fails CI.
+STATELESS_TOOL_NAMES = frozenset(
     {
         # translation (fully stateless)
         "translate_incoming",
@@ -63,22 +77,53 @@ REMOTE_TOOL_NAMES = frozenset(
     }
 )
 
+# The opt-in BYOS surface (ADR 0010 Phase D). These tools are visible to every
+# client, but storing/reading anything requires a signed-in account + connected
+# storage; the privacy boundary is enforced in the store-provider seam.
+OPT_IN_TOOL_NAMES = frozenset(
+    {
+        # storage-admin (hosted-only)
+        "connect_byos_storage",
+        "disconnect_storage",
+        "storage_status",
+        # cognitive-graph (routed to the caller's own BYOS database)
+        "recall_entity",
+        "record_fact",
+        "recall_decisions",
+        "weekly_rollup",
+    }
+)
+
+# The full advertised surface. Pinned by tests against the live listing.
+REMOTE_TOOL_NAMES = STATELESS_TOOL_NAMES | OPT_IN_TOOL_NAMES
+
 _INSTRUCTIONS = (
-    "NeuroDock remote tools: the stateless communication and planning surface. "
-    "Translation decodes incoming messages and shapes outgoing ones; guardrail "
-    "flags rumination, hyperfocus, and over-validation; decompose breaks a vague "
-    "goal into atomic tasks. Personal memory, session timing, and the user profile "
-    "are intentionally NOT available here — they live on the local install."
+    "NeuroDock remote tools. The stateless surface — translation decodes incoming "
+    "messages and shapes outgoing ones; guardrail flags rumination, hyperfocus, and "
+    "over-validation; decompose breaks a vague goal into atomic tasks — needs no "
+    "account. The opt-in memory surface (recall_entity, record_fact, "
+    "recall_decisions, weekly_rollup) requires a signed-in account that has "
+    "connected its OWN database via connect_byos_storage: your graph data lives in "
+    "your database, never on NeuroDock. Anonymous sessions are fully stateless. "
+    "Session timing and the user profile are NOT available here — they live on the "
+    "local install."
 )
 
 _LOG = logging.getLogger("neurodock_remote.app")
 
 
-def build_combined_server() -> FastMCP[Any]:
-    """Compose the three stateless servers into one remote MCP surface.
+def build_combined_server(connections: Any | None = None) -> FastMCP[Any]:
+    """Compose the stateless servers + opt-in BYOS surface into one MCP server.
 
     ``mount`` (no namespace) keeps the original flat tool names, so the combined
     endpoint presents the same tool names the local servers do.
+
+    ``connections`` is the per-user BYOS connection store
+    (:class:`~neurodock_state.byos_connection_store.ByosConnectionStore`). Tests
+    inject an in-memory store; in production it is built from the environment
+    (Clerk-metadata-backed). When ``None`` and no secrets are configured, the
+    opt-in tools are still registered but every storage operation returns the
+    structured "sign in / connect storage" refusal — nothing is ever stored.
     """
     combined: FastMCP[Any] = FastMCP(
         name=SERVER_NAME,
@@ -96,6 +141,28 @@ def build_combined_server() -> FastMCP[Any]:
     # Skill-style MCP prompts (ADR 0010, Phase A) — stateless entry points that
     # guide the model to the matching hosted tool. No personal data.
     register_prompts(combined)
+
+    # Opt-in BYOS surface (ADR 0010 Phase D). The connection store may be missing
+    # (no secrets configured); the ByosState still answers every call with the
+    # structured refusal, so the privacy boundary holds with or without a backing.
+    resolved_connections = (
+        connections if connections is not None else build_connection_store(os.environ)
+    )
+    if resolved_connections is None:
+        from neurodock_state.byos_connection_store import InMemoryByosConnectionStore
+
+        # An ephemeral, never-persisted store. Without auth configured no caller
+        # can ever populate it (require_user() refuses anonymous callers first),
+        # so this stays empty in practice; it exists only so the tools register.
+        resolved_connections = InMemoryByosConnectionStore()
+        _LOG.warning(
+            "byos_storage_unbacked: no NEURODOCK_CLERK_SECRET_KEY/"
+            "NEURODOCK_STATE_MASTER_KEY — opt-in tools are visible but cannot "
+            "persist; every call returns the sign-in/connect refusal (ADR 0010 §4)"
+        )
+    state = ByosState(resolved_connections)
+    register_storage_admin_tools(combined, state)
+    register_graph_tools(combined, state)
 
     @combined.custom_route("/health", methods=["GET"])
     async def health_check(request: Request) -> JSONResponse:

--- a/packages/remote/src/neurodock_remote/state.py
+++ b/packages/remote/src/neurodock_remote/state.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Per-user BYOS state wiring for the hosted server (ADR 0010 Phase D).
+
+This module is the bridge between the stateless remote transport and the opt-in
+BYOS storage. It owns three concerns:
+
+1. **Construction** of the connection store + resolver from the environment.
+   On the hosted path the connection store is the Clerk-metadata-backed store;
+   tests inject :class:`InMemoryByosConnectionStore` directly.
+2. **The structured errors** returned to anonymous and non-opted-in callers. The
+   security boundary lives here: these responses are produced WITHOUT touching
+   any store, so a session that has not opted in stores — and reads — nothing.
+3. **The store provider** handed to the cognitive-graph ``build_app`` seam. It
+   resolves the *caller's own* libSQL store at call time, or raises a structured
+   refusal that the tool layer surfaces verbatim.
+
+Error codes (stable; clients may branch on them):
+
+- ``STORAGE_NOT_AVAILABLE`` — no authenticated NeuroDock user. The tool needs an
+  account + connected storage.
+- ``STORAGE_NOT_CONNECTED`` — authenticated, but no BYOS database connected yet.
+  The caller should run ``connect_byos_storage`` first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from neurodock_state.byos_resolver import ByosResolver
+from neurodock_state.identity import UserKey, user_key_from_context
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from neurodock_state.byos_connection_store import ByosConnectionStore
+    from neurodock_state.registry import GraphStore
+
+# -- structured refusals --------------------------------------------------
+
+STORAGE_NOT_AVAILABLE = "STORAGE_NOT_AVAILABLE"
+STORAGE_NOT_CONNECTED = "STORAGE_NOT_CONNECTED"
+
+_NOT_AVAILABLE_MESSAGE = (
+    "This tool needs a NeuroDock account and connected storage. "
+    "Sign in to the hosted server, then connect your own database with "
+    "connect_byos_storage. NeuroDock stores nothing for anonymous sessions."
+)
+_NOT_CONNECTED_MESSAGE = (
+    "You are signed in but have not connected a storage database yet. "
+    "Call connect_byos_storage with your libSQL/Turso URL (and auth token) to "
+    "enable this tool. Your graph data lives in your database, never on NeuroDock."
+)
+
+
+class StorageUnavailableError(Exception):
+    """The caller has no NeuroDock account: the stateful tools are not available.
+
+    Carries a stable ``code`` and a caller-facing ``message``. The tool layer
+    converts this into a structured payload — it is never a crash, matching the
+    project's never-block-silently norm.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+    def to_payload(self) -> dict[str, str]:
+        return {"error": self.code, "message": self.message}
+
+
+@dataclass(frozen=True)
+class StorageStatus:
+    """A read-only view of the caller's storage posture."""
+
+    authenticated: bool
+    mode: str  # "byos" | "none"
+    connected: bool
+
+
+# -- the BYOS state container --------------------------------------------
+
+
+class ByosState:
+    """Resolves the caller's BYOS backing and enforces the privacy boundary.
+
+    Holds the connection store and a :class:`ByosResolver` over it. Every method
+    derives the caller from the FastMCP request context (the validated token),
+    so identity can never be spoofed by a tool argument.
+    """
+
+    def __init__(self, connections: ByosConnectionStore) -> None:
+        self._connections = connections
+        self._resolver = ByosResolver(connections)
+
+    @property
+    def connections(self) -> ByosConnectionStore:
+        return self._connections
+
+    def require_user(self) -> UserKey:
+        """Return the authenticated caller, or raise :class:`StorageUnavailableError`.
+
+        This is the single choke point for "is there a NeuroDock account?". It
+        reads the validated access token from the request context and never
+        touches a store, so an anonymous caller is refused before any state is
+        consulted.
+        """
+        user = user_key_from_context()
+        if user is None:
+            raise StorageUnavailableError(STORAGE_NOT_AVAILABLE, _NOT_AVAILABLE_MESSAGE)
+        return user
+
+    def status(self) -> StorageStatus:
+        """Report the caller's storage posture without mutating anything."""
+        user = user_key_from_context()
+        if user is None:
+            return StorageStatus(authenticated=False, mode="none", connected=False)
+        mode = self._resolver.storage_mode(user)
+        return StorageStatus(authenticated=True, mode=mode, connected=mode == "byos")
+
+    def graph_store(self) -> GraphStore:
+        """Resolve the caller's own cognitive-graph store, or raise a refusal.
+
+        The provider semantics ADR 0010 Phase D requires:
+
+        - no authenticated user → :class:`StorageUnavailableError`
+          (``STORAGE_NOT_AVAILABLE``), WITHOUT touching any store;
+        - authenticated but not connected → :class:`StorageUnavailableError`
+          (``STORAGE_NOT_CONNECTED``);
+        - otherwise → the user's libSQL store, freshly resolved and initialised.
+        """
+        user = self.require_user()
+        if self._resolver.storage_mode(user) == "none":
+            raise StorageUnavailableError(STORAGE_NOT_CONNECTED, _NOT_CONNECTED_MESSAGE)
+        store = self._resolver.graph_store(user)
+        # Initialise (idempotent migrations) so the first call against a freshly
+        # connected DB just works. Cheap on an already-migrated database.
+        store.initialise()
+        return store
+
+
+def build_connection_store(env: Mapping[str, str]) -> ByosConnectionStore | None:
+    """Build the production connection store from the environment, or ``None``.
+
+    Returns the Clerk-metadata-backed store when its required secrets are
+    present; returns ``None`` (BYOS disabled) when they are not, so a bare local
+    run without secrets simply does not offer storage rather than crashing. The
+    Clerk SDK and crypto are imported lazily inside the store.
+    """
+    has_clerk_secret = bool(env.get("NEURODOCK_CLERK_SECRET_KEY", "").strip())
+    has_master_key = bool(env.get("NEURODOCK_STATE_MASTER_KEY", "").strip())
+    if not (has_clerk_secret and has_master_key):
+        return None
+    from neurodock_state.clerk_byos_store import ClerkMetadataByosStore
+
+    # ClerkMetadataByosStore structurally satisfies ByosConnectionStore; mypy
+    # verifies the protocol conformance on this annotated assignment.
+    store: ByosConnectionStore = ClerkMetadataByosStore(env)
+    return store

--- a/packages/remote/src/neurodock_remote/tools/__init__.py
+++ b/packages/remote/src/neurodock_remote/tools/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Remote-server-owned tools (ADR 0010 Phase D).
+
+These tools exist only on the hosted endpoint and have no local-stdio analogue:
+the storage-admin tools (connect/disconnect/status) and the un-gated
+cognitive-graph tools that route to the caller's own BYOS database.
+"""

--- a/packages/remote/src/neurodock_remote/tools/graph.py
+++ b/packages/remote/src/neurodock_remote/tools/graph.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Un-gated cognitive-graph tools for the hosted server (ADR 0010 Phase D).
+
+The four cognitive-graph tools (``recall_entity``, ``record_fact``,
+``recall_decisions``, ``weekly_rollup``) are exposed on the hosted endpoint for
+opted-in BYOS users. Each call routes to the **caller's own** libSQL database via
+:meth:`ByosState.graph_store`; anonymous and non-opted-in callers get a
+structured refusal and nothing is stored or read.
+
+Why re-wire instead of mounting ``build_app``?
+----------------------------------------------
+``build_app`` (the ADR 0010 Phase B seam) returns a low-level
+``mcp.server.fastmcp.FastMCP`` server, whereas the combined remote server is a
+FastMCP 3.x ``fastmcp.FastMCP``. FastMCP 3.x's ``mount``/``import_server`` only
+accept a 3.x server, and the proxy path runs tool handlers in a *separate*
+session context — where ``user_key_from_context()`` cannot see the combined
+server's validated access token. The privacy boundary depends on the
+store-provider closure executing in the request context that holds the token, so
+we register the tools directly on the combined server and feed them the SAME
+store-provider seam ``build_app`` would. The provider — :meth:`ByosState.graph_store`
+— is resolved per call, exactly as ADR 0010 Phase B specifies.
+
+Error handling mirrors ``build_app``'s server layer (ToolError → payload,
+unexpected → InternalToolError) and adds the storage-boundary refusals from
+:mod:`neurodock_remote.state`, so callers never see a traceback.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from neurodock_mcp_cognitive_graph.clock import SystemClock
+from neurodock_mcp_cognitive_graph.errors import InternalToolError, ToolError
+from neurodock_mcp_cognitive_graph.tools import (
+    recall_decisions as recall_decisions_tool,
+)
+from neurodock_mcp_cognitive_graph.tools import (
+    recall_entity as recall_entity_tool,
+)
+from neurodock_mcp_cognitive_graph.tools import (
+    record_fact as record_fact_tool,
+)
+from neurodock_mcp_cognitive_graph.tools import (
+    weekly_rollup as weekly_rollup_tool,
+)
+
+from neurodock_remote.state import ByosState, StorageUnavailableError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from fastmcp import FastMCP
+
+_LOG = logging.getLogger("neurodock_remote.tools.graph")
+
+
+def _serialise(model: Any) -> dict[str, Any]:
+    """Pydantic v2 model → JSON-safe dict (mirrors the cognitive-graph server)."""
+    parsed: dict[str, Any] = json.loads(model.model_dump_json())
+    return parsed
+
+
+def _payload(value: Any) -> dict[str, Any]:
+    """Coerce an (untyped) cognitive-graph error payload to a typed dict.
+
+    The cognitive-graph package ships without ``py.typed``, so its
+    ``ToolError.to_payload()`` is seen as returning ``Any`` here. This keeps the
+    tool functions' declared ``dict[str, Any]`` return honest under strict mypy.
+    """
+    return cast("dict[str, Any]", value)
+
+
+def register_graph_tools(mcp: FastMCP[Any], state: ByosState) -> None:
+    """Register the four BYOS-gated cognitive-graph tools on the combined server.
+
+    ``state`` is the per-user storage seam: each tool resolves the caller's own
+    store via ``state.graph_store()`` at call time. The first thing every tool
+    does is resolve that store; a refusal (anonymous / not-connected) short-circuits
+    BEFORE any tool logic runs, so nothing is stored or read for those callers.
+    """
+    clock = SystemClock()
+
+    @mcp.tool(
+        name="recall_entity",
+        description=(
+            "Look up everything your connected cognitive graph knows about a named "
+            "person, project, decision, or concept. Alias-resolves the input. "
+            "Requires a signed-in account with connected storage (connect_byos_storage)."
+        ),
+    )
+    def recall_entity(name_or_alias: str) -> dict[str, Any]:
+        try:
+            storage = state.graph_store()
+        except StorageUnavailableError as exc:
+            return exc.to_payload()
+        try:
+            try:
+                result = recall_entity_tool(storage, name_or_alias)
+            except ToolError as exc:
+                _LOG.warning("recall_entity error code=%s", exc.code)
+                return _payload(exc.to_payload())
+            return _serialise(result)
+        finally:
+            storage.close()
+
+    @mcp.tool(
+        name="record_fact",
+        description=(
+            "Persist a typed-edge (subject, predicate, object) fact into your "
+            "connected cognitive graph. Entities referenced by name are auto-created. "
+            "Requires a signed-in account with connected storage (connect_byos_storage)."
+        ),
+    )
+    def record_fact(
+        subject: Any,
+        predicate: Any,
+        object: Any,
+        source: str | None = None,
+        confidence: float | None = None,
+    ) -> dict[str, Any]:
+        # subject/predicate/object are intentionally Any (see the cognitive-graph
+        # server's note) so wrong-shape input gets a friendly error, not a raw
+        # Pydantic validation failure.
+        try:
+            storage = state.graph_store()
+        except StorageUnavailableError as exc:
+            return exc.to_payload()
+        try:
+            try:
+                result = record_fact_tool(
+                    storage,
+                    clock,
+                    subject=subject,
+                    predicate=predicate,
+                    object=object,
+                    source=source,
+                    confidence=confidence,
+                )
+            except ToolError as exc:
+                _LOG.warning("record_fact error code=%s", exc.code)
+                return _payload(exc.to_payload())
+            except Exception as exc:  # mirror build_app's internal-error path
+                _LOG.exception("record_fact unexpected internal error")
+                return _payload(InternalToolError(str(exc)).to_payload())
+            return _serialise(result)
+        finally:
+            storage.close()
+
+    @mcp.tool(
+        name="recall_decisions",
+        description=(
+            "Return decisions recorded against a named project in your connected "
+            "cognitive graph, newest first, optionally filtered by an ISO 8601 "
+            "since-date. Requires a signed-in account with connected storage."
+        ),
+    )
+    def recall_decisions(project: str, since: str | None = None) -> dict[str, Any]:
+        try:
+            storage = state.graph_store()
+        except StorageUnavailableError as exc:
+            return exc.to_payload()
+        try:
+            try:
+                result = recall_decisions_tool(storage, project, since)
+            except ToolError as exc:
+                _LOG.warning("recall_decisions error code=%s", exc.code)
+                return _payload(exc.to_payload())
+            return _serialise(result)
+        finally:
+            storage.close()
+
+    @mcp.tool(
+        name="weekly_rollup",
+        description=(
+            "Return a server-generated activity summary of your connected cognitive "
+            "graph for the trailing seven local days, optionally scoped to a project. "
+            "Requires a signed-in account with connected storage."
+        ),
+    )
+    def weekly_rollup(project: str | None = None) -> dict[str, Any]:
+        try:
+            storage = state.graph_store()
+        except StorageUnavailableError as exc:
+            return exc.to_payload()
+        try:
+            try:
+                result = weekly_rollup_tool(storage, clock, project)
+            except ToolError as exc:
+                _LOG.warning("weekly_rollup error code=%s", exc.code)
+                return _payload(exc.to_payload())
+            return _serialise(result)
+        finally:
+            storage.close()

--- a/packages/remote/src/neurodock_remote/tools/storage_admin.py
+++ b/packages/remote/src/neurodock_remote/tools/storage_admin.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Storage-admin tools for the hosted server (ADR 0010 Phase D).
+
+Three tools let an authenticated user manage their own BYOS connection:
+
+- ``connect_byos_storage(libsql_url, auth_token=None)`` — validate the URL,
+  smoke-test a connect+migrate against it, then persist the connection. Only a
+  database that actually accepts the schema is ever stored, so a user can never
+  end up with a "connected" pointer to a broken endpoint.
+- ``disconnect_storage()`` — delete the stored connection. NeuroDock then
+  retains nothing about the user's storage.
+- ``storage_status()`` — report the caller's mode and whether they are connected.
+
+All three require an authenticated user. An anonymous caller receives the
+structured ``STORAGE_NOT_AVAILABLE`` refusal and nothing is stored or read.
+
+URL validation
+--------------
+Only ``libsql://``, ``https://``, and ``file:`` URLs are accepted. ``file:`` is
+allowed for self-hosted / embedded single-user deployments and for tests; the
+hosted multi-tenant deployment will in practice receive ``libsql://`` Turso URLs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from neurodock_remote.state import ByosState, StorageUnavailableError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from fastmcp import FastMCP
+
+_LOG = logging.getLogger("neurodock_remote.tools.storage_admin")
+
+# Accepted libSQL connection-URL schemes. `libsql://`/`https://` are remote
+# (Turso et al.); `file:` is local/embedded. Anything else is rejected before we
+# even attempt a connection.
+_ALLOWED_SCHEMES = ("libsql://", "https://", "file:")
+
+INVALID_URL = "INVALID_STORAGE_URL"
+CONNECT_FAILED = "STORAGE_CONNECT_FAILED"
+
+
+def _validate_url(libsql_url: Any) -> str:
+    """Return a trimmed, scheme-checked URL or raise a structured error payload.
+
+    Raises:
+        StorageUnavailableError: never (auth is checked by the caller).
+    """
+    if not isinstance(libsql_url, str) or not libsql_url.strip():
+        raise _ToolInputError(
+            INVALID_URL,
+            "libsql_url is required and must be a non-empty string.",
+        )
+    url = libsql_url.strip()
+    if not url.startswith(_ALLOWED_SCHEMES):
+        raise _ToolInputError(
+            INVALID_URL,
+            "libsql_url must start with one of: "
+            f"{', '.join(_ALLOWED_SCHEMES)} (got {url.split(':', 1)[0]!r}).",
+        )
+    return url
+
+
+class _ToolInputError(Exception):
+    """Bad tool input. Converted to a structured payload by the tool wrapper."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+    def to_payload(self) -> dict[str, str]:
+        return {"error": self.code, "message": self.message}
+
+
+def _smoke_test_connection(url: str, auth_token: str | None) -> None:
+    """Connect to the candidate DB and apply migrations, then close it.
+
+    Proves the connection is usable BEFORE it is persisted. Raises
+    :class:`_ToolInputError` with ``STORAGE_CONNECT_FAILED`` on any failure so the
+    user gets an actionable message rather than a later mid-tool crash.
+    """
+    from neurodock_mcp_cognitive_graph.storage.libsql import LibSqlStorage
+
+    store = LibSqlStorage(url, auth_token=auth_token)
+    try:
+        store.initialise()
+    except Exception as exc:  # report any backend failure structurally
+        raise _ToolInputError(
+            CONNECT_FAILED,
+            f"could not connect to or migrate the database: {exc}",
+        ) from exc
+    finally:
+        try:
+            store.close()
+        except Exception:  # close failures must not mask the result
+            _LOG.warning("storage smoke-test close failed", exc_info=True)
+
+
+def register_storage_admin_tools(mcp: FastMCP[Any], state: ByosState) -> None:
+    """Register connect / disconnect / status on the combined server."""
+
+    @mcp.tool(
+        name="connect_byos_storage",
+        description=(
+            "Connect your own libSQL/Turso database so the NeuroDock memory tools "
+            "store data in YOUR database, not on NeuroDock. Validates the URL and "
+            "smoke-tests the connection before saving it. Requires a signed-in "
+            "NeuroDock account."
+        ),
+    )
+    def connect_byos_storage(libsql_url: str, auth_token: str | None = None) -> dict[str, Any]:
+        try:
+            user = state.require_user()
+            url = _validate_url(libsql_url)
+            token = (
+                auth_token.strip() if isinstance(auth_token, str) and auth_token.strip() else None
+            )
+            _smoke_test_connection(url, token)
+            state.connections.put(user, url, token)
+        except StorageUnavailableError as exc:
+            return exc.to_payload()
+        except _ToolInputError as exc:
+            return exc.to_payload()
+        return {
+            "status": "connected",
+            "mode": "byos",
+            "message": (
+                "Storage connected. Your memory tools now read and write your own "
+                "database. NeuroDock stores nothing beyond this connection pointer."
+            ),
+        }
+
+    @mcp.tool(
+        name="disconnect_storage",
+        description=(
+            "Disconnect your storage database. NeuroDock deletes the connection and "
+            "retains nothing about your storage. Your data stays in your own database, "
+            "untouched. Requires a signed-in NeuroDock account."
+        ),
+    )
+    def disconnect_storage() -> dict[str, Any]:
+        try:
+            user = state.require_user()
+            state.connections.delete(user)
+        except StorageUnavailableError as exc:
+            return exc.to_payload()
+        return {
+            "status": "disconnected",
+            "mode": "none",
+            "message": (
+                "Storage disconnected. NeuroDock now retains nothing about your "
+                "storage. Your data remains in your own database."
+            ),
+        }
+
+    @mcp.tool(
+        name="storage_status",
+        description=(
+            "Report whether you are signed in and whether a storage database is "
+            "connected (mode: byos or none)."
+        ),
+    )
+    def storage_status() -> dict[str, Any]:
+        status = state.status()
+        return {
+            "authenticated": status.authenticated,
+            "mode": status.mode,
+            "connected": status.connected,
+        }

--- a/packages/remote/tests/test_app.py
+++ b/packages/remote/tests/test_app.py
@@ -1,9 +1,19 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 NeuroDock contributors.
-"""Combined remote server tests (ADR 0008/0009).
+"""Combined remote server tests (ADR 0008/0009 + ADR 0010 Phase D).
 
-Pins the remote tool surface to exactly the eight remote-safe tools and asserts the
-local-only tools (next_one, cognitive-graph, chronometric) are never exposed.
+Pins TWO surfaces:
+
+- :data:`STATELESS_TOOL_NAMES` — the eight remote-safe tools, ALWAYS present and
+  unchanged (the ADR 0008/0009 boundary).
+- :data:`OPT_IN_TOOL_NAMES` — the BYOS surface (storage-admin + the four
+  cognitive-graph tools), visible in the listing.
+
+The local-only tools (next_one, chronometric) are still never exposed.
+
+Security: a separate test proves an anonymous (no-token) call to a graph tool
+returns the structured not-available response and writes NOTHING to the
+connection store. This is the privacy boundary the phase exists to protect.
 
 Synchronous (``asyncio.run``) rather than ``async def`` so they do not depend on
 pytest-asyncio auto-mode — the repo-root pytest run does not apply the per-package
@@ -14,23 +24,22 @@ from __future__ import annotations
 
 import asyncio
 
+from fastmcp import Client
 from neurodock_remote.app import (
+    OPT_IN_TOOL_NAMES,
     REMOTE_TOOL_NAMES,
+    STATELESS_TOOL_NAMES,
     build_combined_server,
     create_app,
 )
+from neurodock_state.byos_connection_store import InMemoryByosConnectionStore
 from starlette.applications import Starlette
 
 _LOCAL_ONLY_TOOLS = frozenset(
     {
         # task-fractionator (stdio only)
         "next_one",
-        # cognitive-graph
-        "recall_entity",
-        "record_fact",
-        "recall_decisions",
-        "weekly_rollup",
-        # chronometric
+        # chronometric (session timing — deferred, stdio only)
         "get_time_context",
         "mark_session_start",
         "mark_session_end",
@@ -40,17 +49,18 @@ _LOCAL_ONLY_TOOLS = frozenset(
 )
 
 
-def _combined_tool_names() -> set[str]:
-    server = build_combined_server()
+def _combined_tool_names(connections: InMemoryByosConnectionStore | None = None) -> set[str]:
+    server = build_combined_server(connections or InMemoryByosConnectionStore())
     return {tool.name for tool in asyncio.run(server.list_tools())}
 
 
-def test_combined_exposes_exactly_the_remote_safe_tools() -> None:
+def test_combined_exposes_exactly_the_remote_tool_surface() -> None:
     assert _combined_tool_names() == set(REMOTE_TOOL_NAMES)
 
 
-def test_remote_tool_names_constant_is_the_eight_stateless_tools() -> None:
-    assert REMOTE_TOOL_NAMES == {
+def test_stateless_tools_are_always_present_and_unchanged() -> None:
+    # The ADR 0008/0009 boundary: these eight, exactly, unconditionally.
+    assert STATELESS_TOOL_NAMES == {
         "translate_incoming",
         "check_tone",
         "rewrite_outgoing",
@@ -60,12 +70,74 @@ def test_remote_tool_names_constant_is_the_eight_stateless_tools() -> None:
         "check_sycophancy",
         "decompose",
     }
+    assert STATELESS_TOOL_NAMES <= _combined_tool_names()
 
 
-def test_local_only_tools_are_never_exposed() -> None:
+def test_opt_in_tools_are_present_in_the_listing() -> None:
+    # The BYOS surface is visible (clients can discover it); access is gated at
+    # call time, not by hiding the tools.
+    assert OPT_IN_TOOL_NAMES == {
+        "connect_byos_storage",
+        "disconnect_storage",
+        "storage_status",
+        "recall_entity",
+        "record_fact",
+        "recall_decisions",
+        "weekly_rollup",
+    }
+    assert OPT_IN_TOOL_NAMES <= _combined_tool_names()
+
+
+def test_remote_tool_names_is_the_union_of_the_two_surfaces() -> None:
+    assert REMOTE_TOOL_NAMES == STATELESS_TOOL_NAMES | OPT_IN_TOOL_NAMES
+    # The two surfaces are disjoint — no tool is both stateless and opt-in.
+    assert STATELESS_TOOL_NAMES & OPT_IN_TOOL_NAMES == set()
+
+
+def test_deferred_local_only_tools_are_never_exposed() -> None:
     names = _combined_tool_names()
     leaked = names & _LOCAL_ONLY_TOOLS
     assert leaked == set(), f"local-only tools leaked over the remote transport: {leaked}"
+
+
+def test_anonymous_graph_call_is_refused_and_stores_nothing() -> None:
+    # Arrange — no auth provider is configured in tests, so every caller is
+    # anonymous. The connection store starts empty.
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+
+    async def _call() -> dict[str, object]:
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "record_fact",
+                {
+                    "subject": {"type": "person", "name": "Mallory"},
+                    "predicate": "tagged",
+                    "object": {"literal": "should-not-persist"},
+                },
+            )
+            return dict(result.data)
+
+    # Act
+    payload = asyncio.run(_call())
+
+    # Assert — structured refusal, and NOTHING written to the connection store.
+    assert payload["error"] == "STORAGE_NOT_AVAILABLE"
+    assert len(connections) == 0
+
+
+def test_anonymous_storage_status_reports_unauthenticated() -> None:
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+
+    async def _call() -> dict[str, object]:
+        async with Client(server) as client:
+            result = await client.call_tool("storage_status", {})
+            return dict(result.data)
+
+    payload = asyncio.run(_call())
+    assert payload == {"authenticated": False, "mode": "none", "connected": False}
+    assert len(connections) == 0
 
 
 def test_create_app_returns_starlette_app_with_health_route() -> None:

--- a/packages/remote/tests/test_byos_tools.py
+++ b/packages/remote/tests/test_byos_tools.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""BYOS storage-admin + un-gated cognitive-graph tool tests (ADR 0010 Phase D).
+
+These exercise the privacy boundary and the BYOS round-trip end-to-end through a
+real FastMCP ``Client`` against the combined server, with:
+
+- a simulated authenticated user (we patch ``user_key_from_context`` in the state
+  module — there is NO real Clerk here), and
+- a real local ``file:`` libSQL database per user (there is NO real Turso here).
+
+Coverage:
+- authenticated but not connected → "enable storage first" (STORAGE_NOT_CONNECTED);
+- connect → record_fact → recall_entity round-trips against the user's own DB;
+- a second distinct user is isolated (cannot see the first user's data);
+- connect rejects a malformed URL scheme;
+- disconnect clears the stored connection.
+
+``asyncio.run`` (not ``async def``) for the same reason as test_app.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+from neurodock_remote import state as state_module
+from neurodock_remote.app import build_combined_server
+from neurodock_state.byos_connection_store import InMemoryByosConnectionStore
+from neurodock_state.identity import UserKey
+
+
+@contextmanager
+def _as_user(monkeypatch: pytest.MonkeyPatch, sub: str | None) -> Iterator[None]:
+    """Patch the request-context identity used by the state seam.
+
+    ``sub=None`` simulates an anonymous caller; a string simulates a signed-in
+    user with that Clerk subject. We patch the name as imported into the state
+    module (``from ... import user_key_from_context``), which is where every
+    auth decision is made.
+    """
+    user = UserKey(sub=sub) if sub is not None else None
+    monkeypatch.setattr(state_module, "user_key_from_context", lambda: user)
+    yield
+
+
+def _call(server: FastMCP[Any], tool: str, args: dict[str, Any]) -> dict[str, Any]:
+    async def _run() -> dict[str, Any]:
+        async with Client(server) as client:
+            result = await client.call_tool(tool, args)
+            return dict(result.data)
+
+    return asyncio.run(_run())
+
+
+# -- not connected --------------------------------------------------------
+
+
+def test_authenticated_but_not_connected_is_told_to_enable_storage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange — signed in, but no connection on file.
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+
+    # Act / Assert
+    with _as_user(monkeypatch, "user_alice"):
+        payload = _call(server, "recall_entity", {"name_or_alias": "Dana"})
+    assert payload["error"] == "STORAGE_NOT_CONNECTED"
+
+
+def test_storage_status_authenticated_not_connected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+    with _as_user(monkeypatch, "user_alice"):
+        payload = _call(server, "storage_status", {})
+    assert payload == {"authenticated": True, "mode": "none", "connected": False}
+
+
+# -- connect / round-trip / isolation ------------------------------------
+
+
+def test_connect_then_round_trip_against_the_users_own_db(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Arrange — a local libSQL file stands in for Alice's own database.
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+    alice_db = f"file:{tmp_path / 'alice.db'}"
+
+    with _as_user(monkeypatch, "user_alice"):
+        # Connect (smoke-tests + persists).
+        connected = _call(server, "connect_byos_storage", {"libsql_url": alice_db})
+        assert connected["status"] == "connected"
+        assert connected["mode"] == "byos"
+
+        # Status now reflects the connection.
+        status = _call(server, "storage_status", {})
+        assert status == {"authenticated": True, "mode": "byos", "connected": True}
+
+        # Write a fact, then read it back — against Alice's own DB.
+        recorded = _call(
+            server,
+            "record_fact",
+            {
+                "subject": {"type": "person", "name": "Dana"},
+                "predicate": "tagged",
+                "object": {"literal": "engineer"},
+            },
+        )
+        assert "error" not in recorded
+
+        recalled = _call(server, "recall_entity", {"name_or_alias": "Dana"})
+
+    assert recalled.get("entity") is not None
+    assert recalled["entity"]["name"] == "Dana"
+    # The only thing NeuroDock stored is the connection pointer.
+    assert connections.get(UserKey(sub="user_alice")) is not None
+
+
+def test_second_user_is_isolated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Arrange — two users, two separate local libSQL files.
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+    alice_db = f"file:{tmp_path / 'alice.db'}"
+    bob_db = f"file:{tmp_path / 'bob.db'}"
+
+    # Alice connects and records.
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "connect_byos_storage", {"libsql_url": alice_db})
+        _call(
+            server,
+            "record_fact",
+            {
+                "subject": {"type": "person", "name": "Dana"},
+                "predicate": "tagged",
+                "object": {"literal": "engineer"},
+            },
+        )
+
+    # Bob connects to his OWN db and looks for Alice's entity.
+    with _as_user(monkeypatch, "user_bob"):
+        _call(server, "connect_byos_storage", {"libsql_url": bob_db})
+        bob_recall = _call(server, "recall_entity", {"name_or_alias": "Dana"})
+
+    # Assert — cross-tenant isolation: Bob cannot see Alice's data.
+    assert bob_recall.get("entity") is None
+
+
+# -- URL validation / disconnect -----------------------------------------
+
+
+def test_connect_rejects_a_malformed_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+
+    with _as_user(monkeypatch, "user_alice"):
+        payload = _call(
+            server, "connect_byos_storage", {"libsql_url": "postgres://nope.example/db"}
+        )
+
+    assert payload["error"] == "INVALID_STORAGE_URL"
+    # A rejected URL must NOT be persisted.
+    assert connections.get(UserKey(sub="user_alice")) is None
+
+
+def test_connect_rejects_empty_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+
+    with _as_user(monkeypatch, "user_alice"):
+        payload = _call(server, "connect_byos_storage", {"libsql_url": "   "})
+
+    assert payload["error"] == "INVALID_STORAGE_URL"
+    assert connections.get(UserKey(sub="user_alice")) is None
+
+
+def test_disconnect_clears_the_connection(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Arrange — Alice connects.
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+    alice = UserKey(sub="user_alice")
+
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "connect_byos_storage", {"libsql_url": f"file:{tmp_path / 'alice.db'}"})
+        assert connections.get(alice) is not None
+
+        # Act — disconnect.
+        payload = _call(server, "disconnect_storage", {})
+
+        # Assert — nothing retained; status back to none.
+        assert payload["status"] == "disconnected"
+        status = _call(server, "storage_status", {})
+
+    assert status == {"authenticated": True, "mode": "none", "connected": False}
+    assert connections.get(alice) is None
+
+
+def test_anonymous_cannot_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Even the connect tool refuses anonymous callers — nothing is stored.
+    connections = InMemoryByosConnectionStore()
+    server = build_combined_server(connections)
+
+    with _as_user(monkeypatch, None):
+        payload = _call(server, "connect_byos_storage", {"libsql_url": "libsql://x.turso.io"})
+
+    assert payload["error"] == "STORAGE_NOT_AVAILABLE"
+    assert len(connections) == 0

--- a/packages/remote/worker/index.ts
+++ b/packages/remote/worker/index.ts
@@ -27,8 +27,14 @@ declare global {
       NEURODOCK_PUBLIC_URL: string;
       NEURODOCK_CLERK_DOMAIN: string;
       NEURODOCK_CLERK_CLIENT_ID: string;
-      // Secret (wrangler `secret put`); optional at the type level.
+      // Secrets (wrangler `secret put`); optional at the type level.
       NEURODOCK_CLERK_CLIENT_SECRET?: string;
+      // ADR 0010 Phase D — opt-in BYOS storage. The Clerk Backend API key
+      // (persists the per-user connection in Clerk private_metadata) and the
+      // master key that encrypts the BYOS auth token at rest. Without both, the
+      // opt-in tools are visible but return the sign-in/connect refusal.
+      NEURODOCK_CLERK_SECRET_KEY?: string;
+      NEURODOCK_STATE_MASTER_KEY?: string;
     }
   }
 }
@@ -48,6 +54,11 @@ export class NeurodockRemoteContainer extends Container {
     NEURODOCK_CLERK_DOMAIN: env.NEURODOCK_CLERK_DOMAIN,
     NEURODOCK_CLERK_CLIENT_ID: env.NEURODOCK_CLERK_CLIENT_ID,
     NEURODOCK_CLERK_CLIENT_SECRET: env.NEURODOCK_CLERK_CLIENT_SECRET ?? "",
+    // ADR 0010 Phase D — BYOS storage secrets. Empty string when unset; the
+    // server then leaves the opt-in tools un-backed (every call returns the
+    // sign-in/connect refusal) rather than failing to boot.
+    NEURODOCK_CLERK_SECRET_KEY: env.NEURODOCK_CLERK_SECRET_KEY ?? "",
+    NEURODOCK_STATE_MASTER_KEY: env.NEURODOCK_STATE_MASTER_KEY ?? "",
     // The container binds all interfaces; the Worker is the only ingress.
     NEURODOCK_HTTP_HOST: "0.0.0.0",
     NEURODOCK_HTTP_PORT: "8000",

--- a/packages/remote/wrangler.jsonc
+++ b/packages/remote/wrangler.jsonc
@@ -36,8 +36,13 @@
   "routes": [{ "pattern": "mcp.neurodock.org", "custom_domain": true }],
 
   // Non-secret runtime config forwarded into the container (see worker/index.ts).
-  // The secret (NEURODOCK_CLERK_CLIENT_SECRET) is NOT here — set it with
-  //   npx wrangler secret put NEURODOCK_CLERK_CLIENT_SECRET
+  // Secrets are NOT here — set each with `npx wrangler secret put <NAME>`:
+  //   NEURODOCK_CLERK_CLIENT_SECRET   — OAuth client secret (auth).
+  //   NEURODOCK_CLERK_SECRET_KEY      — Clerk Backend API key (ADR 0010 Phase D:
+  //                                     persists the per-user BYOS connection).
+  //   NEURODOCK_STATE_MASTER_KEY      — encrypts the BYOS auth token at rest.
+  // Without the last two, the opt-in memory tools are visible but un-backed:
+  // every call returns the structured sign-in/connect refusal (ADR 0010 §4).
   "vars": {
     "NEURODOCK_AUTH_PROVIDER": "clerk",
     "NEURODOCK_PUBLIC_URL": "https://mcp.neurodock.org",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,18 @@ ignore_missing_imports = true
 module = "fastembed.*"
 ignore_missing_imports = true
 
+# Clerk Backend SDK (ADR 0010 Phase D) — persists the per-user BYOS connection
+# pointer. Imported lazily inside ClerkMetadataByosStore; ships without py.typed.
+[[tool.mypy.overrides]]
+module = "clerk_backend_api.*"
+ignore_missing_imports = true
+
+# The cognitive-graph package is now a runtime dep of neurodock-remote (the
+# un-gated BYOS tools) but does not yet emit py.typed.
+[[tool.mypy.overrides]]
+module = "neurodock_mcp_cognitive_graph.*"
+ignore_missing_imports = true
+
 [[tool.mypy.overrides]]
 module = "rapidfuzz.*"
 ignore_missing_imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -347,6 +347,22 @@ wheels = [
 ]
 
 [[package]]
+name = "clerk-backend-api"
+version = "5.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/12/5df5d44bba32bacc464ccb3fd19d4159b3be5cf3774c09e6a7585d50b3a8/clerk_backend_api-5.0.7.tar.gz", hash = "sha256:9ff40e0450164b9444972ec7d2a81b3f780dc9a08a0a44cd7c598800a6367a4d", size = 264030, upload-time = "2026-05-29T21:58:18.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/96/04bd608407abc3da3fbfa6e949fc4c0c3c8870a4d608bbd45ad863fcd10f/clerk_backend_api-5.0.7-py3-none-any.whl", hash = "sha256:beafa8e074a71e48c9e426c53a7d5f54557cb8e140f69f17cbbcb41ce526e7f1", size = 545290, upload-time = "2026-05-29T21:58:19.749Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -473,61 +489,61 @@ toml = [
 
 [[package]]
 name = "cryptography"
-version = "48.0.0"
+version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
-    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
-    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
-    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
-    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
-    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
-    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
-    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
-    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
-    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
-    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
-    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
-    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
 ]
 
 [[package]]
@@ -1478,9 +1494,11 @@ version = "0.1.0"
 source = { editable = "packages/remote" }
 dependencies = [
     { name = "fastmcp" },
+    { name = "neurodock-mcp-cognitive-graph", extra = ["libsql"] },
     { name = "neurodock-mcp-guardrail" },
     { name = "neurodock-mcp-task-fractionator" },
     { name = "neurodock-mcp-translation" },
+    { name = "neurodock-state", extra = ["clerk"] },
     { name = "pydantic" },
     { name = "uvicorn" },
 ]
@@ -1494,9 +1512,11 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.3.0" },
+    { name = "neurodock-mcp-cognitive-graph", extras = ["libsql"], editable = "packages/mcp-cognitive-graph" },
     { name = "neurodock-mcp-guardrail", editable = "packages/mcp-guardrail" },
     { name = "neurodock-mcp-task-fractionator", editable = "packages/mcp-task-fractionator" },
     { name = "neurodock-mcp-translation", editable = "packages/mcp-translation" },
+    { name = "neurodock-state", extras = ["clerk"], editable = "packages/mcp-state" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
@@ -1513,6 +1533,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+clerk = [
+    { name = "clerk-backend-api" },
+    { name = "cryptography" },
+]
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1520,11 +1544,13 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "clerk-backend-api", marker = "extra == 'clerk'", specifier = ">=2.0" },
+    { name = "cryptography", marker = "extra == 'clerk'", specifier = ">=42.0" },
     { name = "fastmcp", specifier = ">=3.3.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
 ]
-provides-extras = ["test"]
+provides-extras = ["test", "clerk"]
 
 [[package]]
 name = "neurodock-workspace"


### PR DESCRIPTION
## ADR 0010 Phase D — BYOS storage for the cognitive-graph tools

Opted-in users connect their **own** libSQL/Turso database; the hosted server stores **none** of their graph data. Only one tiny per-user pointer (the connection URL + an encrypted auth token) is persisted, and only in the user's own Clerk `private_metadata`.

### The privacy boundary is the point of this PR

Anonymous and non-opted-in sessions stay **completely stateless**. They *see* the opt-in tools in the listing, but every call routes to a structured refusal and **stores/reads nothing**:

| Caller | Result | Touches a store? |
|---|---|---|
| anonymous / no token | `STORAGE_NOT_AVAILABLE` ("sign in + connect storage") | no — refused before any store is consulted |
| signed in, not connected | `STORAGE_NOT_CONNECTED` ("enable storage first") | reads connection state only; never the graph |
| signed in + connected (BYOS) | routed to **their own** libSQL DB | their DB only — never NeuroDock |

The choke point is `ByosState.require_user()`, which reads the **validated access token from the FastMCP request context** (never a tool argument) and refuses anonymous callers *before* any store is consulted. Proven by tests: an anonymous `record_fact` call returns the refusal and the connection store remains empty (`len(connections) == 0`).

`REMOTE_TOOL_NAMES` is treated as a security-relevant boundary and is now split + pinned by tests:
- `STATELESS_TOOL_NAMES` — the 8 existing remote-safe tools, **always present and unchanged**.
- `OPT_IN_TOOL_NAMES` — the 4 cognitive-graph tools + `connect_byos_storage` / `disconnect_storage` / `storage_status`.

### What changed

**`packages/mcp-state`**
- `ByosConnectionStore` protocol + `InMemoryByosConnectionStore` (tests).
- `ClerkMetadataByosStore` — persists the connection in Clerk `private_metadata` via the Clerk Backend API; the auth token is **encrypted at rest** (Fernet, key derived from `NEURODOCK_STATE_MASTER_KEY`). Clerk SDK **and** `cryptography` are lazy-imported so importing the module never fails. Requires `NEURODOCK_CLERK_SECRET_KEY`. Shipped as the `neurodock-state[clerk]` extra.
- `ByosResolver(StateBackingResolver)` — `storage_mode` is `"byos"` when connected else `"none"`; `graph_store` returns a `LibSqlStorage` for the user's own DB. `session_store`/`profile_store` raise `NotImplementedError` (deferred).

**`packages/remote`**
- `state.ByosState` — the per-user seam + privacy choke point.
- `tools/storage_admin.py` — `connect_byos_storage` (validate URL scheme is `libsql://`/`https://`/`file:`, smoke-test connect+migrate, **then** persist), `disconnect_storage` (deletes the pointer; NeuroDock retains nothing), `storage_status`.
- `tools/graph.py` — un-gates the 4 cognitive-graph tools through the per-call store-provider seam.
- `app.py` — the `STATELESS`/`OPT_IN` split and registration.

**Container / edge**
- `remote/pyproject.toml` adds `neurodock-state[clerk]` + `neurodock-mcp-cognitive-graph[libsql]`.
- `Dockerfile` sets `NEURODOCK_GRAPH_DISABLE_EMBEDDINGS=1` so `fastembed` is never loaded (lean image).
- `worker/index.ts` + `wrangler.jsonc` forward `NEURODOCK_CLERK_SECRET_KEY` + `NEURODOCK_STATE_MASTER_KEY` into the container, mirroring the existing `NEURODOCK_CLERK_CLIENT_SECRET` plumbing. **No secret is hardcoded.**

### Implementation note (why re-wire, not literally `mount(build_app(...))`)

`build_app(store_provider=...)` returns a low-level `mcp.server.fastmcp.FastMCP`, but the combined remote server is FastMCP 3.x. FastMCP 3.x `mount`/`import_server` only accept a 3.x server, and the proxy path runs handlers in a **separate session context** where `user_key_from_context()` cannot see the combined server's validated token — which would silently break the privacy boundary. So the graph tools are registered **directly** on the combined server and fed the **same** per-call store-provider seam `build_app` uses. The provider (`ByosState.graph_store`) is resolved per call, exactly as ADR 0010 Phase B specifies, and runs in the request context that holds the token.

### Deferred (tracked follow-up)
Chronometric **session persistence** and task-fractionator **`next_one`** are out of scope for Phase D and remain stdio/local only (`ByosResolver.session_store`/`profile_store` raise `NotImplementedError`). Only the 4 cognitive-graph tools are un-gated here.

### Verification (from repo root)
- `ruff check packages/mcp-state packages/remote` → **All checks passed**
- `ruff format --check` → **27 files already formatted**
- `mypy packages/mcp-state packages/remote` → **Success: no issues found in 27 source files**
- `pytest packages/mcp-state packages/remote` → **74 passed**
- full workspace `pytest packages` → **397 passed, 1 xfailed**

### Test plan
- [x] anonymous graph call → not-available, stores nothing
- [x] authenticated-but-not-connected → enable-storage-first
- [x] connect → `record_fact` → `recall_entity` round-trips against a local `file:` libSQL DB
- [x] second distinct user is isolated
- [x] connect rejects a malformed URL; disconnect clears the connection
- [x] Clerk store: token encrypted at rest, wrong master key fails closed (fake Clerk client; no network)
- [x] stateless tool surface + prompts unchanged
- [ ] (follow-up) integration test against a real Turso endpoint in a staging deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
