### PR TITLE
fix: publish runtime constraints in tool schemas so the contract stops lying

### DIFF
--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/server.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/server.py
@@ -7,11 +7,11 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 
 from neurodock_mcp_guardrail.tools.check_hyperfocus import (
     SessionIdMismatchError,
@@ -120,10 +120,23 @@ def build_server() -> FastMCP[Any]:
         ),
     )
     def _check_hyperfocus(
-        chronometric_snapshot: dict[str, Any],
+        chronometric_snapshot: Annotated[
+            dict[str, Any],
+            Field(
+                description=(
+                    "Current timing snapshot. Required: 'now' (ISO-8601 timestamp). "
+                    "Optional: 'open_session' as {'session_id', 'started_at' (ISO-8601), "
+                    "'intent', 'elapsed_seconds'} or null when no session is open, and "
+                    "'idle_signal' in {active, switched_away, unknown}."
+                ),
+            ),
+        ],
         session_id: str | None = None,
         hyperfocus_break_minutes: int = 90,
-        end_of_day_local: str | None = None,
+        end_of_day_local: Annotated[
+            str | None,
+            Field(description="Local end-of-day time as HH:MM, 24-hour, e.g. '18:00'."),
+        ] = None,
         escalation_thresholds: dict[str, int] | None = None,
     ) -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "check_hyperfocus"})

--- a/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/server.py
+++ b/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/server.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import Field
 
 from neurodock_mcp_task_fractionator.decomposer import (
     AcceptanceCriteriaRequiredError,
@@ -103,7 +104,19 @@ def build_server(
             openWorldHint=False,
         ),
     )
-    def _decompose(goal: str, time_budget: str | None = None) -> dict[str, Any]:
+    def _decompose(
+        goal: str,
+        time_budget: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Optional total time budget as an ISO-8601 duration, e.g. "
+                    "'PT2H' (2 hours) or 'PT90M' (90 minutes) — not prose like "
+                    "'a couple of hours'."
+                ),
+            ),
+        ] = None,
+    ) -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "decompose"})
         try:
             result = decompose(goal=goal, time_budget=time_budget)

--- a/packages/mcp-translation/src/neurodock_mcp_translation/server.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/server.py
@@ -31,6 +31,7 @@ from neurodock_mcp_translation.types import (
     BriefMeetingInput,
     CheckToneInput,
     RewriteOutgoingInput,
+    TargetRegister,
     TranslateIncomingInput,
 )
 
@@ -133,7 +134,7 @@ def build_server() -> FastMCP[Any]:
     def _check_tone(
         text: str,
         baseline_messages: list[str] | None = None,
-        target_register: str | None = None,
+        target_register: TargetRegister | None = None,
         channel: str | None = None,
     ) -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "check_tone"})
@@ -141,7 +142,7 @@ def build_server() -> FastMCP[Any]:
             payload = CheckToneInput(
                 text=text,
                 baseline_messages=baseline_messages,
-                target_register=target_register,  # type: ignore[arg-type]
+                target_register=target_register,
                 channel=channel,  # type: ignore[arg-type]
             )
         except ValidationError as exc:
@@ -167,7 +168,7 @@ def build_server() -> FastMCP[Any]:
     )
     def _rewrite_outgoing(
         text: str,
-        target_register: str,
+        target_register: TargetRegister,
         preserve_terms: list[str] | None = None,
         channel: str | None = None,
         preserve_intent: bool = True,
@@ -176,7 +177,7 @@ def build_server() -> FastMCP[Any]:
         try:
             payload = RewriteOutgoingInput(
                 text=text,
-                target_register=target_register,  # type: ignore[arg-type]
+                target_register=target_register,
                 preserve_terms=preserve_terms,
                 channel=channel,  # type: ignore[arg-type]
                 preserve_intent=preserve_intent,


### PR DESCRIPTION
## Summary

Closes the schema-vs-validator drift the QA pass flagged: several tools advertised free-form values in their exported MCP inputSchema while the handler enforced enums/formats — so a client couldn't get them right first try. Type the parameters with their real constraints so FastMCP publishes them.

| Tool(s) | Param | Before (published) | After (published) |
|---|---|---|---|
| `check_tone`, `rewrite_outgoing` | `target_register` | free-form string | **enum** `{direct, warm, formal, concise, clarifying}` |
| `decompose` | `time_budget` | free-form string | string **+ description**: ISO-8601 duration (`PT2H`/`PT90M`), not prose |
| `check_hyperfocus` | `end_of_day_local` | free-form string | string **+ description**: HH:MM 24-hour |
| `check_hyperfocus` | `chronometric_snapshot` | bare object | object **+ description**: required `now`, the `open_session` shape, `idle_signal` |

Verified the published `inputSchema` now carries the enum + descriptions (introspected via the combined server).

## Design choices
- **Enum** is enforced (closed set) — clients pick from the list, no error needed.
- **Descriptions** (not regex patterns) for the format fields, so the friendly, field-named `INPUT_INVALID` (added last round) still fires on a bad value rather than a raw schema rejection. No behaviour change for valid input.
- `target_register` is now the existing `TargetRegister` Literal — the `str -> Literal` casts drop their `# type: ignore`.

## Test plan
- [x] ruff + per-package `mypy --strict` clean
- [x] 191 tests (translation + task-fractionator + guardrail) + 38 remote — all pass
- [ ] CI green

## Deploy
Ships in the hosted image; `wrangler deploy` to update `mcp.neurodock.org` (bundle with the record_fact redeploy).