### PR TITLE
fix: force shell-quote >=1.8.4 to close critical transitive advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   yaml: ^2.8.3
   uuid: ^11.1.1
   tmp: ^0.2.6
+  shell-quote: '>=1.8.4'
 
 importers:
 
@@ -4953,8 +4954,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.7.3:
-    resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
 
   shellwords@0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==}
@@ -8998,7 +9000,7 @@ snapshots:
   fx-runner@1.4.0:
     dependencies:
       commander: 2.9.0
-      shell-quote: 1.7.3
+      shell-quote: 1.8.4
       spawn-sync: 1.0.15
       when: 3.7.7
       which: 1.2.4
@@ -11160,7 +11162,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.7.3: {}
+  shell-quote@1.8.4: {}
 
   shellwords@0.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,7 @@ overrides:
   # tmp <0.2.6 has a path-traversal advisory (GHSA-52f5-9888-hmc6).
   # wxt → web-ext-run still pulls tmp@0.2.5. Force the patched version.
   "tmp": "^0.2.6"
+  # shell-quote <=1.8.3 fails to escape newlines in object .op values
+  # (critical). fx-runner@1.4.0 (web-ext tooling) + wrangler still pull
+  # shell-quote@1.7.3. Force the patched version.
+  "shell-quote": ">=1.8.4"


### PR DESCRIPTION
## Summary

Resolves **Dependabot alert #33** (critical): `shell-quote` ≤1.8.3 does not escape newlines in object `.op` values. It is pulled transitively at **1.7.3** via `fx-runner@1.4.0` (web-ext dev tooling) and `wrangler`, so there is no direct package to bump and Dependabot opened no PR.

Adds a pnpm `overrides` entry in `pnpm-workspace.yaml` forcing `shell-quote: ">=1.8.4"` — alongside the existing `uuid`/`tmp` security pins that follow the same pattern — and regenerates `pnpm-lock.yaml`.

## Impact

- Dev/build surface only (`fx-runner` = Firefox extension dev runner; `wrangler` = deploy tooling). **Not shipped in any runtime.**
- `shell-quote` now resolves to **1.8.4** in the lockfile (verified).
- No source changes; no functional change.

## Test plan
- [x] `pnpm install --lockfile-only` re-resolves cleanly; `shell-quote@1.8.4` in lockfile + `overrides` block records the pin
- [x] pre-commit hooks pass (yaml, prettier, commitlint)
- [ ] CI green