### PR TITLE
feat: hosted turso per-user storage (adr 0010 phase c)

### DIFF
--- a/docs/decisions/0010-opt-in-hosted-full-experience.md
+++ b/docs/decisions/0010-opt-in-hosted-full-experience.md
@@ -94,8 +94,19 @@ independently and now**.
 - **B. `StateStore` protocol** — abstract the cognitive-graph/chronometric/profile
   persistence behind a per-user store interface, keyed by Clerk `sub`. No behaviour
   change locally (the local stdio path keeps its on-disk SQLite store).
-- **C. Hosted per-user storage** — `HostedDurableObjectStore` (DO-per-user,
-  SQLite-backed), encryption at rest, opt-in consent + erasure endpoint.
+- **C. Hosted per-user storage** — _shipped_ as a **NeuroDock-provisioned Turso
+  database per user** rather than the originally-sketched DO-per-user store: the
+  hosted server provisions one Turso database per Clerk identity via the Turso
+  Platform API (`HostedTursoResolver` + `turso_platform` client), records explicit
+  consent, and resolves the same `LibSqlStorage` the BYOS path uses — so the two
+  modes share one backing class and one combined resolver. The Turso choice keeps
+  hosted and BYOS byte-for-byte identical at the SQL level and avoids a second
+  storage engine. The DB auth token is encrypted at rest with the operator master
+  key. `enable_hosted_storage` provisions (idempotent) + consents;
+  `disable_and_erase_storage` destroys the database + clears the preference.
+  **Open limitation:** a single operator-wide `NEURODOCK_STATE_MASTER_KEY` means
+  NeuroDock can technically decrypt a stored Turso token — see "Open questions"
+  (encryption key custody); per-user / envelope keys are a tracked follow-up.
 - **D. BYOS adapter** — `ByosLibsqlStore`; per-user connection config (supplied via a
   connect step / Clerk private_metadata) handled as a secret.
 - **E. Governance + docs** — privacy-policy rewrite, ETHICS.md amendment, clinical

--- a/packages/mcp-state/pyproject.toml
+++ b/packages/mcp-state/pyproject.toml
@@ -21,13 +21,16 @@ test = [
     "pytest>=8.3.0",
     "pytest-asyncio>=1.3.0",
 ]
-# ADR 0010 Phase D — the Clerk-metadata BYOS store. Both are imported lazily
-# inside `clerk_byos_store`, so the base package stays dependency-light and
-# importable without them; the hosted image installs this extra
-# (`neurodock-state[clerk]`). `cryptography` encrypts the BYOS auth token at rest.
+# ADR 0010 Phases C/D — the Clerk-metadata stores (BYOS connection + storage
+# preference) and the Turso Platform client. All are imported lazily, so the base
+# package stays dependency-light and importable without them; the hosted image
+# installs this extra (`neurodock-state[clerk]`). `cryptography` encrypts the
+# per-user DB/auth tokens at rest; `httpx` drives the Turso Platform API (create /
+# token / destroy the per-user hosted database).
 clerk = [
     "clerk-backend-api>=2.0",
     "cryptography>=42.0",
+    "httpx>=0.27",
 ]
 
 [build-system]

--- a/packages/mcp-state/src/neurodock_state/clerk_byos_store.py
+++ b/packages/mcp-state/src/neurodock_state/clerk_byos_store.py
@@ -31,16 +31,12 @@ stdio install, or unit tests that only exercise the in-memory store).
 
 from __future__ import annotations
 
-import base64
-import hashlib
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from neurodock_state.byos_connection_store import Connection
+from neurodock_state.crypto import MasterKeyError, TokenCipher
 from neurodock_state.identity import UserKey
-
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    from cryptography.fernet import Fernet
 
 # The single key under which the BYOS connection lives in a user's Clerk
 # private_metadata. Namespaced so it never collides with other app metadata.
@@ -56,19 +52,6 @@ class ByosStoreConfigError(RuntimeError):
 
 class ByosStoreBackendError(RuntimeError):
     """The Clerk Backend API call failed (network, auth, or unexpected shape)."""
-
-
-def _derive_fernet(master_key: str) -> Fernet:
-    """Build a :class:`Fernet` from an arbitrary-length master-key string.
-
-    Fernet requires a 32-byte url-safe-base64 key. We derive one deterministically
-    from the operator-supplied master key with SHA-256 so the operator can use any
-    sufficiently strong secret without having to pre-format it.
-    """
-    from cryptography.fernet import Fernet
-
-    digest = hashlib.sha256(master_key.encode("utf-8")).digest()
-    return Fernet(base64.urlsafe_b64encode(digest))
 
 
 class ClerkMetadataByosStore:
@@ -93,7 +76,9 @@ class ClerkMetadataByosStore:
         self._secret_key = secret
         # Build the cipher eagerly so a broken `cryptography` install fails at
         # construction, not mid-request. (Lazy import keeps module import safe.)
-        self._fernet = _derive_fernet(master)
+        # The cipher derivation is shared with the hosted Turso token store via
+        # `neurodock_state.crypto`, so on-disk Phase D tokens decrypt unchanged.
+        self._cipher = TokenCipher(master)
         self._client: Any | None = None
 
     # -- Clerk client (lazy) ---------------------------------------------
@@ -115,14 +100,12 @@ class ClerkMetadataByosStore:
     # -- token encryption ------------------------------------------------
 
     def _encrypt(self, token: str) -> str:
-        return self._fernet.encrypt(token.encode("utf-8")).decode("ascii")
+        return self._cipher.encrypt(token)
 
     def _decrypt(self, blob: str) -> str:
-        from cryptography.fernet import InvalidToken
-
         try:
-            return self._fernet.decrypt(blob.encode("ascii")).decode("utf-8")
-        except InvalidToken as exc:
+            return self._cipher.decrypt(blob)
+        except MasterKeyError as exc:
             raise ByosStoreBackendError(
                 f"stored BYOS auth token could not be decrypted (wrong {_MASTER_KEY_ENV}?)"
             ) from exc

--- a/packages/mcp-state/src/neurodock_state/combined_resolver.py
+++ b/packages/mcp-state/src/neurodock_state/combined_resolver.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Combined per-user backing resolver (ADR 0010 Phase C).
+
+NeuroDock now offers two storage modes side by side:
+
+- **hosted** (Phase C) — a NeuroDock-provisioned Turso database per user, via
+  :class:`~neurodock_state.hosted_resolver.HostedTursoResolver`.
+- **byos** (Phase D)   — the user's own libSQL/Turso connection, via
+  :class:`~neurodock_state.byos_resolver.ByosResolver`.
+
+:class:`CombinedResolver` is the :class:`~neurodock_state.registry.StateBackingResolver`
+the hosted server wires in. It reads the user's recorded **storage preference**
+and routes :meth:`graph_store` / :meth:`storage_mode` to whichever backing the
+user chose:
+
+- preference ``mode == "hosted"`` → delegate to the hosted resolver;
+- preference ``mode == "byos"``   → delegate to the BYOS resolver;
+- otherwise (``"none"`` or no record) → ``"none"`` and a :class:`LookupError`
+  from :meth:`graph_store` (the un-gating layer turns that into the structured
+  "enable storage first" refusal — nothing is provisioned or read).
+
+The preference record is the single source of truth for *which* mode is active.
+This keeps the two backings fully independent: switching modes is a preference
+change plus the relevant provision/connect step, and erasing one mode never
+touches the other.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from neurodock_state.identity import UserKey
+from neurodock_state.registry import GraphStore, StorageMode
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from neurodock_state.byos_resolver import ByosResolver
+    from neurodock_state.hosted_resolver import HostedTursoResolver
+    from neurodock_state.profile_store import ProfileStore
+    from neurodock_state.session_store import SessionStore
+    from neurodock_state.storage_preference_store import StoragePreferenceStore
+
+_SESSION_PROFILE_DEFERRED = (
+    "Hosted/BYOS session/profile persistence is out of scope for ADR 0010 Phase C; "
+    "only the four cognitive-graph tools are un-gated. This is a tracked follow-up."
+)
+
+
+class CombinedResolver:
+    """Route per-user backings to the hosted or BYOS resolver by recorded mode.
+
+    Stateless apart from the injected resolvers and preference store: every call
+    reads the preference fresh, so a mode switch or erase takes effect on the
+    very next call.
+    """
+
+    def __init__(
+        self,
+        *,
+        preferences: StoragePreferenceStore,
+        hosted: HostedTursoResolver,
+        byos: ByosResolver,
+    ) -> None:
+        self._preferences = preferences
+        self._hosted = hosted
+        self._byos = byos
+
+    def storage_mode(self, user: UserKey) -> StorageMode:
+        preference = self._preferences.get(user)
+        if preference is None:
+            return "none"
+        if preference.mode == "hosted":
+            return self._hosted.storage_mode(user)
+        if preference.mode == "byos":
+            return self._byos.storage_mode(user)
+        return "none"
+
+    def graph_store(self, user: UserKey) -> GraphStore:
+        preference = self._preferences.get(user)
+        if preference is not None and preference.mode == "hosted":
+            return self._hosted.graph_store(user)
+        if preference is not None and preference.mode == "byos":
+            return self._byos.graph_store(user)
+        # No active mode: callers MUST check storage_mode() first; this guards the
+        # invariant the same way the per-mode resolvers do.
+        raise LookupError(
+            "no active storage mode for this user; call storage_mode() before graph_store()"
+        )
+
+    def session_store(self, user: UserKey) -> SessionStore:
+        raise NotImplementedError(_SESSION_PROFILE_DEFERRED)
+
+    def profile_store(self, user: UserKey) -> ProfileStore:
+        raise NotImplementedError(_SESSION_PROFILE_DEFERRED)

--- a/packages/mcp-state/src/neurodock_state/crypto.py
+++ b/packages/mcp-state/src/neurodock_state/crypto.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""At-rest secret encryption keyed by the operator master key (ADR 0010 Phases C/D).
+
+NeuroDock holds two kinds of per-user secret on the hosted path: the BYOS auth
+token (Phase D) and the NeuroDock-provisioned Turso DB token (Phase C). Both are
+written into the user's Clerk ``private_metadata`` and so must be encrypted at
+rest. This module is the single place that knows how: a :class:`Fernet` cipher
+derived from ``NEURODOCK_STATE_MASTER_KEY``.
+
+Why factor it out of ``clerk_byos_store``?
+-----------------------------------------
+Phase D embedded the Fernet derivation inside the BYOS store. Phase C needs the
+exact same scheme for the hosted Turso token, so the derivation lives here and
+both stores call it. The behaviour is byte-for-byte identical to the Phase D
+implementation (SHA-256 of the master key → url-safe-base64 → Fernet), so
+already-stored Phase D tokens decrypt unchanged.
+
+The ``cryptography`` package is imported **lazily** inside the helpers so simply
+importing this module never fails on a host that lacks it (the base
+:mod:`neurodock_state` package stays dependency-light; the hosted image installs
+the ``clerk`` extra which pulls ``cryptography``).
+
+Honest limitation (ADR 0010 open question — encryption key custody)
+-------------------------------------------------------------------
+A single operator-wide ``NEURODOCK_STATE_MASTER_KEY`` means NeuroDock can
+technically decrypt every stored token. This is the documented Phase C trade-off;
+per-user / envelope keys (so the operator cannot unilaterally read a user's DB
+token) are a tracked follow-up. The on-disk format is unchanged either way, so a
+future envelope scheme can re-wrap without a data migration.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from cryptography.fernet import Fernet
+
+_MASTER_KEY_ENV = "NEURODOCK_STATE_MASTER_KEY"
+
+
+class MasterKeyError(RuntimeError):
+    """The master key is missing, or a stored secret could not be decrypted."""
+
+
+def derive_fernet(master_key: str) -> Fernet:
+    """Build a :class:`Fernet` from an arbitrary-length master-key string.
+
+    Fernet requires a 32-byte url-safe-base64 key. We derive one deterministically
+    from the operator-supplied master key with SHA-256 so the operator can use any
+    sufficiently strong secret without having to pre-format it.
+
+    The same string always yields the same cipher, so a token written by one
+    process decrypts in any other process configured with the same master key.
+    """
+    from cryptography.fernet import Fernet
+
+    digest = hashlib.sha256(master_key.encode("utf-8")).digest()
+    return Fernet(base64.urlsafe_b64encode(digest))
+
+
+class TokenCipher:
+    """Encrypt/decrypt a single secret string with the operator master key.
+
+    Construct once (the cipher is built eagerly so a broken ``cryptography``
+    install fails at construction, not mid-request) and reuse for every token.
+    """
+
+    def __init__(self, master_key: str) -> None:
+        master = master_key.strip()
+        if not master:
+            raise MasterKeyError(
+                f"{_MASTER_KEY_ENV} is required to encrypt per-user secrets at rest"
+            )
+        self._fernet = derive_fernet(master)
+
+    def encrypt(self, plaintext: str) -> str:
+        """Return the ciphertext (url-safe ASCII) for ``plaintext``."""
+        return self._fernet.encrypt(plaintext.encode("utf-8")).decode("ascii")
+
+    def decrypt(self, blob: str) -> str:
+        """Return the plaintext for a ciphertext produced by :meth:`encrypt`.
+
+        Raises :class:`MasterKeyError` if the blob cannot be decrypted (most
+        often a master-key mismatch), so a wrong key fails loudly rather than
+        returning garbage.
+        """
+        from cryptography.fernet import InvalidToken
+
+        try:
+            return self._fernet.decrypt(blob.encode("ascii")).decode("utf-8")
+        except InvalidToken as exc:
+            raise MasterKeyError(
+                f"a stored secret could not be decrypted (wrong {_MASTER_KEY_ENV}?)"
+            ) from exc

--- a/packages/mcp-state/src/neurodock_state/hosted_resolver.py
+++ b/packages/mcp-state/src/neurodock_state/hosted_resolver.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Hosted per-user backing resolver (ADR 0010 Phase C).
+
+:class:`HostedTursoResolver` is the :class:`~neurodock_state.registry.StateBackingResolver`
+for the **NeuroDock-provisioned** storage path. Where the Phase D
+:class:`~neurodock_state.byos_resolver.ByosResolver` points at the user's *own*
+database, this resolver provisions and owns a Turso database **per user** and
+returns a cognitive-graph store pointed at it.
+
+Responsibilities
+----------------
+- :meth:`storage_mode` — ``"hosted"`` when the user has a recorded preference with
+  ``mode == "hosted"``, else ``"none"``. The ``"none"`` default is the security
+  posture: a user who has not consented to hosted storage gets no storage, and the
+  un-gating layer turns that into the "enable storage first" refusal without ever
+  provisioning or touching a database.
+- :meth:`provision` — idempotently create the user's Turso database (create-if-
+  absent), mint a DB token, and persist the pointer (token encrypted at rest) in
+  the preference record with ``mode == "hosted"`` and the captured consent. Safe
+  to call twice: the second call reuses the existing database.
+- :meth:`graph_store` — return a :class:`LibSqlStorage` over the user's hosted DB.
+  If the database has not been provisioned yet it provisions on demand (so the
+  first graph call after consent just works).
+- :meth:`erase` — destroy the user's Turso database and clear their preference
+  record, so NeuroDock retains nothing after erasure.
+
+Injection
+---------
+The Turso :class:`~neurodock_state.turso_platform.TursoPlatformClient` and the
+:class:`~neurodock_state.storage_preference_store.StoragePreferenceStore` are both
+injected, so the test-suite drives the whole flow with a fake platform client
+(pointed at a local ``file:`` libSQL DB) and an in-memory preference store — no
+real Turso, no real Clerk.
+
+The cognitive-graph package is imported **lazily** inside :meth:`graph_store` so
+:mod:`neurodock_state` stays importable without it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
+
+from neurodock_state.identity import UserKey
+from neurodock_state.registry import GraphStore, StorageMode
+from neurodock_state.storage_preference_store import (
+    HostedDatabase,
+    StoragePreference,
+    StoragePreferenceStore,
+)
+from neurodock_state.turso_platform import TursoPlatformClient
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from neurodock_state.profile_store import ProfileStore
+    from neurodock_state.session_store import SessionStore
+
+# The disclosure version the consent step records. Bump when the disclosure text
+# materially changes so audit can tell which version a user agreed to.
+CONSENT_VERSION = "2026-06-01"
+
+# Turso database names allow lowercase letters, digits, and dashes (<= 64 chars).
+# We derive a deterministic, opaque name from the user's storage_key so the same
+# user always maps to the same database (idempotent provisioning) and the name
+# leaks nothing about the underlying identity.
+_DB_NAME_PREFIX = "nd-"
+_DB_NAME_HASH_LEN = 32  # 32 hex chars + 3-char prefix = 35, well under 64.
+
+_SESSION_PROFILE_DEFERRED = (
+    "Hosted session/profile persistence is out of scope for ADR 0010 Phase C; "
+    "only the four cognitive-graph tools are un-gated. This is a tracked follow-up."
+)
+
+
+def _database_name(user: UserKey) -> str:
+    """Deterministic, opaque Turso DB name for ``user``.
+
+    A second SHA-256 over the already-hashed storage_key keeps the database name
+    decoupled from any other surface that might index on storage_key directly.
+    """
+    digest = hashlib.sha256(user.storage_key.encode("utf-8")).hexdigest()
+    return f"{_DB_NAME_PREFIX}{digest[:_DB_NAME_HASH_LEN]}"
+
+
+class HostedTursoResolver:
+    """Resolve per-user cognitive-graph backings from NeuroDock-provisioned Turso DBs.
+
+    Stateless apart from the injected platform client and preference store: every
+    resolution reads the user's preference fresh, so an erase takes effect on the
+    very next call.
+    """
+
+    def __init__(
+        self,
+        *,
+        platform: TursoPlatformClient,
+        preferences: StoragePreferenceStore,
+        group: str,
+    ) -> None:
+        self._platform = platform
+        self._preferences = preferences
+        self._group = group
+
+    # -- StateBackingResolver --------------------------------------------
+
+    def storage_mode(self, user: UserKey) -> StorageMode:
+        preference = self._preferences.get(user)
+        if preference is not None and preference.mode == "hosted":
+            return "hosted"
+        return "none"
+
+    def graph_store(self, user: UserKey) -> GraphStore:
+        database = self._ensure_database(user)
+        return self._open(database)
+
+    def session_store(self, user: UserKey) -> SessionStore:
+        raise NotImplementedError(_SESSION_PROFILE_DEFERRED)
+
+    def profile_store(self, user: UserKey) -> ProfileStore:
+        raise NotImplementedError(_SESSION_PROFILE_DEFERRED)
+
+    # -- lifecycle (hosted-specific) -------------------------------------
+
+    def provision(self, user: UserKey, *, now: datetime | None = None) -> HostedDatabase:
+        """Idempotently provision ``user``'s hosted DB and record consent.
+
+        Creates the Turso database if absent, mints a DB token, and writes the
+        preference record (``mode == "hosted"``, token encrypted at rest by the
+        preference store) with the consent timestamp/version. Returns the
+        :class:`HostedDatabase`. Calling twice reuses the existing database and
+        refreshes nothing destructive — the existing pointer is kept.
+        """
+        existing = self._preferences.get(user)
+        if existing is not None and existing.mode == "hosted" and existing.database is not None:
+            # Already provisioned: idempotent no-op, return the existing pointer.
+            return existing.database
+
+        database = self._create_database(user)
+        consent_at = (now or datetime.now(UTC)).isoformat()
+        preference = StoragePreference(
+            mode="hosted",
+            consent_at=consent_at,
+            consent_version=CONSENT_VERSION,
+            database=database,
+        )
+        self._preferences.put(user, preference)
+        return database
+
+    def erase(self, user: UserKey) -> None:
+        """Destroy ``user``'s hosted DB and clear their preference record.
+
+        Idempotent: a user with no hosted database simply has their preference
+        cleared. After this call NeuroDock retains no token, pointer, or
+        preference for the user, and the Turso database is gone.
+        """
+        preference = self._preferences.get(user)
+        if preference is not None and preference.database is not None:
+            self._platform.destroy_database(preference.database.name)
+        self._preferences.clear(user)
+
+    # -- internals --------------------------------------------------------
+
+    def _ensure_database(self, user: UserKey) -> HostedDatabase:
+        """Return the user's hosted DB, provisioning on demand if necessary."""
+        preference = self._preferences.get(user)
+        if (
+            preference is not None
+            and preference.mode == "hosted"
+            and preference.database is not None
+        ):
+            return preference.database
+        # Consented to hosted but no database yet (or first graph call): provision.
+        return self.provision(user)
+
+    def _create_database(self, user: UserKey) -> HostedDatabase:
+        name = _database_name(user)
+        info = self._platform.create_database(name, self._group)
+        token = self._platform.create_token(name)
+        return HostedDatabase(name=info.name, url=info.url, token=token)
+
+    def _open(self, database: HostedDatabase) -> GraphStore:
+        # Lazy import: keep neurodock_state free of a hard cognitive-graph
+        # dependency. The hosted image installs the cognitive-graph package and
+        # its `libsql` extra; the resolver only needs them when actually serving.
+        from neurodock_mcp_cognitive_graph.storage.libsql import LibSqlStorage
+
+        # LibSqlStorage is a structural superset of GraphStore (initialise/close);
+        # the cognitive-graph package ships without py.typed so cast to the
+        # declared return type.
+        return cast(GraphStore, LibSqlStorage(database.url, auth_token=database.token))

--- a/packages/mcp-state/src/neurodock_state/storage_preference_store.py
+++ b/packages/mcp-state/src/neurodock_state/storage_preference_store.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Per-user storage-preference record (ADR 0010 Phase C).
+
+A *storage preference* captures the decision a user has made about where their
+stateful data lives, plus — for the hosted mode — the pointer NeuroDock needs to
+reach the database it provisioned for them:
+
+- ``mode``        — ``"hosted"`` | ``"byos"`` | ``"none"`` (the effective mode).
+- ``consent_at``  — ISO 8601 timestamp of the explicit opt-in (audit/erasure).
+- ``consent_version`` — the disclosure version the user agreed to.
+- ``database``    — for hosted only: the provisioned Turso DB name + libSQL URL.
+- ``db_token``    — for hosted only: the user's DB auth token, **encrypted at
+  rest** with the operator master key (see :mod:`neurodock_state.crypto`).
+
+Why a separate record from the BYOS connection?
+-----------------------------------------------
+Phase D's :class:`~neurodock_state.byos_connection_store.ByosConnectionStore`
+holds the BYOS connection (the user's *own* DB). Phase C adds a hosted DB that
+NeuroDock provisions and owns the lifecycle of. The two are different secrets
+with different lifecycles, and a user is in exactly one mode at a time. Rather
+than overload the BYOS record, the preference record is the single source of
+truth for *which* mode is active; the combined resolver reads it to route.
+
+Storage backends
+----------------
+- :class:`InMemoryStoragePreferenceStore` — dict-backed reference impl for tests.
+- :class:`ClerkMetadataPreferenceStore` — persists the record in the user's Clerk
+  ``private_metadata`` (namespaced key ``neurodock_storage_pref``), encrypting the
+  hosted DB token at rest. Mirrors the Phase D Clerk store: the Clerk SDK is
+  imported lazily; the cipher is shared via :mod:`neurodock_state.crypto`.
+
+Privacy
+-------
+The record is keyed by :attr:`UserKey.storage_key` (the SHA-256 of the Clerk
+``sub``) in memory, and by ``sub`` only as the Clerk user id. ``clear`` removes
+the record entirely — after erasure NeuroDock retains no preference, no token,
+and no pointer for the user.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from typing import Any, Literal, Protocol, runtime_checkable
+
+from neurodock_state.crypto import MasterKeyError, TokenCipher
+from neurodock_state.identity import UserKey
+
+PreferenceMode = Literal["hosted", "byos", "none"]
+
+# Namespaced key under which the preference record lives in Clerk private_metadata.
+_METADATA_KEY = "neurodock_storage_pref"
+
+_CLERK_SECRET_ENV = "NEURODOCK_CLERK_SECRET_KEY"
+_MASTER_KEY_ENV = "NEURODOCK_STATE_MASTER_KEY"
+
+
+class PreferenceStoreConfigError(RuntimeError):
+    """Required configuration (a secret) is missing or unusable."""
+
+
+class PreferenceStoreBackendError(RuntimeError):
+    """The Clerk Backend API call failed (network, auth, or unexpected shape)."""
+
+
+@dataclass(frozen=True)
+class HostedDatabase:
+    """The NeuroDock-provisioned Turso database for one hosted user.
+
+    Immutable. ``token`` is the plaintext DB auth token in memory; persistence
+    layers encrypt it at rest. ``None`` token is allowed only for token-less
+    local ``file:`` databases used in tests.
+    """
+
+    name: str
+    url: str
+    token: str | None = None
+
+
+@dataclass(frozen=True)
+class StoragePreference:
+    """One user's recorded storage decision. Immutable: updates return a copy."""
+
+    mode: PreferenceMode
+    consent_at: str | None = None
+    consent_version: str | None = None
+    database: HostedDatabase | None = None
+
+
+@runtime_checkable
+class StoragePreferenceStore(Protocol):
+    """The contract a per-user storage-preference backing must satisfy.
+
+    Implementations isolate records per :class:`UserKey`: one user can never read
+    or clear another user's preference.
+    """
+
+    def get(self, user: UserKey) -> StoragePreference | None:
+        """Return ``user``'s recorded preference, or ``None`` if never set."""
+        ...
+
+    def put(self, user: UserKey, preference: StoragePreference) -> None:
+        """Store (replacing any existing) ``user``'s preference."""
+        ...
+
+    def clear(self, user: UserKey) -> None:
+        """Remove ``user``'s preference entirely. Idempotent."""
+        ...
+
+
+class InMemoryStoragePreferenceStore:
+    """Dict-backed reference :class:`StoragePreferenceStore`. Per-user, no persistence.
+
+    Used by the test-suite to prove the routing/consent/erasure logic without a
+    real Clerk account. Records are keyed by :attr:`UserKey.storage_key`.
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[str, StoragePreference] = {}
+
+    def get(self, user: UserKey) -> StoragePreference | None:
+        return self._records.get(user.storage_key)
+
+    def put(self, user: UserKey, preference: StoragePreference) -> None:
+        self._records[user.storage_key] = preference
+
+    def clear(self, user: UserKey) -> None:
+        self._records.pop(user.storage_key, None)
+
+    def __len__(self) -> int:
+        """Number of stored records. Lets tests assert "nothing was stored"."""
+        return len(self._records)
+
+
+class ClerkMetadataPreferenceStore:
+    """Store storage preferences in Clerk ``private_metadata``, DB token encrypted.
+
+    Construct with the process environment (or any mapping). Both required secrets
+    are read at construction so misconfiguration fails loudly and early.
+    """
+
+    def __init__(self, env: Mapping[str, str]) -> None:
+        secret = env.get(_CLERK_SECRET_ENV, "").strip()
+        if not secret:
+            raise PreferenceStoreConfigError(
+                f"{_CLERK_SECRET_ENV} is required for the Clerk-backed preference store"
+            )
+        master = env.get(_MASTER_KEY_ENV, "").strip()
+        if not master:
+            raise PreferenceStoreConfigError(
+                f"{_MASTER_KEY_ENV} is required to encrypt hosted DB tokens at rest"
+            )
+        self._secret_key = secret
+        # Build the cipher eagerly so a broken `cryptography` install fails at
+        # construction, not mid-request. Shared derivation with the BYOS store.
+        self._cipher = TokenCipher(master)
+        self._client: Any | None = None
+
+    # -- Clerk client (lazy) ---------------------------------------------
+
+    def _clerk(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from clerk_backend_api import Clerk
+        except ImportError as exc:  # pragma: no cover - exercised only without SDK
+            raise PreferenceStoreConfigError(
+                "The 'clerk-backend-api' package is required for "
+                "ClerkMetadataPreferenceStore. Install it in the hosted image "
+                "(it is a dependency of neurodock-remote)."
+            ) from exc
+        self._client = Clerk(bearer_auth=self._secret_key)
+        return self._client
+
+    # -- serialisation ----------------------------------------------------
+
+    def _to_record(self, preference: StoragePreference) -> dict[str, Any]:
+        record: dict[str, Any] = {"mode": preference.mode}
+        if preference.consent_at is not None:
+            record["consent_at"] = preference.consent_at
+        if preference.consent_version is not None:
+            record["consent_version"] = preference.consent_version
+        if preference.database is not None:
+            db: dict[str, Any] = {
+                "name": preference.database.name,
+                "url": preference.database.url,
+            }
+            if preference.database.token:
+                db["token"] = self._cipher.encrypt(preference.database.token)
+            record["database"] = db
+        return record
+
+    def _from_record(self, record: Mapping[str, Any]) -> StoragePreference | None:
+        mode = record.get("mode")
+        if mode not in ("hosted", "byos", "none"):
+            return None
+        database: HostedDatabase | None = None
+        raw_db = record.get("database")
+        if isinstance(raw_db, dict):
+            name = raw_db.get("name")
+            url = raw_db.get("url")
+            if isinstance(name, str) and name and isinstance(url, str) and url:
+                token_blob = raw_db.get("token")
+                token = (
+                    self._decrypt(token_blob)
+                    if isinstance(token_blob, str) and token_blob
+                    else None
+                )
+                database = HostedDatabase(name=name, url=url, token=token)
+        consent_at = record.get("consent_at")
+        consent_version = record.get("consent_version")
+        return StoragePreference(
+            mode=mode,
+            consent_at=consent_at if isinstance(consent_at, str) else None,
+            consent_version=consent_version if isinstance(consent_version, str) else None,
+            database=database,
+        )
+
+    def _decrypt(self, blob: str) -> str:
+        try:
+            return self._cipher.decrypt(blob)
+        except MasterKeyError as exc:
+            raise PreferenceStoreBackendError(
+                f"stored hosted DB token could not be decrypted (wrong {_MASTER_KEY_ENV}?)"
+            ) from exc
+
+    # -- StoragePreferenceStore ------------------------------------------
+
+    def get(self, user: UserKey) -> StoragePreference | None:
+        clerk = self._clerk()
+        try:
+            clerk_user = clerk.users.get(user_id=user.sub)
+        except Exception as exc:  # surface as a structured backend error
+            raise PreferenceStoreBackendError(f"Clerk get-user failed: {exc}") from exc
+
+        metadata = getattr(clerk_user, "private_metadata", None) or {}
+        record = metadata.get(_METADATA_KEY)
+        if not isinstance(record, dict):
+            return None
+        return self._from_record(record)
+
+    def put(self, user: UserKey, preference: StoragePreference) -> None:
+        clerk = self._clerk()
+        try:
+            clerk.users.update_metadata(
+                user_id=user.sub,
+                private_metadata={_METADATA_KEY: self._to_record(preference)},
+            )
+        except Exception as exc:  # surface as a structured backend error
+            raise PreferenceStoreBackendError(f"Clerk update-metadata failed: {exc}") from exc
+
+    def clear(self, user: UserKey) -> None:
+        clerk = self._clerk()
+        # Setting the namespaced key to None clears it (Clerk merges metadata and
+        # drops null-valued keys). NeuroDock then retains no preference/token.
+        try:
+            clerk.users.update_metadata(
+                user_id=user.sub,
+                private_metadata={_METADATA_KEY: None},
+            )
+        except Exception as exc:  # surface as a structured backend error
+            raise PreferenceStoreBackendError(f"Clerk clear-metadata failed: {exc}") from exc
+
+
+def with_mode(preference: StoragePreference | None, mode: PreferenceMode) -> StoragePreference:
+    """Return a copy of ``preference`` with ``mode`` set, immutably.
+
+    A small convenience for callers updating only the mode (e.g. switching an
+    existing record to ``"none"`` on erasure). Starts from a bare record when
+    ``preference`` is ``None``.
+    """
+    if preference is None:
+        return StoragePreference(mode=mode)
+    return replace(preference, mode=mode)

--- a/packages/mcp-state/src/neurodock_state/turso_platform.py
+++ b/packages/mcp-state/src/neurodock_state/turso_platform.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Turso Platform API client for hosted per-user storage (ADR 0010 Phase C).
+
+The hosted storage mode provisions a **NeuroDock-managed Turso database per
+user**. This module is the thin seam over the Turso Platform API that does it:
+create a database, mint a DB auth token, and destroy a database.
+
+Design
+------
+- :class:`TursoPlatformClient` is a :class:`~typing.Protocol` declaring the three
+  operations the hosted resolver needs. The resolver depends on the protocol, so
+  the test-suite injects a fake (no network, no real Turso) and production wires
+  the real :class:`HttpxTursoPlatformClient`.
+- :class:`HttpxTursoPlatformClient` is a small typed ``httpx`` client. ``httpx``
+  is imported **lazily** in the constructor so importing this module never
+  requires it; the hosted image installs it. We deliberately do *not* depend on a
+  third-party Turso SDK: the Platform surface we use is three endpoints, and a
+  hand-rolled typed client keeps the dependency footprint and the failure modes
+  fully under our control.
+
+Endpoints (https://api.turso.tech, Bearer ``platform_token``):
+- create   : ``POST   /v1/organizations/{org}/databases``           {name, group}
+- token    : ``POST   /v1/organizations/{org}/databases/{name}/auth/tokens``
+- destroy  : ``DELETE /v1/organizations/{org}/databases/{name}``
+
+Security
+--------
+- The **platform token** (``NEURODOCK_TURSO_PLATFORM_TOKEN``) is an
+  organisation-wide secret that can create and destroy databases. It is held only
+  in the hosted process environment and never persisted or logged.
+- The **per-database token** minted by :meth:`create_token` is the user's own DB
+  credential. The resolver encrypts it at rest (see
+  :mod:`neurodock_state.crypto`) before it is stored in Clerk metadata.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import httpx
+
+_API_BASE = "https://api.turso.tech"
+_DEFAULT_TIMEOUT = 30.0
+
+
+class TursoPlatformError(RuntimeError):
+    """A Turso Platform API call failed (network, auth, or unexpected shape).
+
+    Carries the HTTP ``status`` when one is available so callers can branch on
+    "already exists" (409) versus "not found" (404) versus everything else.
+    """
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+@dataclass(frozen=True)
+class DatabaseInfo:
+    """The provisioning result for one user's hosted database.
+
+    ``name`` is the Turso database name (deterministic per user); ``hostname`` is
+    the libSQL host. :attr:`url` is the ``libsql://`` connection URL the
+    cognitive-graph store opens.
+    """
+
+    name: str
+    hostname: str
+
+    @property
+    def url(self) -> str:
+        return f"libsql://{self.hostname}"
+
+
+@runtime_checkable
+class TursoPlatformClient(Protocol):
+    """The Platform operations the hosted resolver needs. Inject a fake in tests."""
+
+    def create_database(self, name: str, group: str) -> DatabaseInfo:
+        """Create database ``name`` in ``group``. Idempotent at the resolver layer.
+
+        Implementations MUST treat an "already exists" (HTTP 409) response as a
+        success and return the existing database's :class:`DatabaseInfo`, so a
+        repeated provision call is a no-op rather than an error.
+        """
+        ...
+
+    def create_token(self, name: str) -> str:
+        """Mint and return a full-access auth token (JWT) for database ``name``."""
+        ...
+
+    def destroy_database(self, name: str) -> None:
+        """Permanently delete database ``name``. A missing DB (404) is a no-op."""
+        ...
+
+
+class HttpxTursoPlatformClient:
+    """Typed ``httpx`` implementation of :class:`TursoPlatformClient`.
+
+    Construct with the operator's organisation slug and platform token (both from
+    the hosted environment). ``httpx`` is imported lazily so the base package
+    never requires it.
+    """
+
+    def __init__(
+        self,
+        *,
+        organization: str,
+        platform_token: str,
+        api_base: str = _API_BASE,
+        timeout: float = _DEFAULT_TIMEOUT,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        org = organization.strip()
+        token = platform_token.strip()
+        if not org:
+            raise TursoPlatformError("a Turso organization slug is required")
+        if not token:
+            raise TursoPlatformError("a Turso platform API token is required")
+        self._org = org
+        self._api_base = api_base.rstrip("/")
+        self._timeout = timeout
+        # Lazy import: the hosted image installs httpx; the base package does not.
+        import httpx
+
+        # ``transport`` lets tests inject an ``httpx.MockTransport`` so the client's
+        # own request shaping/parsing is exercised without any network.
+        self._client: httpx.Client = httpx.Client(
+            base_url=self._api_base,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=timeout,
+            transport=transport,
+        )
+
+    # -- TursoPlatformClient ---------------------------------------------
+
+    def create_database(self, name: str, group: str) -> DatabaseInfo:
+        response = self._client.post(
+            f"/v1/organizations/{self._org}/databases",
+            json={"name": name, "group": group},
+        )
+        if response.status_code == 409:
+            # Already exists — the resolver's idempotent path. Resolve its host
+            # from the org/name convention rather than failing.
+            return DatabaseInfo(name=name, hostname=self._default_hostname(name))
+        body = self._json_or_raise(response, "create database")
+        database = body.get("database")
+        if not isinstance(database, dict):
+            raise TursoPlatformError("create-database response missing 'database' object")
+        hostname = database.get("Hostname") or database.get("hostname")
+        if not isinstance(hostname, str) or not hostname:
+            # Some API responses omit a usable hostname; fall back to convention.
+            hostname = self._default_hostname(name)
+        return DatabaseInfo(name=name, hostname=hostname)
+
+    def create_token(self, name: str) -> str:
+        response = self._client.post(
+            f"/v1/organizations/{self._org}/databases/{name}/auth/tokens",
+        )
+        body = self._json_or_raise(response, "create database token")
+        jwt = body.get("jwt")
+        if not isinstance(jwt, str) or not jwt:
+            raise TursoPlatformError("create-token response missing 'jwt'")
+        return jwt
+
+    def destroy_database(self, name: str) -> None:
+        response = self._client.delete(
+            f"/v1/organizations/{self._org}/databases/{name}",
+        )
+        if response.status_code == 404:
+            # Already gone — erase is idempotent.
+            return
+        self._json_or_raise(response, "destroy database")
+
+    def close(self) -> None:
+        self._client.close()
+
+    # -- helpers ----------------------------------------------------------
+
+    def _default_hostname(self, name: str) -> str:
+        """The conventional Turso libSQL host for ``name`` in this org."""
+        return f"{name}-{self._org}.turso.io"
+
+    def _json_or_raise(self, response: httpx.Response, what: str) -> dict[str, Any]:
+        if response.status_code >= 400:
+            raise TursoPlatformError(
+                f"Turso {what} failed: HTTP {response.status_code} {response.text[:200]}",
+                status=response.status_code,
+            )
+        try:
+            parsed: dict[str, Any] = response.json()
+        except ValueError as exc:
+            raise TursoPlatformError(f"Turso {what} returned non-JSON body") from exc
+        return parsed

--- a/packages/mcp-state/tests/test_combined_resolver.py
+++ b/packages/mcp-state/tests/test_combined_resolver.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the combined hosted-or-BYOS resolver (ADR 0010 Phase C).
+
+Proves the routing contract: the user's recorded preference mode selects which
+backing answers storage_mode/graph_store, the two backings stay independent, and
+the "none"/no-record default refuses with a LookupError (which the un-gating
+layer turns into the structured "enable storage first" response).
+
+NO real Turso, NO real Clerk: an in-memory preference store, a fake platform
+client, and an in-memory BYOS connection store. The libSQL round-trip tests skip
+cleanly without the cognitive-graph + libsql stack.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from neurodock_state.byos_connection_store import InMemoryByosConnectionStore
+from neurodock_state.byos_resolver import ByosResolver
+from neurodock_state.combined_resolver import CombinedResolver
+from neurodock_state.hosted_resolver import HostedTursoResolver, _database_name
+from neurodock_state.identity import UserKey
+from neurodock_state.registry import StateBackingResolver
+from neurodock_state.storage_preference_store import (
+    HostedDatabase,
+    InMemoryStoragePreferenceStore,
+    StoragePreference,
+)
+
+_HAS_LIBSQL_STACK = (
+    importlib.util.find_spec("libsql") is not None
+    and importlib.util.find_spec("neurodock_mcp_cognitive_graph") is not None
+)
+
+_needs_libsql = pytest.mark.skipif(
+    not _HAS_LIBSQL_STACK,
+    reason="requires the cognitive-graph package and the optional libsql client",
+)
+
+_GROUP = "default"
+
+
+class _FilePlatform:
+    """Fake platform returning a local file: DB URL so the round-trip is real."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self._tmp = tmp_path
+        self.created: list[str] = []
+        self.destroyed: list[str] = []
+        self._urls: dict[str, str] = {}
+
+    def create_database(self, name: str, group: str):  # type: ignore[no-untyped-def]
+        self.created.append(name)
+        url = self._urls.setdefault(name, f"file:{self._tmp / (name + '.db')}")
+        return _FileInfo(name=name, url=url)
+
+    def create_token(self, name: str) -> str | None:
+        return None
+
+    def destroy_database(self, name: str) -> None:
+        self.destroyed.append(name)
+
+
+class _FileInfo:
+    def __init__(self, name: str, url: str) -> None:
+        self.name = name
+        self._url = url
+        self.hostname = "local"
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+
+def _build(
+    tmp_path: Path,
+) -> tuple[
+    CombinedResolver,
+    InMemoryStoragePreferenceStore,
+    InMemoryByosConnectionStore,
+    HostedTursoResolver,
+    _FilePlatform,
+]:
+    preferences = InMemoryStoragePreferenceStore()
+    connections = InMemoryByosConnectionStore()
+    platform = _FilePlatform(tmp_path)
+    hosted = HostedTursoResolver(platform=platform, preferences=preferences, group=_GROUP)  # type: ignore[arg-type]
+    byos = ByosResolver(connections)
+    combined = CombinedResolver(preferences=preferences, hosted=hosted, byos=byos)
+    return combined, preferences, connections, hosted, platform
+
+
+def test_combined_satisfies_protocol(tmp_path: Path) -> None:
+    combined, *_ = _build(tmp_path)
+    assert isinstance(combined, StateBackingResolver)
+
+
+def test_no_record_is_none_and_graph_store_raises(tmp_path: Path) -> None:
+    combined, *_ = _build(tmp_path)
+    alice = UserKey(sub="alice")
+    assert combined.storage_mode(alice) == "none"
+    with pytest.raises(LookupError):
+        combined.graph_store(alice)
+
+
+def test_mode_none_record_is_refused(tmp_path: Path) -> None:
+    combined, preferences, *_ = _build(tmp_path)
+    alice = UserKey(sub="alice")
+    preferences.put(alice, StoragePreference(mode="none"))
+    assert combined.storage_mode(alice) == "none"
+    with pytest.raises(LookupError):
+        combined.graph_store(alice)
+
+
+def test_routes_storage_mode_to_hosted(tmp_path: Path) -> None:
+    combined, preferences, _, _, _ = _build(tmp_path)
+    alice = UserKey(sub="alice")
+    preferences.put(
+        alice,
+        StoragePreference(
+            mode="hosted",
+            database=HostedDatabase(name="nd-x", url="libsql://nd-x.turso.io", token="t"),
+        ),
+    )
+    assert combined.storage_mode(alice) == "hosted"
+
+
+def test_routes_storage_mode_to_byos(tmp_path: Path) -> None:
+    combined, preferences, connections, _, _ = _build(tmp_path)
+    alice = UserKey(sub="alice")
+    connections.put(alice, "libsql://alice.turso.io", auth_token="t")
+    preferences.put(alice, StoragePreference(mode="byos"))
+    assert combined.storage_mode(alice) == "byos"
+
+
+@_needs_libsql
+def test_hosted_user_round_trips_through_combined(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    from neurodock_mcp_cognitive_graph.clock import FixedClock
+    from neurodock_mcp_cognitive_graph.tools import recall_entity as recall_entity_tool
+    from neurodock_mcp_cognitive_graph.tools import record_fact as record_fact_tool
+
+    combined, _, _, hosted, platform = _build(tmp_path)
+    alice = UserKey(sub="alice")
+    hosted.provision(alice)  # consent + provision via the hosted path
+    clock = FixedClock(datetime(2026, 6, 1, 12, 0, tzinfo=UTC))
+
+    store = combined.graph_store(alice)
+    store.initialise()
+    try:
+        record_fact_tool(
+            store,
+            clock,
+            subject={"type": "person", "name": "Dana"},
+            predicate="tagged",
+            object={"literal": "engineer"},
+        )
+        result = recall_entity_tool(store, "Dana")
+    finally:
+        store.close()
+
+    assert result.entity is not None
+    assert result.entity.name == "Dana"
+    assert platform.created == [_database_name(alice)]
+
+
+@_needs_libsql
+def test_byos_user_round_trips_through_combined(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    from neurodock_mcp_cognitive_graph.clock import FixedClock
+    from neurodock_mcp_cognitive_graph.tools import recall_entity as recall_entity_tool
+    from neurodock_mcp_cognitive_graph.tools import record_fact as record_fact_tool
+
+    combined, preferences, connections, _, platform = _build(tmp_path)
+    alice = UserKey(sub="alice")
+    connections.put(alice, f"file:{tmp_path / 'alice-byos.db'}")
+    preferences.put(alice, StoragePreference(mode="byos"))
+    clock = FixedClock(datetime(2026, 6, 1, 12, 0, tzinfo=UTC))
+
+    store = combined.graph_store(alice)
+    store.initialise()
+    try:
+        record_fact_tool(
+            store,
+            clock,
+            subject={"type": "person", "name": "Eli"},
+            predicate="tagged",
+            object={"literal": "designer"},
+        )
+        result = recall_entity_tool(store, "Eli")
+    finally:
+        store.close()
+
+    assert result.entity is not None
+    assert result.entity.name == "Eli"
+    # The hosted platform was never touched for a BYOS user.
+    assert platform.created == []

--- a/packages/mcp-state/tests/test_crypto.py
+++ b/packages/mcp-state/tests/test_crypto.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the shared at-rest token cipher (ADR 0010 Phases C/D).
+
+Uses the real ``cryptography`` Fernet path so the at-rest guarantee is genuinely
+tested. Skips cleanly when ``cryptography`` is not installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+_HAS_CRYPTO = importlib.util.find_spec("cryptography") is not None
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_CRYPTO, reason="requires the optional cryptography package"
+)
+
+if _HAS_CRYPTO:
+    from neurodock_state.crypto import MasterKeyError, TokenCipher
+
+
+def test_round_trips_a_token() -> None:
+    cipher = TokenCipher("a-strong-master-key")
+    blob = cipher.encrypt("super-secret")
+    assert blob != "super-secret"
+    assert cipher.decrypt(blob) == "super-secret"
+
+
+def test_requires_a_non_empty_master_key() -> None:
+    with pytest.raises(MasterKeyError):
+        TokenCipher("   ")
+
+
+def test_same_master_key_decrypts_across_instances() -> None:
+    # Two processes configured with the same key must interoperate.
+    blob = TokenCipher("shared-key").encrypt("t")
+    assert TokenCipher("shared-key").decrypt(blob) == "t"
+
+
+def test_wrong_master_key_fails_loudly() -> None:
+    blob = TokenCipher("key-one").encrypt("t")
+    with pytest.raises(MasterKeyError):
+        TokenCipher("key-two").decrypt(blob)

--- a/packages/mcp-state/tests/test_hosted_resolver.py
+++ b/packages/mcp-state/tests/test_hosted_resolver.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the hosted Turso per-user resolver (ADR 0010 Phase C).
+
+NO real Turso and NO real Clerk: a fake :class:`TursoPlatformClient` records the
+provisioning calls and maps each provisioned database name to a local ``file:``
+libSQL DB, so ``record_fact`` → ``recall_entity`` actually round-trips against the
+"hosted" store. The preference store is the in-memory reference impl.
+
+The libSQL round-trip tests skip cleanly when the cognitive-graph package or the
+optional ``libsql`` client is unavailable, mirroring the BYOS resolver tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from neurodock_state.hosted_resolver import HostedTursoResolver, _database_name
+from neurodock_state.identity import UserKey
+from neurodock_state.registry import StateBackingResolver
+from neurodock_state.storage_preference_store import InMemoryStoragePreferenceStore
+from neurodock_state.turso_platform import DatabaseInfo
+
+_HAS_LIBSQL_STACK = (
+    importlib.util.find_spec("libsql") is not None
+    and importlib.util.find_spec("neurodock_mcp_cognitive_graph") is not None
+)
+
+_needs_libsql = pytest.mark.skipif(
+    not _HAS_LIBSQL_STACK,
+    reason="requires the cognitive-graph package and the optional libsql client",
+)
+
+_GROUP = "default"
+
+
+class _FakePlatform:
+    """Fake :class:`TursoPlatformClient` that records calls (no real Turso).
+
+    Used by the contract tests that only assert which databases were created /
+    destroyed and that consent was recorded. Returns a synthetic
+    :class:`DatabaseInfo`; the end-to-end round-trip tests use :class:`_FilePlatform`
+    (below), whose URL points at a real local ``file:`` libSQL DB.
+    """
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.created: list[str] = []
+        self.tokens: list[str] = []
+        self.destroyed: list[str] = []
+
+    def create_database(self, name: str, group: str) -> DatabaseInfo:
+        assert group == _GROUP
+        self.created.append(name)
+        return DatabaseInfo(name=name, hostname=f"{name}.local")
+
+    def create_token(self, name: str) -> str:
+        token = f"token-for-{name}"
+        self.tokens.append(token)
+        return token
+
+    def destroy_database(self, name: str) -> None:
+        self.destroyed.append(name)
+
+
+def _resolver(platform: object, preferences: InMemoryStoragePreferenceStore) -> HostedTursoResolver:
+    return HostedTursoResolver(platform=platform, preferences=preferences, group=_GROUP)  # type: ignore[arg-type]
+
+
+def test_resolver_satisfies_protocol(tmp_path: Path) -> None:
+    resolver = _resolver(_FakePlatform(tmp_path), InMemoryStoragePreferenceStore())
+    assert isinstance(resolver, StateBackingResolver)
+
+
+def test_storage_mode_is_none_until_provisioned(tmp_path: Path) -> None:
+    resolver = _resolver(_FakePlatform(tmp_path), InMemoryStoragePreferenceStore())
+    # The security default: no consent => no storage, nothing provisioned.
+    assert resolver.storage_mode(UserKey(sub="alice")) == "none"
+
+
+def test_database_name_is_deterministic_and_opaque() -> None:
+    alice = UserKey(sub="alice")
+    # Deterministic per user, opaque (no raw sub), and within Turso's 64-char limit.
+    assert _database_name(alice) == _database_name(UserKey(sub="alice"))
+    assert _database_name(alice) != _database_name(UserKey(sub="bob"))
+    assert "alice" not in _database_name(alice)
+    assert len(_database_name(alice)) <= 64
+
+
+def test_provision_records_consent_and_calls_platform_once(tmp_path: Path) -> None:
+    platform = _FakePlatform(tmp_path)
+    preferences = InMemoryStoragePreferenceStore()
+    resolver = _resolver(platform, preferences)
+    alice = UserKey(sub="alice")
+
+    db1 = resolver.provision(alice)
+
+    # Consent recorded, mode is hosted, database pointer stored.
+    pref = preferences.get(alice)
+    assert pref is not None
+    assert pref.mode == "hosted"
+    assert pref.consent_at is not None
+    assert pref.consent_version is not None
+    assert pref.database is not None
+    assert resolver.storage_mode(alice) == "hosted"
+    assert platform.created == [_database_name(alice)]
+
+    # Idempotent: a second provision reuses the existing DB, no new create call.
+    db2 = resolver.provision(alice)
+    assert db2 == db1
+    assert platform.created == [_database_name(alice)]
+
+
+def test_erase_destroys_database_and_clears_preference(tmp_path: Path) -> None:
+    platform = _FakePlatform(tmp_path)
+    preferences = InMemoryStoragePreferenceStore()
+    resolver = _resolver(platform, preferences)
+    alice = UserKey(sub="alice")
+
+    resolver.provision(alice)
+    resolver.erase(alice)
+
+    assert platform.destroyed == [_database_name(alice)]
+    assert preferences.get(alice) is None
+    assert resolver.storage_mode(alice) == "none"
+
+
+def test_erase_is_idempotent_without_a_database(tmp_path: Path) -> None:
+    platform = _FakePlatform(tmp_path)
+    preferences = InMemoryStoragePreferenceStore()
+    resolver = _resolver(platform, preferences)
+    # No raise even though nothing was ever provisioned.
+    resolver.erase(UserKey(sub="alice"))
+    assert platform.destroyed == []
+
+
+# -- libSQL round-trip (real local file: DB) -----------------------------
+
+
+class _FilePlatform:
+    """Fake platform whose DatabaseInfo.url is a local ``file:`` URL (token-less).
+
+    Lets the resolver's LibSqlStorage open a real local SQLite DB for the
+    end-to-end round-trip. ``create_token`` returns ``None``-equivalent by way of
+    a sentinel the resolver passes to LibSqlStorage; we use a token-less file DB,
+    so we return an empty token and rely on LibSqlStorage ignoring it for file:.
+    """
+
+    def __init__(self, tmp_path: Path) -> None:
+        self._tmp = tmp_path
+        self.created: list[str] = []
+        self.destroyed: list[str] = []
+        self._urls: dict[str, str] = {}
+
+    def create_database(self, name: str, group: str):  # type: ignore[no-untyped-def]
+        self.created.append(name)
+        url = self._urls.setdefault(name, f"file:{self._tmp / (name + '.db')}")
+        return _FileInfo(name=name, url=url)
+
+    def create_token(self, name: str) -> str | None:
+        return None
+
+    def destroy_database(self, name: str) -> None:
+        self.destroyed.append(name)
+
+
+class _FileInfo:
+    """DatabaseInfo-shaped object whose ``url`` is a local file: URL."""
+
+    def __init__(self, name: str, url: str) -> None:
+        self.name = name
+        self._url = url
+        self.hostname = "local"
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+
+@_needs_libsql
+def test_hosted_round_trips_record_then_recall(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    from neurodock_mcp_cognitive_graph.clock import FixedClock
+    from neurodock_mcp_cognitive_graph.tools import recall_entity as recall_entity_tool
+    from neurodock_mcp_cognitive_graph.tools import record_fact as record_fact_tool
+
+    platform = _FilePlatform(tmp_path)
+    preferences = InMemoryStoragePreferenceStore()
+    resolver = _resolver(platform, preferences)
+    alice = UserKey(sub="alice")
+    clock = FixedClock(datetime(2026, 6, 1, 12, 0, tzinfo=UTC))
+
+    # graph_store provisions on demand (no explicit provision() first).
+    store = resolver.graph_store(alice)
+    store.initialise()
+    try:
+        record_fact_tool(
+            store,
+            clock,
+            subject={"type": "person", "name": "Dana"},
+            predicate="tagged",
+            object={"literal": "engineer"},
+        )
+        result = recall_entity_tool(store, "Dana")
+    finally:
+        store.close()
+
+    assert result.entity is not None
+    assert result.entity.name == "Dana"
+    # Provisioning happened exactly once and is now recorded as hosted.
+    assert platform.created == [_database_name(alice)]
+    assert resolver.storage_mode(alice) == "hosted"
+
+
+@_needs_libsql
+def test_two_hosted_users_get_isolated_databases(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    from neurodock_mcp_cognitive_graph.clock import FixedClock
+    from neurodock_mcp_cognitive_graph.tools import recall_entity as recall_entity_tool
+    from neurodock_mcp_cognitive_graph.tools import record_fact as record_fact_tool
+
+    platform = _FilePlatform(tmp_path)
+    preferences = InMemoryStoragePreferenceStore()
+    resolver = _resolver(platform, preferences)
+    alice = UserKey(sub="alice")
+    bob = UserKey(sub="bob")
+    clock = FixedClock(datetime(2026, 6, 1, 12, 0, tzinfo=UTC))
+
+    alice_store = resolver.graph_store(alice)
+    alice_store.initialise()
+    bob_store = resolver.graph_store(bob)
+    bob_store.initialise()
+    try:
+        record_fact_tool(
+            alice_store,
+            clock,
+            subject={"type": "person", "name": "Dana"},
+            predicate="tagged",
+            object={"literal": "engineer"},
+        )
+        bob_result = recall_entity_tool(bob_store, "Dana")
+    finally:
+        alice_store.close()
+        bob_store.close()
+
+    # Distinct databases → Bob cannot see Alice's data.
+    assert bob_result.entity is None
+    assert _database_name(alice) != _database_name(bob)
+    assert set(platform.created) == {_database_name(alice), _database_name(bob)}

--- a/packages/mcp-state/tests/test_storage_preference_store.py
+++ b/packages/mcp-state/tests/test_storage_preference_store.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the storage-preference store (ADR 0010 Phase C).
+
+The in-memory store proves the routing/consent/erasure contract with no infra.
+The Clerk-metadata store is tested with a fake Clerk client (NO real Clerk, NO
+network), proving the record shape, hosted-DB-token encryption at rest, and
+get/put/clear round-trips. The encryption uses the real ``cryptography`` Fernet
+path so the at-rest guarantee is genuinely tested.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import pytest
+from neurodock_state.identity import UserKey
+from neurodock_state.storage_preference_store import (
+    HostedDatabase,
+    InMemoryStoragePreferenceStore,
+    StoragePreference,
+    StoragePreferenceStore,
+    with_mode,
+)
+
+_HAS_CRYPTO = importlib.util.find_spec("cryptography") is not None
+
+_ENV = {
+    "NEURODOCK_CLERK_SECRET_KEY": "sk_test_fake",
+    "NEURODOCK_STATE_MASTER_KEY": "a-strong-master-key-for-tests",
+}
+
+
+# -- in-memory contract ---------------------------------------------------
+
+
+def test_in_memory_satisfies_protocol() -> None:
+    assert isinstance(InMemoryStoragePreferenceStore(), StoragePreferenceStore)
+
+
+def test_in_memory_get_is_none_when_unset() -> None:
+    store = InMemoryStoragePreferenceStore()
+    assert store.get(UserKey(sub="alice")) is None
+
+
+def test_in_memory_put_then_get_round_trips() -> None:
+    store = InMemoryStoragePreferenceStore()
+    alice = UserKey(sub="alice")
+    pref = StoragePreference(
+        mode="hosted",
+        consent_at="2026-06-01T00:00:00+00:00",
+        consent_version="2026-06-01",
+        database=HostedDatabase(name="nd-x", url="libsql://nd-x.turso.io", token="t"),
+    )
+    store.put(alice, pref)
+    assert store.get(alice) == pref
+
+
+def test_in_memory_clear_removes_record() -> None:
+    store = InMemoryStoragePreferenceStore()
+    alice = UserKey(sub="alice")
+    store.put(alice, StoragePreference(mode="byos"))
+    store.clear(alice)
+    assert store.get(alice) is None
+    assert len(store) == 0
+
+
+def test_in_memory_is_per_user() -> None:
+    store = InMemoryStoragePreferenceStore()
+    store.put(UserKey(sub="alice"), StoragePreference(mode="hosted"))
+    assert store.get(UserKey(sub="bob")) is None
+
+
+def test_with_mode_is_immutable() -> None:
+    pref = StoragePreference(mode="hosted", consent_version="v1")
+    switched = with_mode(pref, "none")
+    assert switched.mode == "none"
+    assert switched.consent_version == "v1"  # other fields preserved
+    assert pref.mode == "hosted"  # original untouched
+    assert with_mode(None, "none") == StoragePreference(mode="none")
+
+
+# -- Clerk-metadata backing ----------------------------------------------
+
+_clerk_only = pytest.mark.skipif(
+    not _HAS_CRYPTO, reason="requires the optional cryptography package"
+)
+
+
+class _FakeUsers:
+    def __init__(self) -> None:
+        self.metadata: dict[str, dict[str, Any]] = {}
+
+    def get(self, *, user_id: str) -> Any:
+        record = self.metadata.get(user_id, {})
+        return type("ClerkUser", (), {"private_metadata": dict(record)})()
+
+    def update_metadata(self, *, user_id: str, private_metadata: dict[str, Any]) -> None:
+        current = self.metadata.setdefault(user_id, {})
+        for key, value in private_metadata.items():
+            if value is None:
+                current.pop(key, None)
+            else:
+                current[key] = value
+
+
+class _FakeClerk:
+    def __init__(self) -> None:
+        self.users = _FakeUsers()
+
+
+def _store_with_fake(env: dict[str, str]):  # type: ignore[no-untyped-def]
+    from neurodock_state.storage_preference_store import ClerkMetadataPreferenceStore
+
+    impl = ClerkMetadataPreferenceStore(env)
+    fake = _FakeClerk()
+    impl._client = fake
+    return impl, fake
+
+
+@_clerk_only
+def test_clerk_requires_secrets() -> None:
+    from neurodock_state.storage_preference_store import (
+        ClerkMetadataPreferenceStore,
+        PreferenceStoreConfigError,
+    )
+
+    with pytest.raises(PreferenceStoreConfigError):
+        ClerkMetadataPreferenceStore({"NEURODOCK_STATE_MASTER_KEY": "k"})
+    with pytest.raises(PreferenceStoreConfigError):
+        ClerkMetadataPreferenceStore({"NEURODOCK_CLERK_SECRET_KEY": "sk"})
+
+
+@_clerk_only
+def test_clerk_get_is_none_when_unset() -> None:
+    store, _ = _store_with_fake(_ENV)
+    assert store.get(UserKey(sub="alice")) is None
+
+
+@_clerk_only
+def test_clerk_round_trips_a_hosted_preference() -> None:
+    store, _ = _store_with_fake(_ENV)
+    alice = UserKey(sub="alice")
+    pref = StoragePreference(
+        mode="hosted",
+        consent_at="2026-06-01T00:00:00+00:00",
+        consent_version="2026-06-01",
+        database=HostedDatabase(name="nd-x", url="libsql://nd-x.turso.io", token="db-secret"),
+    )
+    store.put(alice, pref)
+    loaded = store.get(alice)
+    assert loaded == pref
+
+
+@_clerk_only
+def test_clerk_encrypts_db_token_at_rest() -> None:
+    store, fake = _store_with_fake(_ENV)
+    alice = UserKey(sub="alice")
+    store.put(
+        alice,
+        StoragePreference(
+            mode="hosted",
+            database=HostedDatabase(name="nd-x", url="libsql://nd-x.turso.io", token="db-secret"),
+        ),
+    )
+    raw = fake.users.metadata["alice"]["neurodock_storage_pref"]
+    assert raw["database"]["token"] != "db-secret"
+    assert "db-secret" not in str(raw)
+
+
+@_clerk_only
+def test_clerk_clear_removes_record() -> None:
+    store, _ = _store_with_fake(_ENV)
+    alice = UserKey(sub="alice")
+    store.put(alice, StoragePreference(mode="hosted"))
+    store.clear(alice)
+    assert store.get(alice) is None
+
+
+@_clerk_only
+def test_clerk_wrong_master_key_cannot_decrypt_token() -> None:
+    from neurodock_state.storage_preference_store import (
+        ClerkMetadataPreferenceStore,
+        PreferenceStoreBackendError,
+    )
+
+    writer, fake = _store_with_fake(_ENV)
+    writer.put(
+        UserKey(sub="alice"),
+        StoragePreference(
+            mode="hosted",
+            database=HostedDatabase(name="nd-x", url="libsql://x", token="t"),
+        ),
+    )
+    reader = ClerkMetadataPreferenceStore(
+        {**_ENV, "NEURODOCK_STATE_MASTER_KEY": "a-completely-different-key"}
+    )
+    reader._client = fake
+    with pytest.raises(PreferenceStoreBackendError):
+        reader.get(UserKey(sub="alice"))

--- a/packages/mcp-state/tests/test_turso_platform.py
+++ b/packages/mcp-state/tests/test_turso_platform.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the Turso Platform API client (ADR 0010 Phase C).
+
+NO real Turso and NO network: an ``httpx.MockTransport`` stands in for the
+Platform API so the client's *own* request shaping and response parsing are
+exercised against canned responses. The endpoints/payloads match the documented
+Turso Platform API (create database, mint token, destroy database).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+
+import pytest
+
+_HAS_HTTPX = importlib.util.find_spec("httpx") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_HTTPX, reason="requires the optional httpx client")
+
+if _HAS_HTTPX:
+    import httpx
+    from neurodock_state.turso_platform import (
+        DatabaseInfo,
+        HttpxTursoPlatformClient,
+        TursoPlatformError,
+    )
+
+_ORG = "acme"
+_TOKEN = "platform-secret"
+
+
+def _client(handler) -> HttpxTursoPlatformClient:  # type: ignore[no-untyped-def]
+    return HttpxTursoPlatformClient(
+        organization=_ORG,
+        platform_token=_TOKEN,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def test_requires_org_and_token() -> None:
+    with pytest.raises(TursoPlatformError):
+        HttpxTursoPlatformClient(organization="  ", platform_token=_TOKEN)
+    with pytest.raises(TursoPlatformError):
+        HttpxTursoPlatformClient(organization=_ORG, platform_token="  ")
+
+
+def test_create_database_posts_name_and_group_and_returns_info() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("authorization")
+        seen["body"] = json.loads(request.read().decode())
+        return httpx.Response(
+            200,
+            json={"database": {"Name": "nd-x", "Hostname": "nd-x-acme.turso.io"}},
+        )
+
+    info = _client(handler).create_database("nd-x", "default")
+
+    assert seen["method"] == "POST"
+    assert seen["url"] == "https://api.turso.tech/v1/organizations/acme/databases"
+    assert seen["auth"] == "Bearer platform-secret"
+    assert seen["body"] == {"name": "nd-x", "group": "default"}
+    assert info == DatabaseInfo(name="nd-x", hostname="nd-x-acme.turso.io")
+    assert info.url == "libsql://nd-x-acme.turso.io"
+
+
+def test_create_database_treats_conflict_as_idempotent_success() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, json={"error": "database already exists"})
+
+    info = _client(handler).create_database("nd-x", "default")
+
+    # 409 → reuse the existing DB, host resolved from the org/name convention.
+    assert info == DatabaseInfo(name="nd-x", hostname="nd-x-acme.turso.io")
+
+
+def test_create_database_falls_back_to_conventional_hostname() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Response omits a usable Hostname.
+        return httpx.Response(200, json={"database": {"Name": "nd-x"}})
+
+    info = _client(handler).create_database("nd-x", "default")
+    assert info.hostname == "nd-x-acme.turso.io"
+
+
+def test_create_database_raises_on_server_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": "group not found"})
+
+    with pytest.raises(TursoPlatformError) as exc:
+        _client(handler).create_database("nd-x", "missing")
+    assert exc.value.status == 400
+
+
+def test_create_token_returns_jwt() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["url"] = str(request.url)
+        return httpx.Response(200, json={"jwt": "minted-token"})
+
+    token = _client(handler).create_token("nd-x")
+
+    assert token == "minted-token"
+    assert seen["method"] == "POST"
+    assert seen["url"] == "https://api.turso.tech/v1/organizations/acme/databases/nd-x/auth/tokens"
+
+
+def test_create_token_raises_when_jwt_missing() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"not_jwt": "x"})
+
+    with pytest.raises(TursoPlatformError):
+        _client(handler).create_token("nd-x")
+
+
+def test_destroy_database_issues_delete() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["url"] = str(request.url)
+        return httpx.Response(200, json={"database": "nd-x"})
+
+    _client(handler).destroy_database("nd-x")
+
+    assert seen["method"] == "DELETE"
+    assert seen["url"] == "https://api.turso.tech/v1/organizations/acme/databases/nd-x"
+
+
+def test_destroy_database_treats_404_as_idempotent() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": "record not found"})
+
+    # No raise: erase is idempotent even if the DB is already gone.
+    _client(handler).destroy_database("nd-x")

--- a/packages/remote/Dockerfile
+++ b/packages/remote/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 # NeuroDock remote MCP server — the stateless tool surface (ADR 0008/0009) plus the
-# opt-in BYOS memory surface (ADR 0010 Phase D). Anonymous/non-opted-in sessions stay
-# fully stateless; opted-in users' data lives in their OWN database, not on NeuroDock.
+# opt-in memory surface (ADR 0010 Phases C/D). Anonymous/non-opted-in sessions stay
+# fully stateless; opted-in users' data lives either in a NeuroDock-provisioned
+# per-user Turso database (hosted) or in their OWN database (BYOS).
 #
 # Build from the REPO ROOT (the workspace graph must be visible):
 #   docker build -f packages/remote/Dockerfile -t neurodock-remote .
@@ -24,12 +25,13 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
 COPY packages/ ./packages/
 
-# Install neurodock-remote and its workspace dependencies. As of ADR 0010 Phase D
-# this includes neurodock-state[clerk] and neurodock-mcp-cognitive-graph[libsql]
-# (the opt-in BYOS surface). The chronometric server and task-fractionator
-# `next_one` remain stdio-only and are NOT installed. The cognitive-graph's heavy
-# fastembed dependency is never *loaded* at runtime because embeddings are
-# disabled below — the import is short-circuited by NEURODOCK_GRAPH_DISABLE_EMBEDDINGS.
+# Install neurodock-remote and its workspace dependencies. As of ADR 0010 Phases
+# C/D this includes neurodock-state[clerk] (Clerk Backend SDK + cryptography +
+# httpx for the Turso Platform API) and neurodock-mcp-cognitive-graph[libsql] (the
+# opt-in memory surface). The chronometric server and task-fractionator `next_one`
+# remain stdio-only and are NOT installed. The cognitive-graph's heavy fastembed
+# dependency is never *loaded* at runtime because embeddings are disabled below —
+# the import is short-circuited by NEURODOCK_GRAPH_DISABLE_EMBEDDINGS.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --package neurodock-remote
 

--- a/packages/remote/README.md
+++ b/packages/remote/README.md
@@ -12,13 +12,46 @@ the remote-safe tools:
 | `mcp-guardrail`         | `check_rumination`, `check_hyperfocus`, `check_sycophancy`              |
 | `mcp-task-fractionator` | `decompose` only                                                        |
 
+### Opt-in storage surface (ADR 0010 Phases C/D)
+
+The four cognitive-graph tools (`recall_entity`, `record_fact`,
+`recall_decisions`, `weekly_rollup`) are also exposed, but **gated**: they require
+a signed-in account that has **explicitly enabled** storage. Two modes coexist; a
+user is in exactly one at a time:
+
+| Tool                        | Mode   | What it does                                                                                                                                    |
+| --------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enable_hosted_storage`     | hosted | NeuroDock provisions a **private per-user Turso database** and stores facts there. Returns the consent disclosure.                              |
+| `connect_byos_storage`      | byos   | You point at your **own** libSQL/Turso database; NeuroDock stores only the connection pointer.                                                  |
+| `disable_and_erase_storage` | → none | Hosted: **destroys** your Turso database. BYOS: clears the stored connection (your DB untouched). Either way the preference/consent is cleared. |
+| `disconnect_storage`        | → none | BYOS-only alias: clears the connection + preference. (Use `disable_and_erase_storage` to erase hosted.)                                         |
+| `storage_status`            | —      | Reports your mode (`hosted` \| `byos` \| `none`).                                                                                               |
+
+The mode is selected per user from their recorded **storage preference**; a
+single combined resolver routes each cognitive-graph call to the hosted or BYOS
+backing. The privacy boundary is unchanged from Phase D: an anonymous / no-token
+caller gets `STORAGE_NOT_AVAILABLE` and **nothing is stored, read, or
+provisioned**; a signed-in but not-enabled caller gets `STORAGE_NOT_CONNECTED`.
+
+> **Hosted requires a provisioned Turso org/group/token.** Set
+> `NEURODOCK_TURSO_PLATFORM_TOKEN` + `NEURODOCK_TURSO_ORG` (+ optional
+> `NEURODOCK_TURSO_GROUP`, default `default`, which must already exist in the
+> org). Without them `enable_hosted_storage` is refused and only BYOS is offered.
+
+> **Encryption-key custody (honest limitation).** Both the BYOS auth token and the
+> hosted Turso DB token are encrypted at rest with a single operator-wide
+> `NEURODOCK_STATE_MASTER_KEY`. That means NeuroDock can _technically_ decrypt a
+> stored token. This is the documented ADR 0010 open question; per-user / envelope
+> keys (so the operator cannot unilaterally read a user's DB token) are a tracked
+> follow-up. The on-disk format is unchanged either way, so a future scheme can
+> re-wrap without a data migration.
+
 ### What is deliberately NOT here
 
-The cognitive graph (personal facts), chronometric session state, the user
-profile (neurotype data), and task-fractionator's `next_one` (reads the local
-graph) are **never** mounted. They read or hold local state and stay strictly on
-the local stdio install. The boundary is enforced in code and pinned by tests
-against `REMOTE_TOOL_NAMES`.
+Chronometric session state, the user profile (neurotype data), and
+task-fractionator's `next_one` (reads the local graph) are **never** mounted. They
+hold local state and stay strictly on the local stdio install. The boundary is
+enforced in code and pinned by tests against `REMOTE_TOOL_NAMES`.
 
 > This is a **deploy artifact**, not a published package — it is not uploaded to
 > PyPI (the local install path via `@neurodock/cli` is unchanged). Local-only
@@ -46,9 +79,12 @@ Inspect it with the MCP Inspector pointed at `http://127.0.0.1:8000/mcp`.
 | `NEURODOCK_CLERK_DOMAIN`                             | —           | `clerk`: your Clerk instance domain (e.g. `your-app.clerk.accounts.dev`).               |
 | `NEURODOCK_CLERK_CLIENT_ID`                          | —           | `clerk`: OAuth application client ID.                                                   |
 | `NEURODOCK_CLERK_CLIENT_SECRET`                      | —           | `clerk`: OAuth client secret (set as a secret, not plaintext).                          |
-| `NEURODOCK_CLERK_SECRET_KEY`                         | —           | BYOS (ADR 0010 D): Clerk Backend API key; persists the per-user connection pointer.     |
-| `NEURODOCK_STATE_MASTER_KEY`                         | —           | BYOS (ADR 0010 D): master key that encrypts the BYOS auth token at rest.                |
-| `NEURODOCK_GRAPH_DISABLE_EMBEDDINGS`                 | `1` (image) | BYOS: keeps the hosted graph lean (no fastembed). Set in the Dockerfile.                |
+| `NEURODOCK_CLERK_SECRET_KEY`                         | —           | Storage (ADR 0010 C/D): Clerk Backend API key; persists the per-user storage pointer.   |
+| `NEURODOCK_STATE_MASTER_KEY`                         | —           | Storage (ADR 0010 C/D): master key that encrypts the BYOS/hosted DB token at rest.      |
+| `NEURODOCK_TURSO_PLATFORM_TOKEN`                     | —           | Hosted (ADR 0010 C): Turso Platform API token; provisions/destroys per-user databases.  |
+| `NEURODOCK_TURSO_ORG`                                | —           | Hosted (ADR 0010 C): Turso organization slug the hosted databases are created in.       |
+| `NEURODOCK_TURSO_GROUP`                              | `default`   | Hosted (ADR 0010 C): Turso group the hosted databases are created in (must exist).      |
+| `NEURODOCK_GRAPH_DISABLE_EMBEDDINGS`                 | `1` (image) | Storage: keeps the hosted graph lean (no fastembed). Set in the Dockerfile.             |
 | `NEURODOCK_AUTHKIT_DOMAIN`                           | —           | `workos`: your AuthKit domain.                                                          |
 | `NEURODOCK_OAUTH_ISSUER` / `_JWKS_URI` / `_AUDIENCE` | —           | `jwt`: generic OIDC resource-server config.                                             |
 
@@ -90,10 +126,14 @@ fronted by a thin Worker ([worker/index.ts](worker/index.ts)) that owns the
    ```bash
    npm install
    npx wrangler secret put NEURODOCK_CLERK_CLIENT_SECRET   # paste the secret
-   # Optional — enable the opt-in BYOS memory tools (ADR 0010 Phase D). Without
-   # these two the tools stay visible but un-backed (sign-in/connect refusal):
+   # Optional — enable the opt-in memory tools (ADR 0010 C/D). Without the next
+   # two the tools stay visible but un-backed (sign-in/enable refusal):
    npx wrangler secret put NEURODOCK_CLERK_SECRET_KEY      # Clerk Backend API key
    npx wrangler secret put NEURODOCK_STATE_MASTER_KEY      # token-encryption master key
+   # Optional — enable NeuroDock-hosted storage (ADR 0010 C). Also set
+   # NEURODOCK_TURSO_ORG (and NEURODOCK_TURSO_GROUP) in wrangler.jsonc `vars`.
+   # Without the token + org, enable_hosted_storage is refused; BYOS still works:
+   npx wrangler secret put NEURODOCK_TURSO_PLATFORM_TOKEN  # Turso Platform API token
    npx wrangler deploy                                     # builds ../Dockerfile, pushes, deploys
    ```
 

--- a/packages/remote/src/neurodock_remote/app.py
+++ b/packages/remote/src/neurodock_remote/app.py
@@ -1,24 +1,27 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 NeuroDock contributors.
-"""Combined remote MCP server (ADR 0008/0009 + ADR 0010 Phase D).
+"""Combined remote MCP server (ADR 0008/0009 + ADR 0010 Phases C + D).
 
 Composes the three STATELESS NeuroDock servers into a single Streamable HTTP
-endpoint, and (ADR 0010 Phase D) adds the OPT-IN BYOS surface:
+endpoint, and (ADR 0010 Phases C/D) adds the OPT-IN storage surface:
 
     translation        : translate_incoming, check_tone, rewrite_outgoing, brief_meeting
     guardrail          : check_rumination, check_hyperfocus, check_sycophancy
     task-fractionator  : decompose            (next_one is stdio/local only)
-    storage-admin      : connect_byos_storage, disconnect_storage, storage_status
+    storage-admin      : enable_hosted_storage, connect_byos_storage,
+                         disable_and_erase_storage, disconnect_storage, storage_status
     cognitive-graph    : recall_entity, record_fact, recall_decisions, weekly_rollup
 
 The stateless surface (:data:`STATELESS_TOOL_NAMES`) is ALWAYS present and
 unchanged. The opt-in surface (:data:`OPT_IN_TOOL_NAMES`) is *visible* to every
-client, but every cognitive-graph call routes through the per-user BYOS seam:
+client, but every cognitive-graph call routes through the per-user combined seam
+(hosted OR byos, by the user's recorded preference):
 
 - an anonymous / no-token caller gets ``STORAGE_NOT_AVAILABLE`` and nothing is
-  stored or read;
-- a signed-in but not-connected caller gets ``STORAGE_NOT_CONNECTED``;
-- a connected caller's data lives in THEIR OWN libSQL/Turso database — NeuroDock
+  stored, read, or provisioned;
+- a signed-in but storage-not-enabled caller gets ``STORAGE_NOT_CONNECTED``;
+- a hosted caller's data lives in a NeuroDock-provisioned per-user Turso database;
+- a BYOS caller's data lives in THEIR OWN libSQL/Turso database — NeuroDock
   persists nothing beyond the connection pointer.
 
 This privacy boundary is the point of the phase: anonymous and non-opted-in
@@ -50,7 +53,13 @@ from starlette.responses import JSONResponse
 
 from neurodock_remote.auth import build_auth_provider
 from neurodock_remote.prompts import register_prompts
-from neurodock_remote.state import ByosState, build_connection_store
+from neurodock_remote.state import (
+    ByosState,
+    build_connection_store,
+    build_preference_store,
+    build_turso_platform,
+    turso_group,
+)
 from neurodock_remote.tools.graph import register_graph_tools
 from neurodock_remote.tools.storage_admin import register_storage_admin_tools
 from neurodock_remote.transport import resolve_bind
@@ -77,16 +86,19 @@ STATELESS_TOOL_NAMES = frozenset(
     }
 )
 
-# The opt-in BYOS surface (ADR 0010 Phase D). These tools are visible to every
-# client, but storing/reading anything requires a signed-in account + connected
-# storage; the privacy boundary is enforced in the store-provider seam.
+# The opt-in storage surface (ADR 0010 Phases C/D). These tools are visible to
+# every client, but storing/reading anything requires a signed-in account + an
+# enabled storage mode (hosted or byos); the privacy boundary is enforced in the
+# store-provider seam.
 OPT_IN_TOOL_NAMES = frozenset(
     {
-        # storage-admin (hosted-only)
+        # storage-admin (hosted-only management surface)
+        "enable_hosted_storage",
         "connect_byos_storage",
+        "disable_and_erase_storage",
         "disconnect_storage",
         "storage_status",
-        # cognitive-graph (routed to the caller's own BYOS database)
+        # cognitive-graph (routed to the caller's hosted OR own BYOS database)
         "recall_entity",
         "record_fact",
         "recall_decisions",
@@ -102,28 +114,38 @@ _INSTRUCTIONS = (
     "messages and shapes outgoing ones; guardrail flags rumination, hyperfocus, and "
     "over-validation; decompose breaks a vague goal into atomic tasks — needs no "
     "account. The opt-in memory surface (recall_entity, record_fact, "
-    "recall_decisions, weekly_rollup) requires a signed-in account that has "
-    "connected its OWN database via connect_byos_storage: your graph data lives in "
-    "your database, never on NeuroDock. Anonymous sessions are fully stateless. "
-    "Session timing and the user profile are NOT available here — they live on the "
-    "local install."
+    "recall_decisions, weekly_rollup) requires a signed-in account that has enabled "
+    "storage: either NeuroDock-hosted (enable_hosted_storage provisions a private "
+    "per-user database) or bring-your-own (connect_byos_storage points at your OWN "
+    "database). Erase everything with disable_and_erase_storage. Anonymous sessions "
+    "are fully stateless and store nothing. Session timing and the user profile are "
+    "NOT available here — they live on the local install."
 )
 
 _LOG = logging.getLogger("neurodock_remote.app")
 
 
-def build_combined_server(connections: Any | None = None) -> FastMCP[Any]:
-    """Compose the stateless servers + opt-in BYOS surface into one MCP server.
+def build_combined_server(
+    connections: Any | None = None,
+    *,
+    preferences: Any | None = None,
+    platform: Any | None = None,
+) -> FastMCP[Any]:
+    """Compose the stateless servers + opt-in storage surface into one MCP server.
 
     ``mount`` (no namespace) keeps the original flat tool names, so the combined
     endpoint presents the same tool names the local servers do.
 
     ``connections`` is the per-user BYOS connection store
-    (:class:`~neurodock_state.byos_connection_store.ByosConnectionStore`). Tests
-    inject an in-memory store; in production it is built from the environment
-    (Clerk-metadata-backed). When ``None`` and no secrets are configured, the
-    opt-in tools are still registered but every storage operation returns the
-    structured "sign in / connect storage" refusal — nothing is ever stored.
+    (:class:`~neurodock_state.byos_connection_store.ByosConnectionStore`).
+    ``preferences`` is the per-user storage-preference store (records which mode —
+    hosted/byos/none — each user chose). ``platform`` is the Turso Platform client
+    used to provision hosted databases. Tests inject in-memory stores and a fake
+    platform client; in production all three are built from the environment.
+
+    When the secrets are absent, the opt-in tools are still registered but every
+    storage operation returns the structured refusal — nothing is ever stored or
+    provisioned — and hosted enablement reports that hosting is not configured.
     """
     combined: FastMCP[Any] = FastMCP(
         name=SERVER_NAME,
@@ -142,8 +164,8 @@ def build_combined_server(connections: Any | None = None) -> FastMCP[Any]:
     # guide the model to the matching hosted tool. No personal data.
     register_prompts(combined)
 
-    # Opt-in BYOS surface (ADR 0010 Phase D). The connection store may be missing
-    # (no secrets configured); the ByosState still answers every call with the
+    # Opt-in storage surface (ADR 0010 Phases C/D). The stores may be missing (no
+    # secrets configured); the ByosState still answers every call with the
     # structured refusal, so the privacy boundary holds with or without a backing.
     resolved_connections = (
         connections if connections is not None else build_connection_store(os.environ)
@@ -156,11 +178,29 @@ def build_combined_server(connections: Any | None = None) -> FastMCP[Any]:
         # so this stays empty in practice; it exists only so the tools register.
         resolved_connections = InMemoryByosConnectionStore()
         _LOG.warning(
-            "byos_storage_unbacked: no NEURODOCK_CLERK_SECRET_KEY/"
+            "storage_unbacked: no NEURODOCK_CLERK_SECRET_KEY/"
             "NEURODOCK_STATE_MASTER_KEY — opt-in tools are visible but cannot "
-            "persist; every call returns the sign-in/connect refusal (ADR 0010 §4)"
+            "persist; every call returns the sign-in/enable refusal (ADR 0010 §4)"
         )
-    state = ByosState(resolved_connections)
+
+    resolved_preferences = (
+        preferences if preferences is not None else build_preference_store(os.environ)
+    )
+    # Hosted provisioning is available only when the Turso platform secrets are
+    # set. Without them, enable_hosted_storage refuses up front; BYOS still works.
+    resolved_platform = platform if platform is not None else build_turso_platform(os.environ)
+    if resolved_platform is None:
+        _LOG.warning(
+            "hosted_storage_unconfigured: no NEURODOCK_TURSO_PLATFORM_TOKEN/"
+            "NEURODOCK_TURSO_ORG — enable_hosted_storage is refused; BYOS unaffected"
+        )
+
+    state = ByosState(
+        resolved_connections,
+        preferences=resolved_preferences,
+        platform=resolved_platform,
+        turso_group=turso_group(os.environ),
+    )
     register_storage_admin_tools(combined, state)
     register_graph_tools(combined, state)
 

--- a/packages/remote/src/neurodock_remote/state.py
+++ b/packages/remote/src/neurodock_remote/state.py
@@ -1,26 +1,33 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 NeuroDock contributors.
-"""Per-user BYOS state wiring for the hosted server (ADR 0010 Phase D).
+"""Per-user storage wiring for the hosted server (ADR 0010 Phases C + D).
 
 This module is the bridge between the stateless remote transport and the opt-in
-BYOS storage. It owns three concerns:
+storage. Two storage modes coexist behind a single combined resolver:
 
-1. **Construction** of the connection store + resolver from the environment.
-   On the hosted path the connection store is the Clerk-metadata-backed store;
-   tests inject :class:`InMemoryByosConnectionStore` directly.
+- **hosted** (Phase C) — a NeuroDock-provisioned Turso database per user; and
+- **byos**   (Phase D) — the user's own libSQL/Turso connection.
+
+It owns three concerns:
+
+1. **Construction** of the preference store, BYOS connection store, the Turso
+   platform client, and the resolvers from the environment. On the hosted path
+   the stores are Clerk-metadata-backed; tests inject in-memory stores and a fake
+   platform client directly.
 2. **The structured errors** returned to anonymous and non-opted-in callers. The
    security boundary lives here: these responses are produced WITHOUT touching
-   any store, so a session that has not opted in stores — and reads — nothing.
-3. **The store provider** handed to the cognitive-graph ``build_app`` seam. It
-   resolves the *caller's own* libSQL store at call time, or raises a structured
-   refusal that the tool layer surfaces verbatim.
+   any store or provisioning anything, so a session that has not opted in stores
+   — and reads — nothing.
+3. **The store provider** handed to the cognitive-graph tool seam. It resolves
+   the caller's store (hosted OR byos, by their recorded preference) at call
+   time, or raises a structured refusal that the tool layer surfaces verbatim.
 
 Error codes (stable; clients may branch on them):
 
 - ``STORAGE_NOT_AVAILABLE`` — no authenticated NeuroDock user. The tool needs an
-  account + connected storage.
-- ``STORAGE_NOT_CONNECTED`` — authenticated, but no BYOS database connected yet.
-  The caller should run ``connect_byos_storage`` first.
+  account + enabled storage.
+- ``STORAGE_NOT_CONNECTED`` — authenticated, but no storage enabled yet. The
+  caller should run ``enable_hosted_storage`` or ``connect_byos_storage`` first.
 """
 
 from __future__ import annotations
@@ -30,11 +37,15 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from neurodock_state.byos_resolver import ByosResolver
+from neurodock_state.combined_resolver import CombinedResolver
+from neurodock_state.hosted_resolver import HostedTursoResolver
 from neurodock_state.identity import UserKey, user_key_from_context
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from neurodock_state.byos_connection_store import ByosConnectionStore
     from neurodock_state.registry import GraphStore
+    from neurodock_state.storage_preference_store import StoragePreferenceStore
+    from neurodock_state.turso_platform import TursoPlatformClient
 
 # -- structured refusals --------------------------------------------------
 
@@ -42,19 +53,21 @@ STORAGE_NOT_AVAILABLE = "STORAGE_NOT_AVAILABLE"
 STORAGE_NOT_CONNECTED = "STORAGE_NOT_CONNECTED"
 
 _NOT_AVAILABLE_MESSAGE = (
-    "This tool needs a NeuroDock account and connected storage. "
-    "Sign in to the hosted server, then connect your own database with "
+    "This tool needs a NeuroDock account and enabled storage. "
+    "Sign in to the hosted server, then enable hosted storage with "
+    "enable_hosted_storage, or connect your own database with "
     "connect_byos_storage. NeuroDock stores nothing for anonymous sessions."
 )
 _NOT_CONNECTED_MESSAGE = (
-    "You are signed in but have not connected a storage database yet. "
-    "Call connect_byos_storage with your libSQL/Turso URL (and auth token) to "
-    "enable this tool. Your graph data lives in your database, never on NeuroDock."
+    "You are signed in but have not enabled storage yet. Call "
+    "enable_hosted_storage to let NeuroDock provision a private database for you, "
+    "or connect_byos_storage with your own libSQL/Turso URL. Either way your "
+    "graph data is isolated to you; anonymous sessions store nothing."
 )
 
 
 class StorageUnavailableError(Exception):
-    """The caller has no NeuroDock account: the stateful tools are not available.
+    """The caller cannot use the stateful tools (anonymous, or no storage enabled).
 
     Carries a stable ``code`` and a caller-facing ``message``. The tool layer
     converts this into a structured payload — it is never a crash, matching the
@@ -75,36 +88,87 @@ class StorageStatus:
     """A read-only view of the caller's storage posture."""
 
     authenticated: bool
-    mode: str  # "byos" | "none"
+    mode: str  # "hosted" | "byos" | "none"
     connected: bool
 
 
-# -- the BYOS state container --------------------------------------------
+# -- the storage state container -----------------------------------------
 
 
 class ByosState:
-    """Resolves the caller's BYOS backing and enforces the privacy boundary.
+    """Resolves the caller's storage backing and enforces the privacy boundary.
 
-    Holds the connection store and a :class:`ByosResolver` over it. Every method
-    derives the caller from the FastMCP request context (the validated token),
-    so identity can never be spoofed by a tool argument.
+    Despite the historical name (kept so the Phase D wiring and tests are
+    untouched), this now coordinates BOTH storage modes: it holds the preference
+    store, the BYOS connection store, an optional hosted Turso resolver, and a
+    :class:`CombinedResolver` that routes each call to the user's chosen backing.
+
+    Every method derives the caller from the FastMCP request context (the
+    validated token), so identity can never be spoofed by a tool argument.
     """
 
-    def __init__(self, connections: ByosConnectionStore) -> None:
+    def __init__(
+        self,
+        connections: ByosConnectionStore,
+        *,
+        preferences: StoragePreferenceStore | None = None,
+        platform: TursoPlatformClient | None = None,
+        turso_group: str = "default",
+    ) -> None:
+        from neurodock_state.storage_preference_store import InMemoryStoragePreferenceStore
+
         self._connections = connections
-        self._resolver = ByosResolver(connections)
+        # NB: explicit `is None` — an empty in-memory preference store is falsy
+        # (its __len__ is 0), so `preferences or ...` would silently drop it.
+        self._preferences: StoragePreferenceStore = (
+            preferences if preferences is not None else InMemoryStoragePreferenceStore()
+        )
+        self._byos = ByosResolver(connections)
+        # Hosted is only available when a platform client is wired in. When it is
+        # absent (no Turso secrets configured) we still build a resolver so the
+        # combined router has a target, but provisioning will fail loudly if ever
+        # reached — which it cannot be without a recorded hosted preference, and
+        # enabling hosted storage is refused up front when the platform is absent.
+        self._platform = platform
+        self._hosted = HostedTursoResolver(
+            platform=platform or _UnavailablePlatform(),
+            preferences=self._preferences,
+            group=turso_group,
+        )
+        self._combined = CombinedResolver(
+            preferences=self._preferences,
+            hosted=self._hosted,
+            byos=self._byos,
+        )
+
+    # -- accessors used by the admin tools -------------------------------
 
     @property
     def connections(self) -> ByosConnectionStore:
         return self._connections
+
+    @property
+    def preferences(self) -> StoragePreferenceStore:
+        return self._preferences
+
+    @property
+    def hosted(self) -> HostedTursoResolver:
+        return self._hosted
+
+    @property
+    def hosted_available(self) -> bool:
+        """Whether NeuroDock-hosted provisioning is configured (Turso wired in)."""
+        return self._platform is not None
+
+    # -- the choke point --------------------------------------------------
 
     def require_user(self) -> UserKey:
         """Return the authenticated caller, or raise :class:`StorageUnavailableError`.
 
         This is the single choke point for "is there a NeuroDock account?". It
         reads the validated access token from the request context and never
-        touches a store, so an anonymous caller is refused before any state is
-        consulted.
+        touches a store or provisions anything, so an anonymous caller is refused
+        before any state is consulted. UNCHANGED from Phase D.
         """
         user = user_key_from_context()
         if user is None:
@@ -116,37 +180,61 @@ class ByosState:
         user = user_key_from_context()
         if user is None:
             return StorageStatus(authenticated=False, mode="none", connected=False)
-        mode = self._resolver.storage_mode(user)
-        return StorageStatus(authenticated=True, mode=mode, connected=mode == "byos")
+        mode = self._combined.storage_mode(user)
+        return StorageStatus(authenticated=True, mode=mode, connected=mode != "none")
 
     def graph_store(self) -> GraphStore:
-        """Resolve the caller's own cognitive-graph store, or raise a refusal.
-
-        The provider semantics ADR 0010 Phase D requires:
+        """Resolve the caller's cognitive-graph store, or raise a refusal.
 
         - no authenticated user → :class:`StorageUnavailableError`
-          (``STORAGE_NOT_AVAILABLE``), WITHOUT touching any store;
-        - authenticated but not connected → :class:`StorageUnavailableError`
+          (``STORAGE_NOT_AVAILABLE``), WITHOUT touching any store or provisioning;
+        - authenticated but no storage enabled → :class:`StorageUnavailableError`
           (``STORAGE_NOT_CONNECTED``);
-        - otherwise → the user's libSQL store, freshly resolved and initialised.
+        - otherwise → the user's store (hosted OR byos by their preference),
+          freshly resolved and initialised.
         """
         user = self.require_user()
-        if self._resolver.storage_mode(user) == "none":
+        if self._combined.storage_mode(user) == "none":
             raise StorageUnavailableError(STORAGE_NOT_CONNECTED, _NOT_CONNECTED_MESSAGE)
-        store = self._resolver.graph_store(user)
+        store = self._combined.graph_store(user)
         # Initialise (idempotent migrations) so the first call against a freshly
-        # connected DB just works. Cheap on an already-migrated database.
+        # enabled DB just works. Cheap on an already-migrated database.
         store.initialise()
         return store
 
 
-def build_connection_store(env: Mapping[str, str]) -> ByosConnectionStore | None:
-    """Build the production connection store from the environment, or ``None``.
+class _UnavailablePlatform:
+    """Placeholder :class:`TursoPlatformClient` used when hosting is not configured.
 
-    Returns the Clerk-metadata-backed store when its required secrets are
-    present; returns ``None`` (BYOS disabled) when they are not, so a bare local
-    run without secrets simply does not offer storage rather than crashing. The
-    Clerk SDK and crypto are imported lazily inside the store.
+    Any attempt to actually provision/destroy raises, but it can never be reached
+    without a recorded hosted preference, and ``enable_hosted_storage`` refuses up
+    front when :attr:`ByosState.hosted_available` is false — so this only guards
+    the invariant, it is not an expected runtime path.
+    """
+
+    def _unavailable(self) -> RuntimeError:
+        return RuntimeError(
+            "hosted Turso storage is not configured on this server "
+            "(set NEURODOCK_TURSO_PLATFORM_TOKEN / _ORG / _GROUP)"
+        )
+
+    def create_database(self, name: str, group: str):  # type: ignore[no-untyped-def]
+        raise self._unavailable()
+
+    def create_token(self, name: str) -> str:
+        raise self._unavailable()
+
+    def destroy_database(self, name: str) -> None:
+        raise self._unavailable()
+
+
+def build_connection_store(env: Mapping[str, str]) -> ByosConnectionStore | None:
+    """Build the production BYOS connection store from the environment, or ``None``.
+
+    Returns the Clerk-metadata-backed store when its required secrets are present;
+    returns ``None`` (BYOS disabled) when they are not, so a bare local run without
+    secrets simply does not offer storage rather than crashing. UNCHANGED from
+    Phase D.
     """
     has_clerk_secret = bool(env.get("NEURODOCK_CLERK_SECRET_KEY", "").strip())
     has_master_key = bool(env.get("NEURODOCK_STATE_MASTER_KEY", "").strip())
@@ -154,7 +242,49 @@ def build_connection_store(env: Mapping[str, str]) -> ByosConnectionStore | None
         return None
     from neurodock_state.clerk_byos_store import ClerkMetadataByosStore
 
-    # ClerkMetadataByosStore structurally satisfies ByosConnectionStore; mypy
-    # verifies the protocol conformance on this annotated assignment.
     store: ByosConnectionStore = ClerkMetadataByosStore(env)
     return store
+
+
+def build_preference_store(env: Mapping[str, str]) -> StoragePreferenceStore | None:
+    """Build the production storage-preference store from the environment, or ``None``.
+
+    Requires the same two secrets as the BYOS store (Clerk Backend API key +
+    master key); returns ``None`` when they are absent. The preference store
+    records which mode each user chose and (for hosted) the encrypted DB token.
+    """
+    has_clerk_secret = bool(env.get("NEURODOCK_CLERK_SECRET_KEY", "").strip())
+    has_master_key = bool(env.get("NEURODOCK_STATE_MASTER_KEY", "").strip())
+    if not (has_clerk_secret and has_master_key):
+        return None
+    from neurodock_state.storage_preference_store import ClerkMetadataPreferenceStore
+
+    store: StoragePreferenceStore = ClerkMetadataPreferenceStore(env)
+    return store
+
+
+def build_turso_platform(env: Mapping[str, str]) -> TursoPlatformClient | None:
+    """Build the Turso Platform client from the environment, or ``None``.
+
+    Returns a real :class:`HttpxTursoPlatformClient` when the platform token and
+    organisation slug are present; returns ``None`` when they are not, so hosted
+    provisioning is simply unavailable (``enable_hosted_storage`` refuses) rather
+    than crashing. The group defaults to ``"default"`` and can be overridden with
+    ``NEURODOCK_TURSO_GROUP``.
+    """
+    token = env.get("NEURODOCK_TURSO_PLATFORM_TOKEN", "").strip()
+    org = env.get("NEURODOCK_TURSO_ORG", "").strip()
+    if not (token and org):
+        return None
+    from neurodock_state.turso_platform import HttpxTursoPlatformClient
+
+    client: TursoPlatformClient = HttpxTursoPlatformClient(
+        organization=org,
+        platform_token=token,
+    )
+    return client
+
+
+def turso_group(env: Mapping[str, str]) -> str:
+    """Return the configured Turso group for provisioned databases."""
+    return env.get("NEURODOCK_TURSO_GROUP", "").strip() or "default"

--- a/packages/remote/src/neurodock_remote/tools/storage_admin.py
+++ b/packages/remote/src/neurodock_remote/tools/storage_admin.py
@@ -1,31 +1,40 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 NeuroDock contributors.
-"""Storage-admin tools for the hosted server (ADR 0010 Phase D).
+"""Storage-admin tools for the hosted server (ADR 0010 Phases C + D).
 
-Three tools let an authenticated user manage their own BYOS connection:
+An authenticated user manages their own storage through these tools. Two modes
+coexist; a user is in exactly one at a time, recorded in their storage preference:
 
-- ``connect_byos_storage(libsql_url, auth_token=None)`` — validate the URL,
-  smoke-test a connect+migrate against it, then persist the connection. Only a
-  database that actually accepts the schema is ever stored, so a user can never
-  end up with a "connected" pointer to a broken endpoint.
-- ``disconnect_storage()`` — delete the stored connection. NeuroDock then
-  retains nothing about the user's storage.
-- ``storage_status()`` — report the caller's mode and whether they are connected.
+- ``enable_hosted_storage()`` (Phase C) — capture explicit consent, set
+  mode="hosted", and have NeuroDock provision a private Turso database for the
+  user. Returns the disclosure text. Idempotent: re-enabling reuses the database.
+- ``connect_byos_storage(libsql_url, auth_token=None)`` (Phase D) — validate the
+  URL, smoke-test a connect+migrate, persist the connection, and set mode="byos".
+  Only a database that actually accepts the schema is ever stored.
+- ``disable_and_erase_storage()`` — hosted → destroy the user's Turso database;
+  byos → clear the stored connection. Either way the storage preference/consent
+  is cleared, so NeuroDock retains nothing.
+- ``disconnect_storage()`` — alias kept for Phase D compatibility: clears the
+  BYOS connection and preference (does NOT destroy a hosted DB; that is
+  ``disable_and_erase_storage``).
+- ``storage_status()`` — report the caller's mode (hosted | byos | none) and
+  whether storage is enabled.
 
-All three require an authenticated user. An anonymous caller receives the
-structured ``STORAGE_NOT_AVAILABLE`` refusal and nothing is stored or read.
+All require an authenticated user. An anonymous caller receives the structured
+``STORAGE_NOT_AVAILABLE`` refusal and nothing is stored, read, or provisioned.
 
-URL validation
---------------
+URL validation (BYOS)
+---------------------
 Only ``libsql://``, ``https://``, and ``file:`` URLs are accepted. ``file:`` is
-allowed for self-hosted / embedded single-user deployments and for tests; the
-hosted multi-tenant deployment will in practice receive ``libsql://`` Turso URLs.
+allowed for self-hosted / embedded single-user deployments and for tests.
 """
 
 from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any
+
+from neurodock_state.storage_preference_store import StoragePreference
 
 from neurodock_remote.state import ByosState, StorageUnavailableError
 
@@ -41,14 +50,25 @@ _ALLOWED_SCHEMES = ("libsql://", "https://", "file:")
 
 INVALID_URL = "INVALID_STORAGE_URL"
 CONNECT_FAILED = "STORAGE_CONNECT_FAILED"
+HOSTED_UNAVAILABLE = "HOSTED_STORAGE_UNAVAILABLE"
+PROVISION_FAILED = "HOSTED_PROVISION_FAILED"
+
+# The consent disclosure surfaced when a user enables hosted storage. Keep in
+# step with HostedTursoResolver.CONSENT_VERSION when the wording materially
+# changes.
+_HOSTED_DISCLOSURE = (
+    "You are enabling NeuroDock-hosted storage. NeuroDock will provision a "
+    "private database (isolated to your account) and store your cognitive-graph "
+    "facts there. The database auth token is encrypted at rest. Your data is "
+    "never aggregated with other users' and never used for analytics. You can "
+    "erase everything at any time with disable_and_erase_storage, which destroys "
+    "the database and clears your stored preference. For maximum privacy, prefer "
+    "connect_byos_storage (your own database) or the local install instead."
+)
 
 
 def _validate_url(libsql_url: Any) -> str:
-    """Return a trimmed, scheme-checked URL or raise a structured error payload.
-
-    Raises:
-        StorageUnavailableError: never (auth is checked by the caller).
-    """
+    """Return a trimmed, scheme-checked URL or raise a structured error payload."""
     if not isinstance(libsql_url, str) or not libsql_url.strip():
         raise _ToolInputError(
             INVALID_URL,
@@ -65,7 +85,7 @@ def _validate_url(libsql_url: Any) -> str:
 
 
 class _ToolInputError(Exception):
-    """Bad tool input. Converted to a structured payload by the tool wrapper."""
+    """Bad tool input / operation failure. Converted to a payload by the wrapper."""
 
     def __init__(self, code: str, message: str) -> None:
         super().__init__(f"{code}: {message}")
@@ -101,7 +121,50 @@ def _smoke_test_connection(url: str, auth_token: str | None) -> None:
 
 
 def register_storage_admin_tools(mcp: FastMCP[Any], state: ByosState) -> None:
-    """Register connect / disconnect / status on the combined server."""
+    """Register the storage-admin tools on the combined server."""
+
+    @mcp.tool(
+        name="enable_hosted_storage",
+        description=(
+            "Enable NeuroDock-hosted storage: NeuroDock provisions a private "
+            "database (isolated to your account) and the memory tools store data "
+            "there. Records your explicit consent and returns a disclosure of what "
+            "is stored and how to erase it. Requires a signed-in NeuroDock account. "
+            "For maximum privacy use connect_byos_storage (your own database) instead."
+        ),
+    )
+    def enable_hosted_storage() -> dict[str, Any]:
+        try:
+            user = state.require_user()
+            if not state.hosted_available:
+                raise _ToolInputError(
+                    HOSTED_UNAVAILABLE,
+                    "Hosted storage is not configured on this server. Use "
+                    "connect_byos_storage with your own database instead.",
+                )
+            try:
+                database = state.hosted.provision(user)
+            except Exception as exc:  # provisioning failure → structured payload
+                _LOG.exception("enable_hosted_storage provisioning failed")
+                raise _ToolInputError(
+                    PROVISION_FAILED,
+                    f"could not provision your hosted database: {exc}",
+                ) from exc
+        except StorageUnavailableError as exc:
+            return exc.to_payload()
+        except _ToolInputError as exc:
+            return exc.to_payload()
+        return {
+            "status": "enabled",
+            "mode": "hosted",
+            "database": database.name,
+            "disclosure": _HOSTED_DISCLOSURE,
+            "message": (
+                "Hosted storage enabled. Your memory tools now read and write a "
+                "private NeuroDock-managed database isolated to your account. "
+                "Run disable_and_erase_storage at any time to destroy it."
+            ),
+        }
 
     @mcp.tool(
         name="connect_byos_storage",
@@ -121,6 +184,8 @@ def register_storage_admin_tools(mcp: FastMCP[Any], state: ByosState) -> None:
             )
             _smoke_test_connection(url, token)
             state.connections.put(user, url, token)
+            # Record the active mode so the combined resolver routes to BYOS.
+            state.preferences.put(user, StoragePreference(mode="byos"))
         except StorageUnavailableError as exc:
             return exc.to_payload()
         except _ToolInputError as exc:
@@ -135,17 +200,59 @@ def register_storage_admin_tools(mcp: FastMCP[Any], state: ByosState) -> None:
         }
 
     @mcp.tool(
+        name="disable_and_erase_storage",
+        description=(
+            "Disable storage and erase it. Hosted: destroys the NeuroDock-managed "
+            "database NeuroDock provisioned for you. BYOS: clears the stored "
+            "connection (your own database is left untouched). Either way your "
+            "stored preference and consent are cleared. Requires a signed-in account."
+        ),
+    )
+    def disable_and_erase_storage() -> dict[str, Any]:
+        try:
+            user = state.require_user()
+            preference = state.preferences.get(user)
+            mode = preference.mode if preference is not None else "none"
+            if mode == "hosted":
+                try:
+                    state.hosted.erase(user)  # destroys the DB + clears preference
+                except Exception as exc:
+                    _LOG.exception("disable_and_erase_storage hosted erase failed")
+                    raise _ToolInputError(
+                        PROVISION_FAILED,
+                        f"could not destroy your hosted database: {exc}",
+                    ) from exc
+            else:
+                # BYOS or none: clear the connection (no-op if absent) and the
+                # preference. The user's own database is never touched.
+                state.connections.delete(user)
+                state.preferences.clear(user)
+        except StorageUnavailableError as exc:
+            return exc.to_payload()
+        except _ToolInputError as exc:
+            return exc.to_payload()
+        return {
+            "status": "erased",
+            "mode": "none",
+            "message": (
+                "Storage disabled and erased. NeuroDock now retains nothing about your storage."
+            ),
+        }
+
+    @mcp.tool(
         name="disconnect_storage",
         description=(
-            "Disconnect your storage database. NeuroDock deletes the connection and "
-            "retains nothing about your storage. Your data stays in your own database, "
-            "untouched. Requires a signed-in NeuroDock account."
+            "Disconnect your BYOS storage database. NeuroDock deletes the connection "
+            "and retains nothing about your storage. Your data stays in your own "
+            "database, untouched. (To erase NeuroDock-hosted storage instead, use "
+            "disable_and_erase_storage.) Requires a signed-in NeuroDock account."
         ),
     )
     def disconnect_storage() -> dict[str, Any]:
         try:
             user = state.require_user()
             state.connections.delete(user)
+            state.preferences.clear(user)
         except StorageUnavailableError as exc:
             return exc.to_payload()
         return {
@@ -160,8 +267,8 @@ def register_storage_admin_tools(mcp: FastMCP[Any], state: ByosState) -> None:
     @mcp.tool(
         name="storage_status",
         description=(
-            "Report whether you are signed in and whether a storage database is "
-            "connected (mode: byos or none)."
+            "Report whether you are signed in and which storage mode is active "
+            "(mode: hosted, byos, or none)."
         ),
     )
     def storage_status() -> dict[str, Any]:

--- a/packages/remote/tests/test_app.py
+++ b/packages/remote/tests/test_app.py
@@ -77,7 +77,9 @@ def test_opt_in_tools_are_present_in_the_listing() -> None:
     # The BYOS surface is visible (clients can discover it); access is gated at
     # call time, not by hiding the tools.
     assert OPT_IN_TOOL_NAMES == {
+        "enable_hosted_storage",
         "connect_byos_storage",
+        "disable_and_erase_storage",
         "disconnect_storage",
         "storage_status",
         "recall_entity",

--- a/packages/remote/tests/test_hosted_tools.py
+++ b/packages/remote/tests/test_hosted_tools.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Hosted storage-admin + combined-resolver tool tests (ADR 0010 Phase C).
+
+These exercise the hosted path end-to-end through a real FastMCP ``Client``
+against the combined server, with:
+
+- a simulated authenticated user (we patch ``user_key_from_context`` in the state
+  module — there is NO real Clerk here),
+- a FAKE Turso platform client whose provisioned databases are local ``file:``
+  libSQL files (there is NO real Turso here), and
+- in-memory preference + BYOS connection stores.
+
+Coverage:
+- enable_hosted_storage → consent recorded, provision called once (idempotent on
+  a second call), record_fact → recall_entity round-trips against the user's DB;
+- two hosted users are isolated (distinct databases);
+- disable_and_erase_storage (hosted) → destroy called + preference cleared;
+- disable_and_erase_storage (byos) → connection cleared, hosted untouched;
+- mode switching: a "none" record refuses; ANONYMOUS still gets
+  STORAGE_NOT_AVAILABLE and nothing is stored/provisioned (the boundary, with the
+  hosted path live).
+
+``asyncio.run`` (not ``async def``) for the same reason as test_app.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+from neurodock_remote import state as state_module
+from neurodock_remote.app import build_combined_server
+from neurodock_state.byos_connection_store import InMemoryByosConnectionStore
+from neurodock_state.hosted_resolver import _database_name
+from neurodock_state.identity import UserKey
+from neurodock_state.storage_preference_store import InMemoryStoragePreferenceStore
+
+
+class _FakePlatform:
+    """Fake Turso platform client backed by local ``file:`` libSQL DBs.
+
+    Each provisioned database name maps to a per-test temp file URL (token-less),
+    so the resolver's LibSqlStorage opens a real local SQLite DB and the
+    cognitive-graph round-trip works without any network or real Turso.
+    """
+
+    def __init__(self, tmp_path: Path) -> None:
+        self._tmp = tmp_path
+        self.created: list[str] = []
+        self.destroyed: list[str] = []
+        self._urls: dict[str, str] = {}
+
+    def create_database(self, name: str, group: str):  # type: ignore[no-untyped-def]
+        self.created.append(name)
+        url = self._urls.setdefault(name, f"file:{self._tmp / (name + '.db')}")
+        return _FileInfo(name=name, url=url)
+
+    def create_token(self, name: str) -> str | None:
+        return None  # token-less local file DB
+
+    def destroy_database(self, name: str) -> None:
+        self.destroyed.append(name)
+
+
+class _FileInfo:
+    def __init__(self, name: str, url: str) -> None:
+        self.name = name
+        self._url = url
+        self.hostname = "local"
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+
+@contextmanager
+def _as_user(monkeypatch: pytest.MonkeyPatch, sub: str | None) -> Iterator[None]:
+    """Patch the request-context identity used by the state seam."""
+    user = UserKey(sub=sub) if sub is not None else None
+    monkeypatch.setattr(state_module, "user_key_from_context", lambda: user)
+    yield
+
+
+def _server(
+    tmp_path: Path,
+) -> tuple[
+    FastMCP[Any],
+    InMemoryStoragePreferenceStore,
+    InMemoryByosConnectionStore,
+    _FakePlatform,
+]:
+    preferences = InMemoryStoragePreferenceStore()
+    connections = InMemoryByosConnectionStore()
+    platform = _FakePlatform(tmp_path)
+    server = build_combined_server(connections, preferences=preferences, platform=platform)
+    return server, preferences, connections, platform
+
+
+def _call(server: FastMCP[Any], tool: str, args: dict[str, Any]) -> dict[str, Any]:
+    async def _run() -> dict[str, Any]:
+        async with Client(server) as client:
+            result = await client.call_tool(tool, args)
+            return dict(result.data)
+
+    return asyncio.run(_run())
+
+
+# -- enable / round-trip / idempotency -----------------------------------
+
+
+def test_enable_hosted_records_consent_and_round_trips(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    server, preferences, _, platform = _server(tmp_path)
+    alice = UserKey(sub="user_alice")
+
+    with _as_user(monkeypatch, "user_alice"):
+        enabled = _call(server, "enable_hosted_storage", {})
+        assert enabled["status"] == "enabled"
+        assert enabled["mode"] == "hosted"
+        assert "disclosure" in enabled  # explicit disclosure returned
+
+        # Consent + mode recorded.
+        pref = preferences.get(alice)
+        assert pref is not None
+        assert pref.mode == "hosted"
+        assert pref.consent_at is not None
+        assert pref.consent_version is not None
+
+        status = _call(server, "storage_status", {})
+        assert status == {"authenticated": True, "mode": "hosted", "connected": True}
+
+        recorded = _call(
+            server,
+            "record_fact",
+            {
+                "subject": {"type": "person", "name": "Dana"},
+                "predicate": "tagged",
+                "object": {"literal": "engineer"},
+            },
+        )
+        assert "error" not in recorded
+
+        recalled = _call(server, "recall_entity", {"name_or_alias": "Dana"})
+
+    assert recalled.get("entity") is not None
+    assert recalled["entity"]["name"] == "Dana"
+    # Provisioned exactly once (idempotent across the enable + graph calls).
+    assert platform.created == [_database_name(alice)]
+
+
+def test_enable_hosted_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    server, _, _, platform = _server(tmp_path)
+    alice = UserKey(sub="user_alice")
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "enable_hosted_storage", {})
+        _call(server, "enable_hosted_storage", {})
+    # The second enable reuses the existing database — no second create.
+    assert platform.created == [_database_name(alice)]
+
+
+def test_two_hosted_users_are_isolated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    server, _, _, platform = _server(tmp_path)
+
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "enable_hosted_storage", {})
+        _call(
+            server,
+            "record_fact",
+            {
+                "subject": {"type": "person", "name": "Dana"},
+                "predicate": "tagged",
+                "object": {"literal": "engineer"},
+            },
+        )
+
+    with _as_user(monkeypatch, "user_bob"):
+        _call(server, "enable_hosted_storage", {})
+        bob_recall = _call(server, "recall_entity", {"name_or_alias": "Dana"})
+
+    assert bob_recall.get("entity") is None
+    assert set(platform.created) == {
+        _database_name(UserKey(sub="user_alice")),
+        _database_name(UserKey(sub="user_bob")),
+    }
+
+
+# -- erasure --------------------------------------------------------------
+
+
+def test_disable_and_erase_hosted_destroys_db_and_clears_preference(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    server, preferences, _, platform = _server(tmp_path)
+    alice = UserKey(sub="user_alice")
+
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "enable_hosted_storage", {})
+        erased = _call(server, "disable_and_erase_storage", {})
+        assert erased["status"] == "erased"
+        assert erased["mode"] == "none"
+        status = _call(server, "storage_status", {})
+
+    assert platform.destroyed == [_database_name(alice)]
+    assert preferences.get(alice) is None
+    # Still authenticated in context, but storage is back to none.
+    assert status == {"authenticated": True, "mode": "none", "connected": False}
+
+
+def test_disable_and_erase_byos_clears_connection_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    server, preferences, connections, platform = _server(tmp_path)
+    alice = UserKey(sub="user_alice")
+
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "connect_byos_storage", {"libsql_url": f"file:{tmp_path / 'alice.db'}"})
+        assert connections.get(alice) is not None
+        erased = _call(server, "disable_and_erase_storage", {})
+        assert erased["status"] == "erased"
+
+    # BYOS: connection + preference cleared; no hosted DB was ever destroyed.
+    assert connections.get(alice) is None
+    assert preferences.get(alice) is None
+    assert platform.destroyed == []
+
+
+# -- mode switching + the privacy boundary (with hosted live) ------------
+
+
+def test_mode_none_record_is_refused(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from neurodock_state.storage_preference_store import StoragePreference
+
+    server, preferences, _, _ = _server(tmp_path)
+    alice = UserKey(sub="user_alice")
+    preferences.put(alice, StoragePreference(mode="none"))
+
+    with _as_user(monkeypatch, "user_alice"):
+        payload = _call(server, "recall_entity", {"name_or_alias": "Dana"})
+
+    assert payload["error"] == "STORAGE_NOT_CONNECTED"
+
+
+def test_switch_byos_to_hosted(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    server, preferences, _connections, platform = _server(tmp_path)
+    alice = UserKey(sub="user_alice")
+
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "connect_byos_storage", {"libsql_url": f"file:{tmp_path / 'alice.db'}"})
+        assert preferences.get(alice).mode == "byos"  # type: ignore[union-attr]
+
+        _call(server, "enable_hosted_storage", {})
+        status = _call(server, "storage_status", {})
+
+    assert status["mode"] == "hosted"
+    assert platform.created == [_database_name(alice)]
+
+
+def test_anonymous_is_refused_and_nothing_is_provisioned(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The boundary, re-asserted with the hosted path fully wired: an anonymous
+    # caller is refused before any store is touched and NOTHING is provisioned.
+    server, preferences, connections, platform = _server(tmp_path)
+
+    with _as_user(monkeypatch, None):
+        graph = _call(
+            server,
+            "record_fact",
+            {
+                "subject": {"type": "person", "name": "Mallory"},
+                "predicate": "tagged",
+                "object": {"literal": "should-not-persist"},
+            },
+        )
+        enable = _call(server, "enable_hosted_storage", {})
+
+    assert graph["error"] == "STORAGE_NOT_AVAILABLE"
+    assert enable["error"] == "STORAGE_NOT_AVAILABLE"
+    # Nothing provisioned, nothing stored.
+    assert platform.created == []
+    assert platform.destroyed == []
+    assert len(preferences) == 0
+    assert len(connections) == 0
+
+
+def test_enable_hosted_refused_when_hosting_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No platform client wired in → hosted enablement is refused (BYOS still ok).
+    connections = InMemoryByosConnectionStore()
+    preferences = InMemoryStoragePreferenceStore()
+    server = build_combined_server(connections, preferences=preferences, platform=None)
+
+    with _as_user(monkeypatch, "user_alice"):
+        payload = _call(server, "enable_hosted_storage", {})
+
+    assert payload["error"] == "HOSTED_STORAGE_UNAVAILABLE"
+    assert len(preferences) == 0

--- a/packages/remote/worker/index.ts
+++ b/packages/remote/worker/index.ts
@@ -31,10 +31,17 @@ declare global {
       NEURODOCK_CLERK_CLIENT_SECRET?: string;
       // ADR 0010 Phase D — opt-in BYOS storage. The Clerk Backend API key
       // (persists the per-user connection in Clerk private_metadata) and the
-      // master key that encrypts the BYOS auth token at rest. Without both, the
-      // opt-in tools are visible but return the sign-in/connect refusal.
+      // master key that encrypts the BYOS/hosted auth token at rest. Without both,
+      // the opt-in tools are visible but return the sign-in/enable refusal.
       NEURODOCK_CLERK_SECRET_KEY?: string;
       NEURODOCK_STATE_MASTER_KEY?: string;
+      // ADR 0010 Phase C — opt-in NeuroDock-hosted storage. The Turso Platform
+      // API token + organization slug let NeuroDock provision a private Turso
+      // database per user; the group is where those databases are created.
+      // Without the token + org, enable_hosted_storage is refused (BYOS still works).
+      NEURODOCK_TURSO_PLATFORM_TOKEN?: string;
+      NEURODOCK_TURSO_ORG?: string;
+      NEURODOCK_TURSO_GROUP?: string;
     }
   }
 }
@@ -56,9 +63,15 @@ export class NeurodockRemoteContainer extends Container {
     NEURODOCK_CLERK_CLIENT_SECRET: env.NEURODOCK_CLERK_CLIENT_SECRET ?? "",
     // ADR 0010 Phase D — BYOS storage secrets. Empty string when unset; the
     // server then leaves the opt-in tools un-backed (every call returns the
-    // sign-in/connect refusal) rather than failing to boot.
+    // sign-in/enable refusal) rather than failing to boot.
     NEURODOCK_CLERK_SECRET_KEY: env.NEURODOCK_CLERK_SECRET_KEY ?? "",
     NEURODOCK_STATE_MASTER_KEY: env.NEURODOCK_STATE_MASTER_KEY ?? "",
+    // ADR 0010 Phase C — NeuroDock-hosted storage. Empty string when unset; the
+    // server then refuses enable_hosted_storage (BYOS is unaffected) rather than
+    // failing to boot. NEURODOCK_TURSO_GROUP defaults to "default" in the app.
+    NEURODOCK_TURSO_PLATFORM_TOKEN: env.NEURODOCK_TURSO_PLATFORM_TOKEN ?? "",
+    NEURODOCK_TURSO_ORG: env.NEURODOCK_TURSO_ORG ?? "",
+    NEURODOCK_TURSO_GROUP: env.NEURODOCK_TURSO_GROUP ?? "",
     // The container binds all interfaces; the Worker is the only ingress.
     NEURODOCK_HTTP_HOST: "0.0.0.0",
     NEURODOCK_HTTP_PORT: "8000",

--- a/packages/remote/wrangler.jsonc
+++ b/packages/remote/wrangler.jsonc
@@ -37,16 +37,24 @@
 
   // Non-secret runtime config forwarded into the container (see worker/index.ts).
   // Secrets are NOT here — set each with `npx wrangler secret put <NAME>`:
-  //   NEURODOCK_CLERK_CLIENT_SECRET   — OAuth client secret (auth).
-  //   NEURODOCK_CLERK_SECRET_KEY      — Clerk Backend API key (ADR 0010 Phase D:
-  //                                     persists the per-user BYOS connection).
-  //   NEURODOCK_STATE_MASTER_KEY      — encrypts the BYOS auth token at rest.
-  // Without the last two, the opt-in memory tools are visible but un-backed:
-  // every call returns the structured sign-in/connect refusal (ADR 0010 §4).
+  //   NEURODOCK_CLERK_CLIENT_SECRET    — OAuth client secret (auth).
+  //   NEURODOCK_CLERK_SECRET_KEY       — Clerk Backend API key (ADR 0010 Phase D:
+  //                                      persists the per-user BYOS/hosted pointer).
+  //   NEURODOCK_STATE_MASTER_KEY       — encrypts the BYOS/hosted DB token at rest.
+  //   NEURODOCK_TURSO_PLATFORM_TOKEN   — Turso Platform API token (ADR 0010 Phase C:
+  //                                      create/destroy the per-user hosted database).
+  // Without the Clerk-secret + master-key pair, the opt-in memory tools are visible
+  // but un-backed (every call returns the sign-in/enable refusal, ADR 0010 §4).
+  // Without the Turso token + org below, enable_hosted_storage is refused; BYOS works.
+  //
+  // NEURODOCK_TURSO_ORG / _GROUP are non-secret (the org slug + group name where
+  // hosted databases are provisioned); set them here to your Turso org/group.
   "vars": {
     "NEURODOCK_AUTH_PROVIDER": "clerk",
     "NEURODOCK_PUBLIC_URL": "https://mcp.neurodock.org",
     "NEURODOCK_CLERK_DOMAIN": "clerk.neurodock.org",
-    "NEURODOCK_CLERK_CLIENT_ID": "W0lnEKzJnL6wGU7g"
+    "NEURODOCK_CLERK_CLIENT_ID": "W0lnEKzJnL6wGU7g",
+    "NEURODOCK_TURSO_ORG": "",
+    "NEURODOCK_TURSO_GROUP": "default"
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1536,6 +1536,7 @@ dependencies = [
 clerk = [
     { name = "clerk-backend-api" },
     { name = "cryptography" },
+    { name = "httpx" },
 ]
 test = [
     { name = "pytest" },
@@ -1547,6 +1548,7 @@ requires-dist = [
     { name = "clerk-backend-api", marker = "extra == 'clerk'", specifier = ">=2.0" },
     { name = "cryptography", marker = "extra == 'clerk'", specifier = ">=42.0" },
     { name = "fastmcp", specifier = ">=3.3.0" },
+    { name = "httpx", marker = "extra == 'clerk'", specifier = ">=0.27" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
 ]


### PR DESCRIPTION
## ADR 0010 Phase C — hosted per-user Turso storage

Adds **NeuroDock-provisioned Turso databases** as a second opt-in storage mode, alongside the **BYOS** mode shipped in Phase D. Both modes now coexist behind a single combined resolver. **The anonymous-stores-nothing privacy boundary is unchanged.**

### How hosted + BYOS coexist (the combined resolver)

A per-user **storage preference** record (`mode` = `hosted` | `byos` | `none`, plus consent timestamp/version and — for hosted — the encrypted Turso DB token) is the single source of truth for which mode is active. `CombinedResolver` reads it and routes each cognitive-graph call:

- `mode == "hosted"` → `HostedTursoResolver` (a NeuroDock-provisioned Turso DB per Clerk identity, opened via the same `LibSqlStorage`).
- `mode == "byos"` → the existing `ByosResolver` (the user's own libSQL/Turso DB).
- `none` / no record → `LookupError`, which the un-gating layer turns into the structured "enable storage first" refusal — nothing is provisioned or read.

Because hosted reuses `LibSqlStorage`, the two modes are byte-for-byte identical at the SQL level; only the backing differs. The same `require_user()` choke point in `state.py` is preserved.

### Privacy boundary (unchanged)

An anonymous / no-token caller is refused with `STORAGE_NOT_AVAILABLE` **before any store is touched and nothing is provisioned** — re-asserted by a test with the hosted path fully wired. A signed-in but not-enabled caller gets `STORAGE_NOT_CONNECTED`. The 8-tool stateless surface and the MCP prompts are unchanged.

### Erasure path

- `enable_hosted_storage()` — captures explicit consent, sets `mode="hosted"`, idempotently provisions the user's Turso DB, returns the disclosure text.
- `disable_and_erase_storage()` — **hosted**: destroys the user's Turso database via the Platform API; **byos**: clears the connection (the user's own DB is untouched). Either way the preference/consent record is cleared, so NeuroDock retains nothing.
- `connect_byos_storage` now also records `mode="byos"`; `disconnect_storage` and `storage_status` (reports hosted/byos/none) are retained.

### Encryption-key custody limitation (honest note)

Both the BYOS auth token and the hosted Turso DB token are encrypted at rest with a single operator-wide `NEURODOCK_STATE_MASTER_KEY`, so NeuroDock can *technically* decrypt a stored token. This is the documented ADR 0010 open question; per-user / envelope keys are a tracked follow-up. Documented in code (`crypto.py`), the README, and the ADR. The on-disk format is unchanged, so a future scheme can re-wrap without a data migration.

### Deploy note

Hosted requires a provisioned Turso org/group + Platform token: `NEURODOCK_TURSO_PLATFORM_TOKEN`, `NEURODOCK_TURSO_ORG`, `NEURODOCK_TURSO_GROUP` (forwarded by the Worker/wrangler; no hardcoded secrets). Without them, `enable_hosted_storage` is refused and only BYOS is offered. **Tests use a fake platform client — no real Turso, no real Clerk.**

### What changed

- **mcp-state** (new): `turso_platform.py` (typed httpx client behind a Protocol), `crypto.py` (shared Fernet cipher, factored out of `clerk_byos_store` — Phase D tokens decrypt unchanged), `storage_preference_store.py` (in-memory + Clerk-metadata backings), `hosted_resolver.py`, `combined_resolver.py`.
- **remote**: `state.py` routes through the combined resolver; `storage_admin.py` adds `enable_hosted_storage` + `disable_and_erase_storage`; `app.py` wires it and updates `OPT_IN_TOOL_NAMES`; worker/wrangler/Dockerfile/README plumbing.

### Test plan

All unit; no real Turso, no real Clerk (fake platform client + in-memory preference/connection stores + local `file:` libSQL for the resolved store).

- [x] `enable_hosted_storage` → consent recorded, provision called once (idempotent on a second call), `record_fact`→`recall_entity` round-trips against the resolved store.
- [x] Two hosted users are isolated (distinct databases).
- [x] `disable_and_erase_storage` (hosted) → destroy called + preference cleared; (byos) → connection cleared, hosted untouched.
- [x] Mode switching: `mode="none"` → not-connected refusal; ANONYMOUS still → `STORAGE_NOT_AVAILABLE` and nothing is stored/provisioned (boundary re-asserted with hosted live).
- [x] Phase D BYOS tests pass unchanged.

### Verification (from repo root)

- `ruff check packages/mcp-state packages/remote` — All checks passed
- `ruff format --check` — 38 files already formatted
- `mypy packages/mcp-state packages/remote` — Success: no issues found in 38 source files
- `pytest packages/mcp-state packages/remote` — 123 passed
- `cd packages/remote && npx tsc --noEmit` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
