### PR TITLE
fix: refuse destructive storage mode switches to prevent orphaned hosted dbs

### DIFF
--- a/packages/remote/src/neurodock_remote/tools/storage_admin.py
+++ b/packages/remote/src/neurodock_remote/tools/storage_admin.py
@@ -52,6 +52,10 @@ INVALID_URL = "INVALID_STORAGE_URL"
 CONNECT_FAILED = "STORAGE_CONNECT_FAILED"
 HOSTED_UNAVAILABLE = "HOSTED_STORAGE_UNAVAILABLE"
 PROVISION_FAILED = "HOSTED_PROVISION_FAILED"
+# Refused when a destructive mode switch would orphan a hosted Turso database
+# (which holds the user's data and is billable). The user must explicitly run
+# disable_and_erase_storage first — we never silently drop a hosted-DB pointer.
+HOSTED_ACTIVE = "HOSTED_STORAGE_ACTIVE"
 
 # The consent disclosure surfaced when a user enables hosted storage. Keep in
 # step with HostedTursoResolver.CONSENT_VERSION when the wording materially
@@ -150,6 +154,11 @@ def register_storage_admin_tools(mcp: FastMCP[Any], state: ByosState) -> None:
                     PROVISION_FAILED,
                     f"could not provision your hosted database: {exc}",
                 ) from exc
+            # Switching BYOS → hosted: drop any stale BYOS connection pointer so it
+            # cannot linger. Safe (and not a refusal like the reverse switch): the
+            # BYOS pointer references the user's OWN database, so nothing of theirs
+            # is destroyed and no NeuroDock-provisioned resource is orphaned.
+            state.connections.delete(user)
         except StorageUnavailableError as exc:
             return exc.to_payload()
         except _ToolInputError as exc:
@@ -178,6 +187,19 @@ def register_storage_admin_tools(mcp: FastMCP[Any], state: ByosState) -> None:
     def connect_byos_storage(libsql_url: str, auth_token: str | None = None) -> dict[str, Any]:
         try:
             user = state.require_user()
+            # Refuse if hosted storage is active: switching to BYOS here would
+            # overwrite the preference and ORPHAN the user's hosted Turso database
+            # (their data would persist, unreferenced and billable). Make the user
+            # destroy it explicitly first.
+            existing = state.preferences.get(user)
+            if existing is not None and existing.mode == "hosted":
+                raise _ToolInputError(
+                    HOSTED_ACTIVE,
+                    "You have NeuroDock-hosted storage enabled. Run "
+                    "disable_and_erase_storage first (it destroys your hosted "
+                    "database), then connect your own. This prevents silently "
+                    "orphaning your hosted data.",
+                )
             url = _validate_url(libsql_url)
             token = (
                 auth_token.strip() if isinstance(auth_token, str) and auth_token.strip() else None
@@ -251,9 +273,23 @@ def register_storage_admin_tools(mcp: FastMCP[Any], state: ByosState) -> None:
     def disconnect_storage() -> dict[str, Any]:
         try:
             user = state.require_user()
+            # Refuse for hosted users: clearing the preference here would leave the
+            # NeuroDock-provisioned Turso database orphaned (their data persists,
+            # billable). disconnect_storage only clears a BYOS connection pointer;
+            # hosted removal must go through disable_and_erase_storage (destroys it).
+            preference = state.preferences.get(user)
+            if preference is not None and preference.mode == "hosted":
+                raise _ToolInputError(
+                    HOSTED_ACTIVE,
+                    "You have NeuroDock-hosted storage. disconnect_storage only "
+                    "clears a bring-your-own connection; to remove hosted storage "
+                    "use disable_and_erase_storage (it destroys your hosted database).",
+                )
             state.connections.delete(user)
             state.preferences.clear(user)
         except StorageUnavailableError as exc:
+            return exc.to_payload()
+        except _ToolInputError as exc:
             return exc.to_payload()
         return {
             "status": "disconnected",

--- a/packages/remote/tests/test_hosted_tools.py
+++ b/packages/remote/tests/test_hosted_tools.py
@@ -262,6 +262,70 @@ def test_switch_byos_to_hosted(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     assert platform.created == [_database_name(alice)]
 
 
+def test_switch_byos_to_hosted_clears_stale_byos_pointer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Regression (security review, finding 3): enabling hosted while a BYOS
+    # connection exists must drop the stale BYOS pointer, so it cannot linger and
+    # route a later write to the old database after the mode switched to hosted.
+    server, preferences, connections, _platform = _server(tmp_path)
+    alice = UserKey(sub="user_alice")
+
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "connect_byos_storage", {"libsql_url": f"file:{tmp_path / 'alice.db'}"})
+        assert connections.get(alice) is not None
+        _call(server, "enable_hosted_storage", {})
+
+    assert preferences.get(alice).mode == "hosted"  # type: ignore[union-attr]
+    # The BYOS connection pointer is gone — not left dangling.
+    assert connections.get(alice) is None
+
+
+def test_connect_byos_refused_when_hosted_active_so_db_is_not_orphaned(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Regression (security review, finding 1): a hosted user calling
+    # connect_byos_storage must be refused, so the hosted Turso database is never
+    # silently orphaned (it holds their data and is billable). They must run
+    # disable_and_erase_storage first.
+    server, preferences, connections, platform = _server(tmp_path)
+    alice = UserKey(sub="user_alice")
+
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "enable_hosted_storage", {})
+        payload = _call(
+            server, "connect_byos_storage", {"libsql_url": f"file:{tmp_path / 'alice.db'}"}
+        )
+
+    assert payload["error"] == "HOSTED_STORAGE_ACTIVE"
+    # Still hosted; the hosted DB was neither destroyed nor orphaned, and no BYOS
+    # pointer was written behind it.
+    assert preferences.get(alice).mode == "hosted"  # type: ignore[union-attr]
+    assert platform.destroyed == []
+    assert connections.get(alice) is None
+
+
+def test_disconnect_storage_refused_when_hosted_active(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Regression (security review, finding 2): disconnect_storage only clears a
+    # BYOS pointer; a hosted user must be refused (and pointed at
+    # disable_and_erase_storage) so the hosted database is not orphaned.
+    server, preferences, _connections, platform = _server(tmp_path)
+    alice = UserKey(sub="user_alice")
+
+    with _as_user(monkeypatch, "user_alice"):
+        _call(server, "enable_hosted_storage", {})
+        payload = _call(server, "disconnect_storage", {})
+        status = _call(server, "storage_status", {})
+
+    assert payload["error"] == "HOSTED_STORAGE_ACTIVE"
+    # Preference untouched (still hosted) and the hosted DB intact.
+    assert preferences.get(alice).mode == "hosted"  # type: ignore[union-attr]
+    assert status == {"authenticated": True, "mode": "hosted", "connected": True}
+    assert platform.destroyed == []
+
+
 def test_anonymous_is_refused_and_nothing_is_provisioned(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Security-review remediation for the ADR 0010 Phase C (hosted storage) code merged in #49. A hosted user switching storage modes could silently **orphan their NeuroDock-provisioned Turso database** — it holds their data and is billable, but nothing references it anymore. Three data-retention fixes, all in [storage_admin.py](packages/remote/src/neurodock_remote/tools/storage_admin.py):

| # | Severity | Before | After |
| - | -------- | ------ | ----- |
| 1 | HIGH | `connect_byos_storage` on a hosted user overwrote the preference to `byos`, orphaning the hosted Turso DB | Refused with `HOSTED_STORAGE_ACTIVE`; user must `disable_and_erase_storage` first (destroys the DB) |
| 2 | HIGH | `disconnect_storage` on a hosted user cleared the pointer but left the Turso DB | Refused with `HOSTED_STORAGE_ACTIVE`, pointing at `disable_and_erase_storage` |
| 3 | MEDIUM | `enable_hosted_storage` left a stale BYOS connection pointer behind | Drops the BYOS pointer after provisioning (safe — it references the user's *own* DB) |

The invariant: **we never silently drop a pointer to a NeuroDock-provisioned, billable database.** The one destructive path (`disable_and_erase_storage`) stays the single, explicit way to remove hosted storage.

## Tests

Adds three regression tests in [test_hosted_tools.py](packages/remote/tests/test_hosted_tools.py), one per finding:

- `test_connect_byos_refused_when_hosted_active_so_db_is_not_orphaned` — refusal + DB not destroyed + no BYOS pointer written.
- `test_disconnect_storage_refused_when_hosted_active` — refusal + preference still hosted + DB intact.
- `test_switch_byos_to_hosted_clears_stale_byos_pointer` — `connections.get(user) is None` after the switch.

## Test plan

- [x] `pytest packages/mcp-state packages/remote` — 126 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy --strict` — clean
- [x] Diff is Python-only; the Worker (`worker/index.ts`) is untouched, so `tsc` is unaffected