### PR TITLE
chore: add stdio entrypoint + glama docker image for one-listing introspection

### DIFF
--- a/packages/remote/Dockerfile.glama
+++ b/packages/remote/Dockerfile.glama
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+# NeuroDock — Glama introspection image.
+#
+# This image exists ONLY so the Glama registry (glama.ai) can build the server,
+# start it, and enumerate its tools (tools/list) to produce a quality/coherence
+# score and a release. It runs the SAME combined server the hosted deploy uses
+# (translation + guardrail + decompose + the opt-in storage/graph surface), but
+# over STDIO and WITHOUT auth — introspection only lists tools, it never calls
+# them, so no IdP, no secrets, and no Turso/Clerk configuration are needed.
+#
+# This is NOT the production transport. The hosted server is HTTP + OAuth via
+# packages/remote/Dockerfile; local users run the individual stdio servers
+# through @neurodock/cli. Point the Glama build spec at this file.
+#
+# Build from the REPO ROOT (the workspace graph must be visible):
+#   docker build -f packages/remote/Dockerfile.glama -t neurodock-glama .
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+
+# Workspace metadata + lockfile first for layer caching, then the whole workspace
+# (neurodock-remote resolves three sibling packages from the frozen lock).
+COPY pyproject.toml uv.lock README.md ./
+COPY packages/ ./packages/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --package neurodock-remote
+
+# Keep the image lean: skip the embedding rung so fastembed is never imported and
+# no model is downloaded (introspection does not exercise the graph anyway).
+ENV NEURODOCK_GRAPH_DISABLE_EMBEDDINGS=1
+
+# Run as a non-root user.
+RUN useradd --create-home --uid 10001 neurodock \
+    && chown -R neurodock:neurodock /app
+USER neurodock
+
+# stdio MCP server: Glama (via mcp-proxy) speaks JSON-RPC over stdio to list tools.
+ENTRYPOINT ["neurodock-remote-stdio"]

--- a/packages/remote/pyproject.toml
+++ b/packages/remote/pyproject.toml
@@ -41,6 +41,9 @@ test = [
 
 [project.scripts]
 neurodock-remote = "neurodock_remote.app:main"
+# stdio transport for registry introspection (Glama Dockerfile.glama); not a
+# user-facing transport — the hosted deploy serves Streamable HTTP.
+neurodock-remote-stdio = "neurodock_remote.app:main_stdio"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/remote/src/neurodock_remote/app.py
+++ b/packages/remote/src/neurodock_remote/app.py
@@ -247,5 +247,30 @@ def main() -> None:
     uvicorn.run(create_app(), host=host, port=port)
 
 
+def main_stdio() -> None:
+    """Console-script entrypoint that serves the combined surface over **stdio**
+    (``neurodock-remote-stdio``).
+
+    This exists for registry introspection (e.g. Glama builds the
+    ``Dockerfile.glama`` image and speaks MCP over stdio to enumerate the tool
+    surface). It is NOT a user-facing transport — the hosted deployment serves
+    Streamable HTTP via :func:`create_app`/:func:`main`, and local users run the
+    individual stdio servers through ``@neurodock/cli``.
+
+    No auth and no storage secrets are required: a ``tools/list`` introspection
+    only *enumerates* the registered tools, it never calls them, and the opt-in
+    storage tools stay gated behind ``require_user`` exactly as elsewhere. So the
+    same combined server that the HTTP deploy builds is run here unchanged, just
+    over stdio.
+    """
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format='{"logger":"%(name)s","level":"%(levelname)s","msg":"%(message)s"}',
+    )
+    _LOG.info("serving_combined_remote_mcp_stdio")
+    build_combined_server().run()
+
+
 if __name__ == "__main__":  # pragma: no cover — exercised via console script
     main()


### PR DESCRIPTION
## Summary

Enables a **single Glama listing covering all of NeuroDock's tools** (rather than one server per repo). Glama builds a Dockerfile, starts the server, and enumerates tools via `tools/list` — it never calls them — so introspection needs **no auth and no storage secrets**.

- **`main_stdio()`** (console script `neurodock-remote-stdio`) — runs the **same** combined server the HTTP deploy builds, but over **stdio**. The opt-in storage tools stay gated behind `require_user`; listing just enumerates them.
- **`packages/remote/Dockerfile.glama`** — repo-root build, installs `neurodock-remote` from the frozen lock, runs the stdio entrypoint as a non-root user, no IdP/Turso/Clerk config. **Not** the production transport (the HTTP + OAuth `Dockerfile` is unchanged).

## Verified
`build_combined_server()` with empty env lists **all 17 tools** (translation ×4, guardrail ×3, `decompose`, storage-admin ×5, cognitive-graph ×4). `FastMCP.run` (stdio) present; ruff + mypy clean; 38 remote tests pass.

## To use (on Glama, after merge)
Point the Glama build spec at **`packages/remote/Dockerfile.glama`** → Deploy → Make Release. The listing then covers the whole tool surface.

> Coherence-score note: a single 17-tool mixed surface may score lower on Server Coherence than a focused server, but it represents the whole product in one entry — that tradeoff is the maintainer's call.

## Test plan
- [x] ruff + mypy clean; 38 remote tests pass; introspection lists 17 tools
- [ ] CI green