### PR TITLE
fix: drop redundant prompts force-include that broke the mcp-translation wheel

### DIFF
--- a/packages/mcp-translation/pyproject.toml
+++ b/packages/mcp-translation/pyproject.toml
@@ -33,10 +33,11 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
+# `prompts/` is a subpackage (it has __init__.py), so `packages` already bundles
+# it AND its .prompt.md data files. A force-include of the same dir would add
+# every file twice and fail the wheel build on newer hatchling
+# ("a second file is being added to the wheel archive at the same path").
 packages = ["src/neurodock_mcp_translation"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/neurodock_mcp_translation/prompts" = "neurodock_mcp_translation/prompts"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

The Release workflow's PyPI build step fails on `mcp-translation`:

```
ValueError: A second file is being added to the wheel archive at the same path:
`neurodock_mcp_translation/prompts/__init__.py`
```

`prompts/` is a **subpackage** (it has `__init__.py`), so the wheel target's `packages = ["src/neurodock_mcp_translation"]` already bundles it **and** its `.prompt.md` data files. The extra `force-include` of the same directory added every file a second time. Older hatchling silently de-duplicated (so v0.7.3 built); newer hatchling errors — which surfaced when the v0.7.4 tag ran the release workflow.

**Fix:** remove the redundant `force-include`. cognitive-graph keeps its force-include — its prompts dir has **no** `__init__.py`, so it isn't a package and isn't double-counted.

## Verification (local)
```
uv build --package neurodock-mcp-translation   # succeeds (was failing)
```
Wheel contains all five `.prompt.md` files + `__init__.py`, **each exactly once** (no duplicates, no missing data).

## Impact
Unblocks future PyPI releases. No runtime change (the data files are still bundled). The v0.7.4 GitHub Release already exists; this makes the next release build clean.

## Test plan
- [x] local `uv build` green + wheel contents verified
- [ ] CI green