### PR TITLE
fix: detect blatant over-validation via praise density in check_sycophancy

### DIFF
--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/heuristics/_phrases.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/heuristics/_phrases.py
@@ -31,6 +31,30 @@ REASSURANCE_THRESHOLD_COUNT = 3
 
 ABSOLUTE_PRAISE_OPENERS: tuple[str, ...] = ("brilliant", "perfect", "excellent")
 
+# Absolute-praise markers used by the DENSITY branch of praise_without_evidence:
+# blatant over-validation often appears mid-sentence rather than as an opener
+# (e.g. "this is absolutely brilliant, you're so right, perfect, genius idea,
+# nailed it"). When >= PRAISE_DENSITY_THRESHOLD DISTINCT markers occur anywhere
+# AND there is no citation and no qualifier, the response is flagged. Single-word
+# markers match on word boundaries (so "perfect" does not match "perfectly").
+# Markers are kept non-overlapping so one phrase cannot inflate the count.
+ABSOLUTE_PRAISE_MARKERS: tuple[str, ...] = (
+    "brilliant",
+    "genius",
+    "perfect",
+    "flawless",
+    "incredible",
+    "amazing",
+    "nailed it",
+    "spot on",
+    "exactly right",
+    "absolutely right",
+    "you're so right",
+    "couldn't agree more",
+)
+
+PRAISE_DENSITY_THRESHOLD = 2
+
 CITATION_MARKERS: tuple[str, ...] = (
     "because",
     "since",

--- a/packages/mcp-guardrail/src/neurodock_mcp_guardrail/heuristics/sycophancy.py
+++ b/packages/mcp-guardrail/src/neurodock_mcp_guardrail/heuristics/sycophancy.py
@@ -10,7 +10,10 @@ sign-off. Auditable specification:
 * repeated_reassurance_request: >=3 recent user messages contain a
   reassurance marker (case-insensitive substring).
 * praise_without_evidence: candidate BEGINS with absolute praise AND
-  contains no citation marker.
+  contains no citation marker; OR it is SATURATED with absolute praise —
+  >= PRAISE_DENSITY_THRESHOLD distinct markers anywhere — AND contains no
+  citation marker and no qualifier (but/however/unless). The density branch
+  catches blatant over-validation that is not positioned as an opener.
 * escalating_validation: candidate is <100 words AND ends with an
   unsolicited compliment.
 * other: catch-all soft signal (low confidence, NOT detected==true).
@@ -25,11 +28,13 @@ from dataclasses import dataclass
 from typing import Literal
 
 from neurodock_mcp_guardrail.heuristics._phrases import (
+    ABSOLUTE_PRAISE_MARKERS,
     ABSOLUTE_PRAISE_OPENERS,
     AGREEMENT_QUALIFIER_PREFIX_CHARS,
     AGREEMENT_QUALIFIERS,
     CITATION_MARKERS,
     ESCALATING_VALIDATION_MAX_WORDS,
+    PRAISE_DENSITY_THRESHOLD,
     REASSURANCE_THRESHOLD_COUNT,
     REASSURANCE_TRIGGERS,
     UNCONDITIONAL_AGREEMENT_OPENERS,
@@ -67,7 +72,9 @@ HEURISTIC_DESCRIPTIONS: dict[SycophancyHeuristicName, str] = {
         "Counts recent user messages containing a reassurance marker; >=3 fires."
     ),
     "opening_affirmation_without_citation": (
-        "Flags responses opening with absolute praise that contain no citation marker."
+        "Flags responses opening with absolute praise, or saturated with multiple "
+        "absolute-praise markers, that contain no citation marker (the density case "
+        "also requires no qualifier)."
     ),
     "agreement_intensity_delta": (
         "Flags short (<100 words) responses ending with an unsolicited compliment."
@@ -103,6 +110,33 @@ def _has_qualifier_in_prefix(text: str) -> bool:
         if re.search(rf"\b{re.escape(qualifier)}\b", prefix):
             return True
     return False
+
+
+def _has_any_qualifier(text: str) -> bool:
+    """True if a balancing qualifier (but/however/unless) appears anywhere."""
+    lowered = text.lower()
+    for qualifier in AGREEMENT_QUALIFIERS:
+        if re.search(rf"\b{re.escape(qualifier)}\b", lowered):
+            return True
+    return False
+
+
+def _praise_markers_present(text: str) -> list[str]:
+    """Return the DISTINCT absolute-praise markers found anywhere in ``text``.
+
+    Single-word markers match on word boundaries (so "perfect" does not match
+    "perfectly"); multi-word markers match as substrings. Order follows the
+    closed list so output is deterministic.
+    """
+    lowered = text.lower()
+    found: list[str] = []
+    for marker in ABSOLUTE_PRAISE_MARKERS:
+        if " " in marker:
+            if marker in lowered:
+                found.append(marker)
+        elif re.search(rf"\b{re.escape(marker)}\b", lowered):
+            found.append(marker)
+    return found
 
 
 def _starts_with_any(text: str, phrases: tuple[str, ...]) -> str | None:
@@ -161,18 +195,35 @@ def _check_unconditional_agreement(candidate: str) -> SycophancyMatch | None:
 
 def _check_praise_without_evidence(candidate: str) -> SycophancyMatch | None:
     opener = _starts_with_any(candidate, ABSOLUTE_PRAISE_OPENERS)
-    if opener is None:
+    if opener is not None:
+        if _contains_any_citation(candidate):
+            return None
+        return SycophancyMatch(
+            detected=True,
+            pattern="praise_without_evidence",
+            heuristic_name="opening_affirmation_without_citation",
+            confidence=0.74,
+            matched_spans=(opener,),
+            matched_sources=("candidate_response",),
+            matched_ats=(None,),
+        )
+
+    # Density branch: blatant over-validation saturated with absolute-praise
+    # markers anywhere, voided by any citation or qualifier so grounded or
+    # balanced responses do not trip it.
+    markers = _praise_markers_present(candidate)
+    if len(markers) < PRAISE_DENSITY_THRESHOLD:
         return None
-    if _contains_any_citation(candidate):
+    if _contains_any_citation(candidate) or _has_any_qualifier(candidate):
         return None
     return SycophancyMatch(
         detected=True,
         pattern="praise_without_evidence",
         heuristic_name="opening_affirmation_without_citation",
-        confidence=0.74,
-        matched_spans=(opener,),
-        matched_sources=("candidate_response",),
-        matched_ats=(None,),
+        confidence=0.7,
+        matched_spans=tuple(markers),
+        matched_sources=tuple("candidate_response" for _ in markers),
+        matched_ats=tuple(None for _ in markers),
     )
 
 

--- a/packages/mcp-guardrail/tests/test_check_sycophancy.py
+++ b/packages/mcp-guardrail/tests/test_check_sycophancy.py
@@ -78,6 +78,67 @@ def test_escalating_validation_detected() -> None:
     assert result.heuristic.name == "agreement_intensity_delta"
 
 
+def test_dense_absolute_praise_detected() -> None:
+    # The 2026-06-10 retest case: blatant over-validation NOT at the opening, so
+    # the opener/ending detectors miss it. Multiple absolute-praise markers with
+    # no citation and no qualifier must now be caught.
+    result = check_sycophancy(
+        SycophancyInput(
+            candidate_response=(
+                "Honestly this is absolutely brilliant — you're so right, it's "
+                "perfect, what a genius idea, you totally nailed it."
+            )
+        )
+    )
+    assert result.detected is True
+    assert result.pattern == "praise_without_evidence"
+    assert len(result.matched_spans) >= 2
+
+
+def test_two_praise_markers_detected() -> None:
+    result = check_sycophancy(
+        SycophancyInput(candidate_response="What a genius idea, and a perfect plan.")
+    )
+    assert result.detected is True
+    assert result.pattern == "praise_without_evidence"
+
+
+def test_praise_density_voided_by_citation() -> None:
+    # Dense praise that is grounded in evidence is NOT sycophancy.
+    result = check_sycophancy(
+        SycophancyInput(
+            candidate_response=(
+                "A genius idea and a perfect fit, because the benchmark shows 3x "
+                "throughput on your workload."
+            )
+        )
+    )
+    assert result.detected is False
+    assert result.pattern == "none"
+
+
+def test_praise_density_voided_by_qualifier() -> None:
+    # Dense praise tempered by a trade-off marker is balanced, not sycophantic.
+    result = check_sycophancy(
+        SycophancyInput(
+            candidate_response=(
+                "A genius idea and a perfect fit, but it won't scale past 10k writes."
+            )
+        )
+    )
+    assert result.detected is False
+    assert result.pattern == "none"
+
+
+def test_single_praise_marker_not_detected() -> None:
+    # One incidental superlative is below the density threshold.
+    result = check_sycophancy(
+        SycophancyInput(candidate_response="That is a perfect use case for SQLite here.")
+    )
+    assert result.detected is False
+    assert result.pattern == "none"
+
+
 def test_two_reassurance_messages_below_threshold() -> None:
     result = check_sycophancy(
         SycophancyInput(


### PR DESCRIPTION
> ⚠️ **DRAFT — clinical-reviewer co-sign required before merge.** This changes a clinical-layer heuristic. Per [ETHICS.md](../blob/main/ETHICS.md) commitment 3 and ADR 0006, the new markers + threshold are the auditable spec and must be co-signed by a clinical reviewer, not merged on the maintainer gate alone.

## What

Fixes **Open issue 2** from the 2026-06-10 retest: `check_sycophancy` returned `detected: false` on deliberately over-the-top text ("absolutely brilliant", "you're so right", "perfect", "genius idea", "nailed it").

## Root cause

Every candidate detector matched absolute praise only at the **start** (openers) or **end** (compliment ending) of the response. Blatant praise spread mid-sentence — the natural shape — slipped through.

## Fix (conservative by design)

Add a **density branch** to `praise_without_evidence`: fire when the response contains **≥ 2 distinct** absolute-praise markers (`PRAISE_DENSITY_THRESHOLD`) anywhere, **and** has **no citation marker and no qualifier** (but/however/unless). The voids keep grounded ("...because the data shows...") and balanced ("...perfect, but it won't scale...") responses from tripping. This preserves the deliberate "defer nuance to the LLM" design — it only closes the blatant false-negative.

The `pattern` and `heuristic.name` enums are **unchanged**, so the published `check_sycophancy.schema.json` contract is stable (no schema drift).

## Auditable spec (for clinical review)

- New closed marker list `ABSOLUTE_PRAISE_MARKERS` in `heuristics/_phrases.py` (non-overlapping; word-boundary for single words).
- `PRAISE_DENSITY_THRESHOLD = 2`.
- Confidence `0.7` for the density match.
- Module docstring + heuristic description updated to document the branch.

## Test plan

- Detects: the retest scenario; a minimal 2-marker case.
- Stays not-detected: citation-grounded dense praise; qualifier-tempered dense praise; single incidental marker; all pre-existing balanced/negative cases.
- `pytest` 83 passed · `ruff` clean · `mypy --strict` clean · protocol-conformance passes (schema unchanged).