### PR TITLE
ci: filter codeql maintainability false positives via config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,28 @@
+# CodeQL configuration for NeuroDock.
+#
+# We run the full `security-and-quality` suite (security + maintainability).
+# Two of its *maintainability* (non-security) queries fire repeatedly on
+# idiomatic Python in this codebase and are false positives here, so they are
+# filtered out. No security query is excluded.
+#
+#   py/ineffectual-statement
+#     Fires on the `...` (ellipsis) bodies of typing.Protocol method stubs —
+#     e.g. the store/platform Protocols in packages/mcp-state. The ellipsis is
+#     the idiomatic, required stub body; it is not dead code.
+#
+#   py/import-and-import-from
+#     Fires on a test that deliberately imports a module two ways to exercise
+#     both entry points. Stylistic, not a security or correctness issue.
+#
+# Removing these clears the standing "note"-severity alerts and stops them
+# recurring as new Protocols are added, without weakening security coverage.
+name: "NeuroDock CodeQL config"
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - exclude:
+      id: py/ineffectual-statement
+  - exclude:
+      id: py/import-and-import-from

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,10 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          queries: security-and-quality
+          # Query suite + false-positive filters live in the config file, so the
+          # standing maintainability-query noise (Protocol `...` stubs) is
+          # excluded without weakening security coverage.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
## Summary

Resolves the **22 standing code-scanning alerts** ([security/code-scanning](https://github.com/tlennon-ie/neurodock/security/code-scanning)). All 22 are `note`-severity **maintainability** queries (not security findings) firing on idiomatic Python:

| Rule | Count | Why it's a false positive |
|------|-------|---------------------------|
| `py/ineffectual-statement` | 21 | The `...` bodies of `typing.Protocol` method stubs in `packages/mcp-state`. The ellipsis is the required stub body, not dead code. |
| `py/import-and-import-from` | 1 | A test that imports a module two ways on purpose. |

Moves the query-suite selection into `.github/codeql/codeql-config.yml` and adds `query-filters` excluding just those two rule IDs. **No security query is excluded** — the full security-and-quality security coverage is intact.

## Effect
- On the next CodeQL scan of `main` (this PR's merge), the 22 alerts close as **fixed**.
- New Protocol stubs won't reintroduce the noise.

## Test plan
- [ ] CodeQL workflow runs green with the config file on this PR
- [ ] After merge, the 22 alerts on `main` move to Closed/Fixed