### PR TITLE
fix: hosted graph schema over remote libsql + tolerant guardrail inputs

### DIFF
--- a/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/libsql.py
+++ b/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/libsql.py
@@ -136,9 +136,27 @@ class LibSqlStorage:
             self._conn = None
 
     def _apply_migrations(self) -> None:
+        # Apply each migration statement individually rather than via
+        # ``executescript``. Over a REMOTE libSQL/Turso connection,
+        # ``executescript`` silently halts on the local-only PRAGMAs at the top of
+        # the schema (``journal_mode = WAL``, ``foreign_keys = ON``) — which Turso
+        # manages itself and does not accept — leaving every CREATE TABLE
+        # unexecuted, so the database has no tables. (Local ``file:`` connections
+        # accept the PRAGMAs, which is why the unit tests, all on ``file:`` URLs,
+        # never caught this.) Executing statements one at a time and skipping an
+        # unsupported PRAGMA lets the DDL run on both local files and Turso.
         conn = self._c
         for sql in _iter_migration_resources():
-            conn.executescript(sql)
+            for statement in _split_sql_statements(sql):
+                try:
+                    conn.execute(statement)
+                except Exception:
+                    # PRAGMAs are advisory here; a remote backend rejecting one
+                    # must not abort the schema migration. DDL failures must still
+                    # surface, so only swallow PRAGMA statements.
+                    if statement.lstrip().upper().startswith("PRAGMA"):
+                        continue
+                    raise
         conn.commit()
 
     @property
@@ -462,6 +480,27 @@ class LibSqlStorage:
             (input_text, entity_id, method, score, now.isoformat()),
         )
         self._c.commit()
+
+
+def _split_sql_statements(script: str) -> list[str]:
+    """Split a migration script into individual statements.
+
+    Strips ``-- ...`` comments to end-of-line first (the migrations contain
+    inline comments whose text includes a semicolon, e.g. ``-- nullable;
+    populated``, which would otherwise break the split), then splits on ``;``.
+    The cognitive-graph migrations are plain DDL — no triggers and no semicolons
+    inside string literals — so this simple split is safe. Per-statement
+    execution is what lets the schema apply over remote libSQL, where
+    ``executescript`` halts on the local-only PRAGMAs.
+    """
+    stripped_lines: list[str] = []
+    for line in script.splitlines():
+        marker = line.find("--")
+        if marker != -1:
+            line = line[:marker]
+        stripped_lines.append(line)
+    cleaned = "\n".join(stripped_lines)
+    return [statement.strip() for statement in cleaned.split(";") if statement.strip()]
 
 
 def _iter_migration_resources() -> Iterable[str]:

--- a/packages/mcp-cognitive-graph/tests/test_libsql_storage.py
+++ b/packages/mcp-cognitive-graph/tests/test_libsql_storage.py
@@ -32,6 +32,8 @@ libsql = pytest.importorskip("libsql", reason="optional 'libsql' client not inst
 
 from neurodock_mcp_cognitive_graph.storage.libsql import (  # noqa: E402  (after importorskip)
     LibSqlStorage,
+    _iter_migration_resources,
+    _split_sql_statements,
 )
 
 NOW = datetime(2026, 5, 15, 9, 14, 22, tzinfo=UTC)
@@ -545,3 +547,57 @@ def test_libsql_matches_sqlite_on_same_operations(tmp_path: Path) -> None:
     finally:
         sqlite_store.close()
         libsql_store.close()
+
+
+# -- migration robustness over a remote-style connection ------------------
+
+
+def test_split_sql_statements_keeps_inline_comment_semicolons_intact() -> None:
+    """The facts CREATE TABLE has an inline comment containing a semicolon
+    (``-- nullable; populated``). The splitter must not break the statement
+    there, or the migration would apply a truncated, invalid CREATE."""
+    statements = [s for sql in _iter_migration_resources() for s in _split_sql_statements(sql)]
+    facts_create = [s for s in statements if s.startswith("CREATE TABLE IF NOT EXISTS facts (")]
+    assert len(facts_create) == 1
+    # The whole facts definition survived in one statement — the inline-comment
+    # semicolon did not truncate it.
+    assert "object_kind" in facts_create[0]
+    assert "recorded_at" in facts_create[0]
+    assert facts_create[0].rstrip().endswith(")")
+
+
+class _PragmaRejectingConn:
+    """A connection that rejects PRAGMA statements, like remote libSQL/Turso.
+
+    Backed by stdlib sqlite3 so the DDL actually runs; any ``PRAGMA`` raises,
+    reproducing the hosted-only failure where ``executescript`` halted on the
+    schema's leading PRAGMAs and created no tables (Bug B, the missing
+    ``entities``/``facts`` tables on hosted storage).
+    """
+
+    def __init__(self) -> None:
+        import sqlite3
+
+        self._c = sqlite3.connect(":memory:")
+
+    def execute(self, sql: str, params: tuple = ()):  # type: ignore[no-untyped-def]
+        if sql.lstrip().upper().startswith("PRAGMA"):
+            raise RuntimeError("PRAGMA not supported on this remote backend")
+        return self._c.execute(sql, params)
+
+    def commit(self) -> None:
+        self._c.commit()
+
+    def table_names(self) -> set[str]:
+        rows = self._c.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        return {r[0] for r in rows}
+
+
+def test_migrations_apply_when_pragmas_are_rejected() -> None:
+    """Regression for hosted storage (Bug B): the full schema must be created
+    even when the backend rejects the leading PRAGMAs, as remote Turso does."""
+    storage = LibSqlStorage("ignored://remote")
+    storage._conn = _PragmaRejectingConn()  # inject the remote-style connection
+    storage._apply_migrations()
+    tables = storage._conn.table_names()  # type: ignore[attr-defined]
+    assert {"entities", "facts", "fact_provenance", "entity_embeddings"} <= tables

--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/heuristics/sycophancy.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/heuristics/sycophancy.py
@@ -194,9 +194,9 @@ def _check_escalating_validation(candidate: str) -> SycophancyMatch | None:
 
 
 def _check_repeated_reassurance(
-    messages: list[tuple[str, str]],
+    messages: list[tuple[str, str | None]],
 ) -> SycophancyMatch | None:
-    hits: list[tuple[str, str]] = []
+    hits: list[tuple[str, str | None]] = []
     for text, at in messages:
         lowered = text.lower()
         if any(trigger in lowered for trigger in REASSURANCE_TRIGGERS):
@@ -220,7 +220,7 @@ def _check_repeated_reassurance(
 def evaluate(
     *,
     candidate_response: str | None,
-    recent_user_messages: list[tuple[str, str]] | None,
+    recent_user_messages: list[tuple[str, str | None]] | None,
 ) -> SycophancyMatch:
     soft_other: SycophancyMatch | None = None
     if recent_user_messages:

--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/server.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/server.py
@@ -45,6 +45,23 @@ class _ToolError(RuntimeError):
         self.metadata = metadata or {}
 
 
+def _validation_message(exc: ValidationError) -> str:
+    """Turn a pydantic ValidationError into an actionable, field-named message.
+
+    The bare "input failed schema validation" left callers blind to which nested
+    field was wrong (the advertised MCP schema is an open object, so the caller
+    cannot see the required keys). Name the offending field paths and the reason
+    so the model can self-correct — matching the field-level errors the other
+    NeuroDock tools (check_tone, decompose, record_fact) already emit.
+    """
+    parts: list[str] = []
+    for err in exc.errors()[:6]:
+        loc = ".".join(str(p) for p in err.get("loc", ())) or "(root)"
+        parts.append(f"{loc}: {err.get('msg', 'invalid')}")
+    detail = "; ".join(parts) if parts else "input did not match the expected shape"
+    return f"input failed schema validation — {detail}"
+
+
 def build_server() -> FastMCP[Any]:
     mcp: FastMCP[Any] = FastMCP(name=SERVER_NAME, version=SERVER_VERSION)
 
@@ -80,7 +97,7 @@ def build_server() -> FastMCP[Any]:
                 }
             )
         except ValidationError as exc:
-            raise _ToolError("INPUT_INVALID", "input failed schema validation") from exc
+            raise _ToolError("INPUT_INVALID", _validation_message(exc)) from exc
         try:
             result = check_rumination(payload)
         except HistoryOutOfOrderError as exc:
@@ -121,7 +138,7 @@ def build_server() -> FastMCP[Any]:
                 }
             )
         except ValidationError as exc:
-            raise _ToolError("INPUT_INVALID", "input failed schema validation") from exc
+            raise _ToolError("INPUT_INVALID", _validation_message(exc)) from exc
         try:
             result = check_hyperfocus(payload)
         except SessionIdMismatchError as exc:
@@ -156,7 +173,7 @@ def build_server() -> FastMCP[Any]:
                 }
             )
         except ValidationError as exc:
-            raise _ToolError("INPUT_INVALID", "input failed schema validation") from exc
+            raise _ToolError("INPUT_INVALID", _validation_message(exc)) from exc
         try:
             result = check_sycophancy(payload)
         except SycophancyInputMissingError as exc:

--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/tools/check_sycophancy.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/tools/check_sycophancy.py
@@ -86,7 +86,7 @@ def check_sycophancy(payload: SycophancyInput) -> SycophancyOutput:
             "at least one of candidate_response or recent_user_messages is required"
         )
 
-    messages: list[tuple[str, str]] | None = None
+    messages: list[tuple[str, str | None]] | None = None
     if payload.recent_user_messages is not None:
         messages = [(msg.text, msg.at) for msg in payload.recent_user_messages]
 

--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/types.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/types.py
@@ -6,11 +6,32 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
 class _Base(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+
+class _InputItem(BaseModel):
+    """Base for the caller-supplied nested objects (history items, the
+    chronometric snapshot, recent messages).
+
+    These receive raw dicts the calling model assembles, so they are lenient
+    where the strict output contract is not: extra keys are ignored rather than
+    rejected (the advertised MCP schema is an open object, so a caller cannot
+    know which keys are forbidden), and fields accept their canonical name or a
+    natural alias. The heuristics still read the canonical fields, unchanged.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+
+# Aliases for the two recurring caller fields, so the natural shapes an LLM
+# produces ({"prompt"/"message"/"content": ...}, {"timestamp"/"time": ...}) map
+# onto the canonical `text`/`at` the heuristics consume.
+_TEXT_ALIASES = AliasChoices("text", "message", "prompt", "content")
+_AT_ALIASES = AliasChoices("at", "timestamp", "time", "ts")
 
 
 HeuristicName = Literal["word_overlap_jaccard", "embedding_cosine", "topic_model"]
@@ -78,9 +99,9 @@ DEFAULT_FP_FEEDBACK_PATH: str = (
 )
 
 
-class RuminationHistoryItem(_Base):
-    text: str = Field(min_length=1, max_length=8000)
-    at: str
+class RuminationHistoryItem(_InputItem):
+    text: str = Field(min_length=1, max_length=8000, validation_alias=_TEXT_ALIASES)
+    at: str = Field(validation_alias=_AT_ALIASES)
 
 
 class RuminationInput(_Base):
@@ -121,20 +142,22 @@ class RuminationOutput(_Base):
     false_positive_feedback_path: str = DEFAULT_FP_FEEDBACK_PATH
 
 
-class OpenSessionSnapshot(_Base):
+class OpenSessionSnapshot(_InputItem):
     session_id: str
-    started_at: str
+    started_at: str = Field(validation_alias=AliasChoices("started_at", "startedAt", "start"))
     intent: str = Field(min_length=1, max_length=500)
-    elapsed_seconds: int = Field(ge=0)
+    elapsed_seconds: int = Field(
+        ge=0, validation_alias=AliasChoices("elapsed_seconds", "elapsedSeconds")
+    )
 
 
-class ChronometricSnapshot(_Base):
-    open_session: OpenSessionSnapshot | None
-    now: str
+class ChronometricSnapshot(_InputItem):
+    open_session: OpenSessionSnapshot | None = None
+    now: str = Field(validation_alias=_AT_ALIASES)
     idle_signal: HyperfocusIdleSignal | None = None
 
 
-class EscalationThresholds(_Base):
+class EscalationThresholds(_InputItem):
     gentle: int = Field(ge=5, le=480)
     nudge: int = Field(ge=5, le=480)
     hard: int = Field(ge=5, le=480)
@@ -175,9 +198,11 @@ class HyperfocusOutput(_Base):
     false_positive_feedback_path: str = DEFAULT_FP_FEEDBACK_PATH
 
 
-class SycophancyRecentMessage(_Base):
-    text: str = Field(min_length=1, max_length=8000)
-    at: str
+class SycophancyRecentMessage(_InputItem):
+    text: str = Field(min_length=1, max_length=8000, validation_alias=_TEXT_ALIASES)
+    # Sycophancy is not time-windowed (unlike rumination), so a timestamp is
+    # optional here — a bare {"text": "..."} message is valid.
+    at: str | None = Field(default=None, validation_alias=_AT_ALIASES)
 
 
 class SycophancyInput(_Base):

--- a/packages/mcp-guardrail/tests/test_input_tolerance.py
+++ b/packages/mcp-guardrail/tests/test_input_tolerance.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Caller-input tolerance for the guardrail tools (Bug A regression).
+
+The nested objects an LLM assembles for check_rumination / check_hyperfocus /
+check_sycophancy used to be validated by `extra="forbid"` models that required
+exact keys (`text`, `at`, ...). Because the advertised MCP schema is an open
+object, the caller could not know those keys, so natural shapes
+({"prompt","timestamp"}, {"text"}) failed with an opaque INPUT_INVALID. These
+tests pin the loosened behaviour: alias the common fields, ignore extras, and
+emit an actionable field-named error.
+"""
+
+from __future__ import annotations
+
+import pytest
+from neurodock_mcp_guardrail.server import _validation_message
+from neurodock_mcp_guardrail.types import (
+    RuminationInput,
+    SycophancyInput,
+)
+from pydantic import ValidationError
+
+
+def test_rumination_history_accepts_prompt_timestamp_aliases() -> None:
+    payload = RuminationInput.model_validate(
+        {
+            "current_prompt": "should I rewrite the intro again",
+            # Natural LLM shape: prompt/timestamp, plus an extra key.
+            "history": [
+                {
+                    "prompt": "should I rewrite the intro",
+                    "timestamp": "2026-06-10T09:00:00Z",
+                    "role": "user",
+                },
+            ],
+        }
+    )
+    assert payload.history[0].text == "should I rewrite the intro"
+    assert payload.history[0].at == "2026-06-10T09:00:00Z"
+
+
+def test_rumination_history_accepts_canonical_keys_too() -> None:
+    payload = RuminationInput.model_validate(
+        {
+            "current_prompt": "x",
+            "history": [{"text": "y", "at": "2026-06-10T09:00:00Z"}],
+        }
+    )
+    assert payload.history[0].text == "y"
+
+
+def test_sycophancy_accepts_bare_text_message_without_timestamp() -> None:
+    # The blocker the QA pass hit: a {"text": ...} object (no `at`) is valid for
+    # sycophancy, which is not time-windowed.
+    payload = SycophancyInput.model_validate(
+        {"recent_user_messages": [{"text": "are you sure that's right?"}]}
+    )
+    assert payload.recent_user_messages is not None
+    assert payload.recent_user_messages[0].text == "are you sure that's right?"
+    assert payload.recent_user_messages[0].at is None
+
+
+def test_validation_message_names_the_offending_field() -> None:
+    with pytest.raises(ValidationError) as caught:
+        RuminationInput.model_validate(
+            {"current_prompt": "x", "history": [{"timestamp": "2026-06-10T09:00:00Z"}]}
+        )
+    message = _validation_message(caught.value)
+    assert "input failed schema validation" in message
+    # Names the path + reason rather than the old opaque blanket message.
+    assert "history" in message and "0" in message
+    assert "input failed schema validation —" in message


### PR DESCRIPTION
## Summary

Two hosted-server bugs found by a live tool-by-tool QA pass against `mcp.neurodock.org`.

### Bug B — graph tables never created on hosted storage (HIGH)
`recall_entity` / `recall_decisions` / `weekly_rollup` / `record_fact` all failed with `SQLite: no such table: entities/facts`. `LibSqlStorage` applied migrations via `executescript`, which **silently halts on the schema's leading local-only PRAGMAs** (`journal_mode = WAL`, `foreign_keys = ON`) over a remote `libsql://`/Turso connection — so **no `CREATE TABLE` ran**. The unit tests only use local `file:` URLs (which accept the PRAGMAs), so this was hosted-only.

**Fix:** apply migrations **statement-by-statement**, skipping an unsupported PRAGMA instead of aborting; add a splitter that strips inline comments first (one is `-- nullable; populated`, whose semicolon would otherwise split a `CREATE TABLE`). Regression test drives a PRAGMA-rejecting connection and asserts the full schema is created.

### Bug A — guardrail tools rejected natural nested input (MEDIUM)
`check_hyperfocus` / `check_rumination` / `check_sycophancy` returned `INPUT_INVALID` with **no field name**. The nested item models were `extra="forbid"` and required exact keys (`text`, `at`, …), but the advertised MCP schema is an open object, so a caller can't know them.

**Fix:** the caller-supplied item models now **ignore extra keys** and accept **natural aliases** (`prompt`/`message`/`content` → `text`; `timestamp`/`time` → `at`); the sycophancy message timestamp is **optional** (it isn't time-windowed); and `INPUT_INVALID` now **names the offending field path**. Output contracts stay strict (`extra="forbid"`).

## Not changed (by design — defer to the LLM layer)
The QA pass also noted shallow deterministic detection (subtext, sycophancy sensitivity) — those intentionally defer to the structured LLM-refinement prompts, per ADR 0005.

## Test plan
- [x] `pytest packages/mcp-guardrail packages/mcp-cognitive-graph` — 155 passed (incl. new regressions)
- [x] `ruff` + `mypy --strict` clean
- [ ] CI green

## Deploy
Both packages ship inside the hosted remote image — **`wrangler deploy` is required** for the live `mcp.neurodock.org` server to pick these up.