### PR TITLE
fix: surface decisions linked to a project by belongs_to, not only decided_in

### DIFF
--- a/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/rollup.py
+++ b/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/rollup.py
@@ -17,11 +17,14 @@ blocker on <subject>: '<literal>'", "Follow up on decision '<name>' …").
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from datetime import date as _date
 
-from neurodock_mcp_cognitive_graph.storage.base import EntityRow, FactRow, Storage
+from neurodock_mcp_cognitive_graph.storage.base import (
+    PROJECT_DECISION_PREDICATES,
+    FactRow,
+    Storage,
+)
 from neurodock_mcp_cognitive_graph.tools._shared import fact_row_to_fact
 from neurodock_mcp_cognitive_graph.types import (
     DecisionAttributor,
@@ -30,18 +33,6 @@ from neurodock_mcp_cognitive_graph.types import (
     Period,
     RollupDecision,
 )
-
-
-@dataclass
-class _DecisionSlot:
-    """Mutable accumulator used while assembling rollup decisions."""
-
-    row: EntityRow
-    recorded_at: datetime
-    attributors: list[DecisionAttributor] = field(default_factory=list)
-    source: str | None = None
-    confidence: float = 1.0
-
 
 NEXT_ACTIONS_CAP = 10
 DECISIONS_CAP = 50
@@ -70,62 +61,62 @@ def collect_decisions_in_window(
     period: Period,
     project_id: str | None,
 ) -> list[RollupDecision]:
-    """Return decisions whose ``decided_in`` fact landed inside ``period``.
+    """Return decisions for the project whose most recent linking fact is in
+    ``period``.
 
-    If ``project_id`` is None, decisions for any project are returned.
+    A decision is associated with the project by a ``decided_in`` OR
+    ``belongs_to`` fact (either orientation) between the decision entity and the
+    project — see :data:`PROJECT_DECISION_PREDICATES`. This matches
+    ``recall_decisions`` so the ``decision belongs_to project`` shape an LLM
+    naturally records surfaces here too. When ``project_id`` is None, every
+    decision entity is considered. Attribution comes from ``decided_in`` facts
+    crediting a non-project, non-decision entity.
     """
-    decided_in_facts = [
-        f for f in storage.facts_by_predicate("decided_in") if _within_period(f.recorded_at, period)
-    ]
     if project_id is not None:
-        decided_in_facts = [
-            f for f in decided_in_facts if f.subject_id == project_id or f.object_id == project_id
-        ]
-
-    # Map decision_id -> slot.
-    accum: dict[str, _DecisionSlot] = {}
-    for fact in decided_in_facts:
-        # Determine which side is the decision (type=decision); attributor is the other.
-        subj_row = storage.find_entity_by_id(fact.subject_id)
-        obj_row = storage.find_entity_by_id(fact.object_id) if fact.object_id is not None else None
-        decision_row: EntityRow | None = None
-        attributor_row: EntityRow | None = None
-        if obj_row is not None and obj_row.type == "decision":
-            decision_row = obj_row
-            attributor_row = subj_row
-        elif subj_row is not None and subj_row.type == "decision":
-            decision_row = subj_row
-            attributor_row = obj_row
-        if decision_row is None:
-            continue
-        slot = accum.setdefault(
-            decision_row.id,
-            _DecisionSlot(row=decision_row, recorded_at=fact.recorded_at),
-        )
-        if fact.recorded_at > slot.recorded_at:
-            slot.recorded_at = fact.recorded_at
-        if attributor_row is not None and attributor_row.type != "project":
-            attr = DecisionAttributor(
-                type=attributor_row.type, id=attributor_row.id, name=attributor_row.name
-            )
-            if attr not in slot.attributors:
-                slot.attributors.append(attr)
-        if fact.source and slot.source is None:
-            slot.source = fact.source
-        slot.confidence = fact.confidence
+        decision_rows = storage.decisions_for_project(project_id)
+    else:
+        decision_rows = storage.all_decision_entities()
 
     out: list[RollupDecision] = []
-    for slot in accum.values():
+    for decision in decision_rows:
+        facts, _ = storage.facts_touching_entity(decision.id)
+        linking = [f for f in facts if f.predicate in PROJECT_DECISION_PREDICATES]
+        if not linking:
+            continue
+        recorded_at = max(f.recorded_at for f in linking)
+        if not _within_period(recorded_at, period):
+            continue
+
+        ordered = sorted(linking, key=lambda f: f.recorded_at, reverse=True)
+        confidence = ordered[0].confidence
+        source: str | None = None
+        attributors: list[DecisionAttributor] = []
+        for fact in ordered:
+            if fact.source and source is None:
+                source = fact.source
+            if fact.predicate != "decided_in":
+                continue
+            other_id = fact.object_id if fact.subject_id == decision.id else fact.subject_id
+            if other_id is None or other_id == decision.id:
+                continue
+            other = storage.find_entity_by_id(other_id)
+            if other is None or other.type in ("project", "decision"):
+                continue
+            attr = DecisionAttributor(type=other.type, id=other.id, name=other.name)
+            if attr not in attributors:
+                attributors.append(attr)
+
         out.append(
             RollupDecision(
-                id=slot.row.id,
-                name=slot.row.name,
-                decided_on=_date_of(slot.recorded_at),
-                decided_by=slot.attributors,
-                source=slot.source,
-                confidence=slot.confidence,
+                id=decision.id,
+                name=decision.name,
+                decided_on=_date_of(recorded_at),
+                decided_by=attributors,
+                source=source,
+                confidence=confidence,
             )
         )
+
     out.sort(key=lambda d: d.decided_on, reverse=True)
     return out[:DECISIONS_CAP]
 

--- a/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/base.py
+++ b/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/base.py
@@ -22,6 +22,15 @@ DEFAULT_RELATED_CAP = 20
 DEFAULT_DECISIONS_CAP = 200
 """Hard cap on decisions returned per ``recall_decisions`` call."""
 
+PROJECT_DECISION_PREDICATES: tuple[Predicate, ...] = ("decided_in", "belongs_to")
+"""Predicates that link a ``decision`` entity to its project (either orientation).
+
+A decision counts as belonging to a project when a ``decision``-type entity is
+joined to the project by EITHER ``decided_in`` (``project decided_in decision``)
+OR ``belongs_to`` (``decision belongs_to project``). The latter is the shape an
+LLM client naturally records, so both decision read-paths must honour it.
+"""
+
 
 @dataclass(frozen=True)
 class EntityRow:
@@ -141,11 +150,13 @@ class Storage(Protocol):
         self,
         project_id: str,
     ) -> list[FactRow]:
-        """Return facts whose predicate is ``decided_in`` and where the
-        project entity is either subject or object."""
+        """Return facts whose predicate is in :data:`PROJECT_DECISION_PREDICATES`
+        (``decided_in`` or ``belongs_to``) and where the project entity is either
+        subject or object."""
 
     def decisions_for_project(self, project_id: str) -> list[EntityRow]:
-        """Return entities of type ``decision`` linked to the project."""
+        """Return entities of type ``decision`` linked to the project by a
+        ``decided_in`` or ``belongs_to`` fact (either orientation)."""
 
     def all_decision_entities(self) -> list[EntityRow]: ...
 

--- a/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/libsql.py
+++ b/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/libsql.py
@@ -45,6 +45,7 @@ from typing import TYPE_CHECKING, Any, cast
 from neurodock_mcp_cognitive_graph.storage.base import (
     DEFAULT_FACTS_CAP,
     DEFAULT_RELATED_CAP,
+    PROJECT_DECISION_PREDICATES,
     EmbeddingRow,
     EntityRow,
     FactRow,
@@ -348,22 +349,24 @@ class LibSqlStorage:
         return [(r["neighbour_id"], int(r["c"])) for r in rows]
 
     def facts_for_project_decisions(self, project_id: str) -> list[FactRow]:
+        placeholders = ", ".join("?" * len(PROJECT_DECISION_PREDICATES))
         rows = self._query_all(
-            "SELECT * FROM facts WHERE predicate = 'decided_in' "
+            f"SELECT * FROM facts WHERE predicate IN ({placeholders}) "
             "AND (subject_id = ? OR object_id = ?)",
-            (project_id, project_id),
+            (*PROJECT_DECISION_PREDICATES, project_id, project_id),
         )
         return [_row_to_fact(r) for r in rows]
 
     def decisions_for_project(self, project_id: str) -> list[EntityRow]:
+        placeholders = ", ".join("?" * len(PROJECT_DECISION_PREDICATES))
         rows = self._query_all(
             "SELECT DISTINCT e.* FROM entities e "
             "JOIN facts f ON ("
             "   (f.subject_id = e.id AND f.object_id = ?) OR "
             "   (f.object_id = e.id AND f.subject_id = ?)"
             ") "
-            "WHERE e.type = 'decision' AND f.predicate = 'decided_in'",
-            (project_id, project_id),
+            f"WHERE e.type = 'decision' AND f.predicate IN ({placeholders})",
+            (project_id, project_id, *PROJECT_DECISION_PREDICATES),
         )
         return [_row_to_entity(r) for r in rows]
 

--- a/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/memory.py
+++ b/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/memory.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from neurodock_mcp_cognitive_graph.storage.base import (
     DEFAULT_FACTS_CAP,
     DEFAULT_RELATED_CAP,
+    PROJECT_DECISION_PREDICATES,
     EmbeddingRow,
     EntityRow,
     FactRow,
@@ -174,14 +175,14 @@ class InMemoryStorage:
         return [
             row
             for row in self._facts.values()
-            if row.predicate == "decided_in"
+            if row.predicate in PROJECT_DECISION_PREDICATES
             and (row.subject_id == project_id or row.object_id == project_id)
         ]
 
     def decisions_for_project(self, project_id: str) -> list[EntityRow]:
         decision_ids: set[str] = set()
         for row in self._facts.values():
-            if row.predicate != "decided_in":
+            if row.predicate not in PROJECT_DECISION_PREDICATES:
                 continue
             if row.subject_id == project_id and row.object_id is not None:
                 decision_ids.add(row.object_id)

--- a/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/sqlite.py
+++ b/packages/mcp-cognitive-graph/src/neurodock_mcp_cognitive_graph/storage/sqlite.py
@@ -21,6 +21,7 @@ from typing import cast
 from neurodock_mcp_cognitive_graph.storage.base import (
     DEFAULT_FACTS_CAP,
     DEFAULT_RELATED_CAP,
+    PROJECT_DECISION_PREDICATES,
     EmbeddingRow,
     EntityRow,
     FactRow,
@@ -270,22 +271,24 @@ class SQLiteStorage:
         return [(r["neighbour_id"], int(r["c"])) for r in cur.fetchall()]
 
     def facts_for_project_decisions(self, project_id: str) -> list[FactRow]:
+        placeholders = ", ".join("?" * len(PROJECT_DECISION_PREDICATES))
         cur = self._c.execute(
-            "SELECT * FROM facts WHERE predicate = 'decided_in' "
+            f"SELECT * FROM facts WHERE predicate IN ({placeholders}) "
             "AND (subject_id = ? OR object_id = ?)",
-            (project_id, project_id),
+            (*PROJECT_DECISION_PREDICATES, project_id, project_id),
         )
         return [_row_to_fact(r) for r in cur.fetchall()]
 
     def decisions_for_project(self, project_id: str) -> list[EntityRow]:
+        placeholders = ", ".join("?" * len(PROJECT_DECISION_PREDICATES))
         cur = self._c.execute(
             "SELECT DISTINCT e.* FROM entities e "
             "JOIN facts f ON ("
             "   (f.subject_id = e.id AND f.object_id = ?) OR "
             "   (f.object_id = e.id AND f.subject_id = ?)"
             ") "
-            "WHERE e.type = 'decision' AND f.predicate = 'decided_in'",
-            (project_id, project_id),
+            f"WHERE e.type = 'decision' AND f.predicate IN ({placeholders})",
+            (project_id, project_id, *PROJECT_DECISION_PREDICATES),
         )
         return [_row_to_entity(r) for r in cur.fetchall()]
 

--- a/packages/mcp-cognitive-graph/tests/test_recall_decisions.py
+++ b/packages/mcp-cognitive-graph/tests/test_recall_decisions.py
@@ -76,6 +76,58 @@ def test_since_filter_respected(memory_storage: InMemoryStorage) -> None:
     assert result.since.isoformat() == "2026-05-01"
 
 
+def test_decision_via_belongs_to_with_person_attribution_surfaces(
+    memory_storage: InMemoryStorage,
+) -> None:
+    # The shape Claude naturally records: the decision BELONGS_TO the project
+    # (not project decided_in decision), and a person is credited via decided_in
+    # on the decision. Both read-paths must surface it (regression for the
+    # 2026-06-10 retest "decisions don't surface" bug).
+    clock = FixedClock(datetime(2026, 5, 14, 10, 0, tzinfo=UTC))
+    record_fact(
+        memory_storage,
+        clock,
+        subject={"type": "decision", "name": "Adopt hosted Turso storage"},
+        predicate="belongs_to",
+        object={"type": "project", "name": "neurodock"},
+    )
+    record_fact(
+        memory_storage,
+        clock,
+        subject={"type": "person", "name": "Thomas"},
+        predicate="decided_in",
+        object={"type": "decision", "name": "Adopt hosted Turso storage"},
+    )
+
+    result = recall_decisions(memory_storage, "neurodock")
+    assert result.project is not None
+    assert result.project.name == "neurodock"
+    assert len(result.decisions) == 1
+    decision = result.decisions[0]
+    assert decision.name == "Adopt hosted Turso storage"
+    assert [a.name for a in decision.decided_by] == ["Thomas"]
+
+
+def test_decision_via_belongs_to_only_surfaces_without_attributor(
+    memory_storage: InMemoryStorage,
+) -> None:
+    # A decision linked to the project ONLY via belongs_to (no person credited)
+    # still surfaces, with an empty decided_by.
+    clock = FixedClock(datetime(2026, 5, 14, 10, 0, tzinfo=UTC))
+    record_fact(
+        memory_storage,
+        clock,
+        subject={"type": "decision", "name": "License under AGPL-3.0"},
+        predicate="belongs_to",
+        object={"type": "project", "name": "neurodock"},
+    )
+
+    result = recall_decisions(memory_storage, "neurodock")
+    assert len(result.decisions) == 1
+    assert result.decisions[0].name == "License under AGPL-3.0"
+    assert result.decisions[0].decided_by == []
+
+
 def test_invalid_since_raises(memory_storage: InMemoryStorage) -> None:
     with pytest.raises(ToolError) as exc_info:
         recall_decisions(memory_storage, "neurodock", since="not-a-date")

--- a/packages/mcp-cognitive-graph/tests/test_weekly_rollup.py
+++ b/packages/mcp-cognitive-graph/tests/test_weekly_rollup.py
@@ -96,6 +96,36 @@ def test_respects_project_filter(
     assert result.decisions[0].name == "Ship rumination detector first"
 
 
+def test_decision_via_belongs_to_surfaces_in_rollup(
+    memory_storage: InMemoryStorage,
+    fixed_clock: FixedClock,
+) -> None:
+    # Same shape as the 2026-06-10 retest: decision BELONGS_TO project, person
+    # decided_in decision. weekly_rollup must aggregate it under the project.
+    in_window_clock = FixedClock(datetime(2026, 5, 12, 10, 0, tzinfo=UTC))
+    record_fact(
+        memory_storage,
+        in_window_clock,
+        subject={"type": "decision", "name": "Adopt hosted Turso storage"},
+        predicate="belongs_to",
+        object={"type": "project", "name": "neurodock"},
+    )
+    record_fact(
+        memory_storage,
+        in_window_clock,
+        subject={"type": "person", "name": "Thomas"},
+        predicate="decided_in",
+        object={"type": "decision", "name": "Adopt hosted Turso storage"},
+    )
+
+    result = weekly_rollup(memory_storage, fixed_clock, project="neurodock")
+    assert result.project == "neurodock"
+    assert len(result.decisions) == 1
+    assert result.decisions[0].name == "Adopt hosted Turso storage"
+    assert [a.name for a in result.decisions[0].decided_by] == ["Thomas"]
+    assert "1 decisions recorded" in result.summary
+
+
 def test_unknown_project_raises_project_not_found(
     memory_storage: InMemoryStorage,
     fixed_clock: FixedClock,


### PR DESCRIPTION
## What

Fixes **Open issue 1** from the 2026-06-10 post-redeploy MCP retest: `recall_decisions` and `weekly_rollup` returned empty even though the decision was demonstrably in the graph (`record_fact` returned its id, `recall_entity` listed it under `related_entities`).

## Root cause

Both decision read-paths treated a decision as "belonging to" a project **only** when a `decided_in` fact had the project as an endpoint. The retest recorded the decision the way an LLM naturally does:

- `decision belongs_to NeuroDock`
- `Thomas decided_in decision`

The project is an endpoint of the `belongs_to` fact, **not** of any `decided_in` fact — so the project↔decision join never matched and both paths returned empty.

## Fix

- Introduce a shared `PROJECT_DECISION_PREDICATES = ("decided_in", "belongs_to")` constant (the auditable membership rule).
- Broaden `facts_for_project_decisions` and `decisions_for_project` to that set, **either orientation**, across all three storage backends (`memory`, `sqlite`, `libsql` — the hosted Turso backend).
- Rewrite `weekly_rollup`'s decision collector to be **decision-centric** so `belongs_to`-only decisions surface consistently with `recall_decisions`.
- Backward compatible with the existing `project decided_in decision` model the prior tests use.

## Test plan

- New regression tests: the exact retest shape (`belongs_to` + person `decided_in`) for both `recall_decisions` and `weekly_rollup`, plus a `belongs_to`-only decision with no attributor.
- `pytest` 82 passed · `ruff` clean · `mypy --strict` clean.
- `packages/remote` suite 38 passed (composed server unaffected).

## Deploy

Goes live on `mcp.neurodock.org` via `wrangler deploy` from `packages/remote` (image installs from source, not PyPI). No version bump, matching the prior retest-fix PRs.