### PR TITLE
fix: repair docs build broken on main by remote.mdx jsx placeholders

### DIFF
--- a/docs/src/content/docs/getting-started/remote.mdx
+++ b/docs/src/content/docs/getting-started/remote.mdx
@@ -34,10 +34,10 @@ That's it for the stateless tools — they need no further setup and store nothi
 
 You don't call the tools by name; you ask Claude in plain language and it routes to the matching tool. For example:
 
-- _"Translate this Slack message — what are they actually asking me to do? '<paste message>'"_ → `translate_incoming`
-- _"Check the tone of this draft before I send it: '<paste draft>'"_ → `check_tone`
-- _"Rewrite this so it lands as neutral and direct: '<paste draft>'"_ → `rewrite_outgoing`
-- _"Break this goal into startable steps: 'ship the onboarding revamp'"_ → `decompose`
+- _"Translate this Slack message — what are they actually asking me to do?"_ (then paste the message) → `translate_incoming`
+- _"Check the tone of this draft before I send it"_ (then paste the draft) → `check_tone`
+- _"Rewrite this so it lands as neutral and direct"_ (then paste the draft) → `rewrite_outgoing`
+- _"Break this goal into startable steps: ship the onboarding revamp"_ → `decompose`
 - _"Is this prompt a guardrail concern?"_ → `check_rumination` / `check_hyperfocus` / `check_sycophancy`
 
 Each returns a deterministic baseline plus a structured prompt your client's model refines — no model SDK runs on the server (vendor-neutral by ADR 0005).


### PR DESCRIPTION
## Urgent — main is red

PR #63 auto-merged at its **pre-fix** commit (`030f0c6`). The repo's branch protection does not require the `TypeScript (lint, typecheck, test, build)` / docs-build check, so it merged even though that check was failing. The merged `remote.mdx` contained `<paste message>` / `<paste draft>` placeholders that **MDX parses as unclosed JSX tags**, breaking `astro build` on main — failing both the docs CI job and the **Cloudflare `neurodock-docs` deploy**.

This re-applies the escape fix that landed on the PR branch *after* the auto-merge (commit `074be22`): the invoke examples are reworded to drop the angle brackets.

## Verification
- [x] `pnpm --filter @neurodock/docs build` → **Complete!** (53 pages)
- [x] No remaining `<…>` JSX-like tokens in `remote.mdx`

## Follow-up (repo setting, your call)
Consider adding **`TypeScript (lint, typecheck, test, build)`** to the required status checks for `main` so a failing docs/extension build can't auto-merge again.