### PR TITLE
fix: record_fact accepts json-stringified subject/object (unblocks hosted writes)

### DIFF
--- a/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/tools/_entities.py
+++ b/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/tools/_entities.py
@@ -9,6 +9,7 @@ resolve the subject, resolve the object, then write the fact.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Any, cast
 
@@ -36,6 +37,27 @@ _VALID_CALL_EXAMPLE: dict[str, Any] = {
 }
 
 
+def _coerce_object(raw: Any) -> Any:
+    """Tolerate a JSON-stringified object on the wire.
+
+    ``subject``/``object`` are declared untyped in the published MCP inputSchema
+    (so the friendly shape errors below can fire instead of a raw Pydantic 422).
+    A standards-compliant MCP client serialises an object argument for an untyped
+    parameter into a JSON *string* in transit — e.g. ``'{"type":"project",
+    "name":"NeuroDock"}'`` arrives as a bare string and is rejected. If ``raw`` is
+    a string that decodes to a JSON object, decode it; otherwise leave it
+    untouched so the existing shape errors still apply to genuinely-wrong input.
+    """
+    if isinstance(raw, str):
+        try:
+            decoded = json.loads(raw)
+        except (ValueError, TypeError):
+            return raw
+        if isinstance(decoded, dict):
+            return decoded
+    return raw
+
+
 def _describe_received(raw: Any) -> str:
     """Render the actual input shape for the friendly error message."""
     if raw is None:
@@ -57,6 +79,7 @@ def resolve_subject(
 ) -> tuple[FactSubject, list[AutoCreatedEntity]]:
     """Return the resolved subject reference and any auto-created entity."""
     valid_types = sorted(VALID_ENTITY_TYPES)
+    raw = _coerce_object(raw)
     if not isinstance(raw, dict):
         raise ToolError(
             "SUBJECT_REQUIRED",
@@ -129,6 +152,7 @@ def resolve_object(
 ) -> tuple[str | None, str | None, FactObjectEntity | LiteralValue, list[AutoCreatedEntity]]:
     """Return ``(object_id, object_literal, object_payload, auto_created)``."""
     valid_types = sorted(VALID_ENTITY_TYPES)
+    raw = _coerce_object(raw)
     if not isinstance(raw, dict):
         raise ToolError(
             "OBJECT_REQUIRED",

--- a/packages/mcp-cognitive-graph/tests/test_record_fact.py
+++ b/packages/mcp-cognitive-graph/tests/test_record_fact.py
@@ -250,3 +250,41 @@ def test_payload_omits_hint_and_example_when_absent() -> None:
 
     payload = TE("GRAPH_WRITE_FAILED", "disk full").to_payload()
     assert payload == {"error": "GRAPH_WRITE_FAILED", "message": "disk full"}
+
+
+def test_accepts_json_stringified_subject_and_object(
+    memory_storage: InMemoryStorage,
+    fixed_clock: FixedClock,
+) -> None:
+    """A standards-compliant MCP client serialises an object argument for an
+    untyped parameter into a JSON string in transit. record_fact must decode
+    that rather than reject it — the bug that left hosted graphs empty because
+    every write failed with "subject must be an object; got a bare string"."""
+    import json
+
+    result = record_fact(
+        memory_storage,
+        fixed_clock,
+        subject=json.dumps({"type": "project", "name": "NeuroDock"}),
+        predicate="tagged",
+        object=json.dumps({"literal": "external-memory"}),
+    )
+    assert result.fact_id.startswith("fact_")
+    assert "NeuroDock" in {e.name for e in result.auto_created_entities}
+
+
+def test_bare_non_json_string_subject_still_raises_friendly_error(
+    memory_storage: InMemoryStorage,
+    fixed_clock: FixedClock,
+) -> None:
+    """A genuinely wrong bare string (not a JSON object) still gets the friendly
+    SUBJECT_REQUIRED shape error — the coercion only rescues stringified JSON."""
+    with pytest.raises(ToolError) as exc_info:
+        record_fact(
+            memory_storage,
+            fixed_clock,
+            subject="just some prose",
+            predicate="tagged",
+            object={"literal": "x"},
+        )
+    assert exc_info.value.code == "SUBJECT_REQUIRED"

--- a/packages/remote/src/neurodock_remote/app.py
+++ b/packages/remote/src/neurodock_remote/app.py
@@ -268,6 +268,11 @@ def main_stdio() -> None:
         level=logging.INFO,
         format='{"logger":"%(name)s","level":"%(levelname)s","msg":"%(message)s"}',
     )
+    # Introspection never exercises the embedding rung, so default it off: this
+    # keeps fastembed from being imported (no model download) and means a Glama
+    # build needs no environment configuration at all. An explicit env value, if
+    # set, still wins.
+    os.environ.setdefault("NEURODOCK_GRAPH_DISABLE_EMBEDDINGS", "1")
     _LOG.info("serving_combined_remote_mcp_stdio")
     build_combined_server().run()
 


### PR DESCRIPTION
## Summary

From the post-redeploy smoke test — the redeploy confirmed Bug A (actionable errors) and Bug B (hosted graph tables) are fixed. This closes the one remaining **blocking** bug + a small Glama-build convenience.

### `record_fact` — JSON-stringified object args (BLOCKING)
`subject`/`object` are declared untyped in the published MCP inputSchema (so the *friendly* shape errors can fire instead of a raw Pydantic 422). A standards-compliant client serialises an object argument for an untyped parameter into a **JSON string** in transit, so `{"type":"project","name":"NeuroDock"}` arrived as a bare string and was rejected (`subject must be an object; got a bare string`). **Every write failed → hosted graphs stayed empty** (which is why `recall_entity`/`recall_decisions`/`weekly_rollup` executed correctly but returned nothing).

`resolve_subject` / `resolve_object` now **decode a JSON-stringified object** before the shape check. Genuinely-wrong input (non-JSON prose) still gets the friendly `SUBJECT_REQUIRED` error — coercion only rescues stringified JSON. Tests cover both.

### Glama stdio — default embeddings off
`main_stdio()` now defaults `NEURODOCK_GRAPH_DISABLE_EMBEDDINGS=1`, so a Glama introspection build needs **no env config** and never imports fastembed (a `tools/list` probe doesn't touch the embedding rung). An explicit env value still wins.

## Test plan
- [x] full cognitive-graph + remote suites — 117 passed (incl. new stringified-arg regressions)
- [x] per-package `ruff` + `mypy --strict` clean
- [x] smoke: `record_fact` with stringified subject/object writes the fact

## Deploy
The record_fact fix is in `mcp-cognitive-graph` (bundled in the hosted image) — **`wrangler deploy` required** for live `mcp.neurodock.org`.

## Noted, not in this PR (your call — follow-ups)
- **Schema-vs-validator drift** (published schema doesn't advertise runtime constraints): `target_register` enum (`check_tone`/`rewrite_outgoing`), `time_budget` ISO-8601 (`decompose`), `end_of_day_local` HH:MM + `chronometric_snapshot.at` required (`check_hyperfocus`). Fix = type those params with their real constraints so FastMCP publishes them.
- **`check_sycophancy` sensitivity** — false negative on blatant over-validation; heuristic-corpus tuning (deterministic layer defers to the LLM by design).