### PR TITLE
chore: add agent repo-hygiene rules, glama.json, and refresh roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# Working in this repository (AI-agent instructions)
+
+This is a **public, open-source** repository. Average users and external
+contributors clone it. Default to that audience for everything you commit.
+
+## Repository hygiene — what does NOT belong in the tracked tree
+
+Do **not** commit maintainer-internal, strategy, marketing, or audit documents
+to this repo. Before creating any new top-level or `docs/` markdown file, ask:
+
+> Would an average user or external contributor cloning this repo need this?
+
+If the answer is no, it must not be tracked. Keep such files **out of the tree**
+— either outside the repo, or untracked-and-gitignored locally (so the
+maintainer keeps a working copy without publishing it).
+
+**Internal — never commit to this repo:**
+
+- Distribution / store-submission kits and reviewer notes (e.g. an
+  `MCP-DISTRIBUTION.md`, `store-listings/`).
+- Marketing / media / content-strategy docs and AI-image prompts.
+- Internal audits (accuracy audits, internal branding notes, competitive notes).
+- Scratch / rolling working notes that duplicate the per-package `CHANGELOG.md`.
+- Anything containing submission credentials, form field dumps, or launch tactics.
+
+**Public — belongs in the repo:**
+
+- Standard root docs: `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`,
+  `SECURITY.md`, `LICENSE`, `CHANGELOG.md`, `ETHICS.md`, `GOVERNANCE.md`,
+  `MANIFESTO.md`, `ROADMAP.md`, `PRIVACY.md`.
+- The documentation site under `docs/src/content/docs/` (this is what ships to
+  docs.neurodock.org).
+- Per-package `README.md` / `CHANGELOG.md`, ADRs the project chooses to publish,
+  and code.
+
+Do not proliferate root-level `*.md` files. When you think you need a new doc,
+prefer extending an existing public doc or adding a page under the docs site.
+
+## Commit conventions (this repo's hooks will reject otherwise)
+
+- **commitlint**: the subject line must be **all lowercase** — no capitalised
+  words, including acronyms (`mcp`, `codeql`, `tab`, not `MCP`/`CodeQL`/`Tab`).
+- A `mixed-line-ending` pre-commit hook normalises CRLF→LF and **aborts the
+  first commit** after rewriting the file. Re-stage the file and commit again.
+- Conventional-commit types: `feat`, `fix`, `docs`, `chore`, `ci`, `refactor`,
+  `test`, `perf`, `style`.
+
+## CI gotchas
+
+- `main` branch protection does **not** require the
+  `TypeScript (lint, typecheck, test, build)` or `axe-core` checks, so a PR can
+  auto-merge while those are red. Before merging a PR that touches `docs/` or the
+  browser extension, confirm those checks are green — "mergeable" ≠ "all green".
+- MDX gotcha: any `<word ...>` in `.mdx` prose is parsed as JSX and breaks
+  `astro build`. Wrap placeholders in backticks. Verify docs with
+  `pnpm --filter @neurodock/docs build` before pushing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ without something landing, that's fine — this is volunteer work, not a
 ship list. If you want to drive any of these, open an issue or comment
 on the existing one.
 
-> Updated: 2026-05-25.
+> Updated: 2026-06-10.
 
 ## Shipped (Q2 2026)
 
@@ -63,14 +63,30 @@ Landed since the v0.2.1 developer preview:
       instead of raw Pydantic errors. Closes the six-retry validation
       loop documented on 2026-05-22. Landed in mcp-cognitive-graph
       v0.0.4 (2026-05-24).
+- [x] **Distribution channels** — the five servers are published to the
+      official MCP Registry (`registry.modelcontextprotocol.io`, namespace
+      `io.github.tlennon-ie/*`), plus a Claude Code plugin, per-server
+      `.mcpb` Desktop Extensions, and an `awesome-mcp-servers` listing.
+      Recorded in ADR 0008.
+- [x] **Hosted remote MCP server** — the stateless tools (translation,
+      guardrail, `decompose`) are served over OAuth at
+      `https://mcp.neurodock.org/mcp` (Cloudflare Containers + Clerk).
+      Addable as a custom connector with no local install. The cognitive
+      graph and profile are never hosted. ADR 0009.
+- [x] **Opt-in hosted state** — signed-in users can enable per-account
+      NeuroDock-hosted storage (a private Turso database) or bring their
+      own libSQL/Turso DB, with explicit consent and one-call erasure.
+      Default stays stateless/local; anonymous sessions store nothing.
+      ADR 0010.
 
 ## Now — Q2 2026
 
 **Theme:** make the developer preview comfortable to actually use.
 
 - [ ] **Browser-store submissions** — Chrome Web Store, Firefox Add-ons,
-      Edge Add-ons. Build artefacts are clean; developer accounts +
-      screenshots + privacy disclosures remain manual.
+      Edge Add-ons. Build artefacts and promo/icon assets are ready;
+      developer accounts + the five listing screenshots + privacy
+      disclosures remain the manual steps.
 - [ ] **Demo GIF / video** (issue #27) — a short video remains the
       lowest-friction "see it work" surface.
 - [x] **Docs site DNS** — `neurodock.org` and `docs.neurodock.org` now

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["tlennon-ie"]
+}


### PR DESCRIPTION
## Summary

Three things, all additive — no removals here (the internal-doc cleanup is gated on a scope decision; see the PR discussion / chat).

- **`CLAUDE.md`** — AI-agent instructions for this **public** repo. The core rule: do **not** commit maintainer-internal / strategy / marketing / audit docs to the tracked tree — only user- and contributor-facing content belongs. Also documents the commit-hook conventions (all-lowercase subject, the line-ending hook) and the `main` required-checks gap so future agents don't repeat recent mistakes.
- **`glama.json`** — registers the server on Glama with the maintainer handle; clears the "No glama.json" quality check.
- **`ROADMAP.md`** — bumped the date; moved the shipped distribution work (MCP Registry, hosted remote server at `mcp.neurodock.org`, opt-in hosted/BYOS storage — ADRs 0008/0009/0010) into Shipped; refreshed the browser-store line (assets ready, screenshots + accounts manual).

## Test plan
- [x] No code touched; JSON valid (prettier + check-json pass)
- [ ] CI green