### PR TITLE
fix: compensate opendyslexic font metrics and clarify full-view icon

### DIFF
--- a/packages/extension-browser/entrypoints/_shared/mountIsland.ts
+++ b/packages/extension-browser/entrypoints/_shared/mountIsland.ts
@@ -134,6 +134,11 @@ export function mountIsland(hostId: string, doc: Document = document): Island {
     }
     :host { all: initial; }
     :host {
+      /* Per-font metric compensation. This sheet declares text sizes in
+         px (not rem), so the root-rem trick in tokens.css cannot reach
+         it. Every font-size below multiplies by this scale instead.
+         Keep the factors in sync with src/styles/tokens.css. */
+      --nd-island-font-scale: 1;
       --nd-font-body: "Atkinson Hyperlegible", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       --nd-font-heading: "Lexend Variable", "Lexend", "Atkinson Hyperlegible", system-ui, -apple-system, sans-serif;
       --nd-color-bg: oklch(98% 0.005 95);
@@ -229,10 +234,12 @@ export function mountIsland(hostId: string, doc: Document = document): Island {
       --nd-font-heading: "Lexend Variable", "Lexend", "Atkinson Hyperlegible", system-ui, -apple-system, sans-serif;
     }
     :host(.font-opendyslexic) {
+      --nd-island-font-scale: 0.85;
       --nd-font-body: "OpenDyslexic", "Atkinson Hyperlegible", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       --nd-font-heading: "OpenDyslexic", "Atkinson Hyperlegible", system-ui, -apple-system, sans-serif;
     }
     :host(.font-comic) {
+      --nd-island-font-scale: 0.95;
       --nd-font-body: "Comic Neue", "Atkinson Hyperlegible", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       --nd-font-heading: "Comic Neue", "Atkinson Hyperlegible", system-ui, -apple-system, sans-serif;
     }
@@ -243,7 +250,7 @@ export function mountIsland(hostId: string, doc: Document = document): Island {
     .neurodock-button {
       pointer-events: auto;
       font-family: var(--nd-font-body);
-      font-size: 14px;
+      font-size: calc(14px * var(--nd-island-font-scale, 1));
       line-height: 1.65;
       padding: 6px 10px;
       border: 1px solid var(--nd-color-hairline);
@@ -258,12 +265,13 @@ export function mountIsland(hostId: string, doc: Document = document): Island {
     .neurodock-panel {
       pointer-events: auto;
       font-family: var(--nd-font-body);
-      font-size: 14px;
+      font-size: calc(14px * var(--nd-island-font-scale, 1));
       line-height: 1.5;
       width: 420px;
       max-width: 92vw;
       max-height: 80vh;
       overflow-y: auto;
+      overflow-wrap: anywhere;
       padding: 12px 14px 14px 14px;
       border: 1px solid var(--nd-color-hairline);
       background: var(--nd-color-bg);
@@ -278,7 +286,7 @@ export function mountIsland(hostId: string, doc: Document = document): Island {
       border: 1px solid var(--nd-color-warn-border);
       background: var(--nd-color-warn-bg);
       color: var(--nd-color-warn-fg);
-      font-size: 14px;
+      font-size: calc(14px * var(--nd-island-font-scale, 1));
     }
     /* RFC B3: pacing-copilot toast. Same hairline + warn tokens as the
        cloud banner so it sits inside the existing visual language. No
@@ -294,13 +302,13 @@ export function mountIsland(hostId: string, doc: Document = document): Island {
       background: var(--nd-color-bg);
       color: var(--nd-color-fg);
       font-family: var(--nd-font-body);
-      font-size: 14px;
+      font-size: calc(14px * var(--nd-island-font-scale, 1));
       line-height: 1.5;
     }
     .neurodock-toast-body { display: flex; flex-direction: column; gap: 4px; flex: 1; }
     .neurodock-toast-title { font-weight: 600; font-family: var(--nd-font-heading); }
     .neurodock-toast-text { color: var(--nd-color-fg-muted); }
-    .neurodock-toast-dismiss { align-self: flex-start; padding: 4px 8px; font-size: 13px; }
+    .neurodock-toast-dismiss { align-self: flex-start; padding: 4px 8px; font-size: calc(13px * var(--nd-island-font-scale, 1)); }
     @media (prefers-reduced-motion: no-preference) {
       .neurodock-toast {
         opacity: 0;

--- a/packages/extension-browser/entrypoints/popup/styles.css
+++ b/packages/extension-browser/entrypoints/popup/styles.css
@@ -128,20 +128,32 @@ samp {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  /* Survive width pressure from large reader fonts: flex children that
+     contain text must be allowed to shrink below their content size. */
+  min-width: 0;
   text-decoration: none;
   color: var(--nd-color-fg-accent);
   font-family: var(--nd-font-heading);
   font-weight: 600;
 }
+.nd-header-wordmark {
+  white-space: nowrap;
+}
 .nd-header-controls {
   display: inline-flex;
   align-items: center;
+  /* Wrap rather than overflow when a wide reader font inflates the
+     font select + toggles past the popup width. */
+  flex-wrap: wrap;
+  min-width: 0;
   gap: 0.5rem;
 }
 .nd-font-switcher select {
   appearance: auto;
   font-family: inherit;
   font-size: 0.8125rem;
+  max-width: 11rem;
+  text-overflow: ellipsis;
   padding: 0.2rem 0.4rem;
   border-radius: 0.25rem;
   border: 1px solid var(--nd-color-hairline);
@@ -155,12 +167,29 @@ samp {
   outline-offset: 2px;
 }
 .nd-header-settings {
+  display: inline-flex;
+  align-items: center;
   background: none;
   border: 1px solid var(--nd-color-hairline);
   border-radius: 0.25rem;
   cursor: pointer;
   color: var(--nd-color-fg);
   padding: 0.2rem 0.4rem;
+}
+
+/* Defensive overflow guards — large reader fonts (OpenDyslexic) must
+   wrap inside cards instead of escaping the fixed-width surface. */
+.nd-powerup,
+.nd-reader-prefs,
+.nd-field {
+  min-width: 0;
+}
+.nd-powerup,
+.nd-reader-prefs {
+  overflow-wrap: anywhere;
+}
+.nd-powerup-cmd code {
+  max-width: 100%;
 }
 
 /* ── PowerUpCard + ReaderPreferences ────────────────────────────────────

--- a/packages/extension-browser/entrypoints/tab/styles.css
+++ b/packages/extension-browser/entrypoints/tab/styles.css
@@ -55,6 +55,19 @@ html {
   font-size: 17px;
 }
 
+/* Metric compensation re-declared against the tab's 17px base. The
+   tokens.css `:root.font-*` percentage rules resolve against the 16px
+   browser default, which would silently drop the tab's larger base;
+   these equal-specificity rules load later, so they win and keep the
+   tab proportional. Keep the 0.85 / 0.95 factors in sync with
+   src/styles/tokens.css. */
+:root.font-opendyslexic {
+  font-size: calc(17px * 0.85);
+}
+:root.font-comic {
+  font-size: calc(17px * 0.95);
+}
+
 body {
   font-family: var(--nd-font-body);
   line-height: var(--nd-line-height);
@@ -142,20 +155,32 @@ samp {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  /* Survive width pressure from large reader fonts: flex children that
+     contain text must be allowed to shrink below their content size. */
+  min-width: 0;
   text-decoration: none;
   color: var(--nd-color-fg-accent);
   font-family: var(--nd-font-heading);
   font-weight: 600;
 }
+.nd-header-wordmark {
+  white-space: nowrap;
+}
 .nd-header-controls {
   display: inline-flex;
   align-items: center;
+  /* Wrap rather than overflow when a wide reader font inflates the
+     font select + toggles past the popup width. */
+  flex-wrap: wrap;
+  min-width: 0;
   gap: 0.5rem;
 }
 .nd-font-switcher select {
   appearance: auto;
   font-family: inherit;
   font-size: 0.8125rem;
+  max-width: 11rem;
+  text-overflow: ellipsis;
   padding: 0.2rem 0.4rem;
   border-radius: 0.25rem;
   border: 1px solid var(--nd-color-hairline);
@@ -169,12 +194,29 @@ samp {
   outline-offset: 2px;
 }
 .nd-header-settings {
+  display: inline-flex;
+  align-items: center;
   background: none;
   border: 1px solid var(--nd-color-hairline);
   border-radius: 0.25rem;
   cursor: pointer;
   color: var(--nd-color-fg);
   padding: 0.2rem 0.4rem;
+}
+
+/* Defensive overflow guards — large reader fonts (OpenDyslexic) must
+   wrap inside cards instead of escaping the fixed-width surface. */
+.nd-powerup,
+.nd-reader-prefs,
+.nd-field {
+  min-width: 0;
+}
+.nd-powerup,
+.nd-reader-prefs {
+  overflow-wrap: anywhere;
+}
+.nd-powerup-cmd code {
+  max-width: 100%;
 }
 
 /* ── PowerUpCard + ReaderPreferences ────────────────────────────────────

--- a/packages/extension-browser/src/components/NeuroDockHeader.tsx
+++ b/packages/extension-browser/src/components/NeuroDockHeader.tsx
@@ -24,7 +24,7 @@ function markUrl(): string {
 }
 
 interface NeuroDockHeaderProps {
-  /** When provided, render a gear button that opens the full settings page. */
+  /** When provided, render an expand button that opens the full-page view. */
   readonly onOpenSettings?: () => void;
 }
 
@@ -51,10 +51,28 @@ export function NeuroDockHeader({ onOpenSettings }: NeuroDockHeaderProps) {
             type="button"
             className="nd-header-settings"
             data-testid="nd-header-settings"
-            aria-label="Open settings"
+            aria-label="Open full view"
+            title="Open full view"
             onClick={onOpenSettings}
           >
-            ⚙
+            {/* Expand icon (YouTube-fullscreen style): four corner
+                brackets pointing outward. currentColor so it themes. */}
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M15 3h6v6" />
+              <path d="M9 21H3v-6" />
+              <path d="M21 3l-7 7" />
+              <path d="M3 21l7-7" />
+            </svg>
           </button>
         )}
       </div>

--- a/packages/extension-browser/src/styles/tokens.css
+++ b/packages/extension-browser/src/styles/tokens.css
@@ -368,3 +368,18 @@
     system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
 }
+
+/* Metric compensation: OpenDyslexic's x-height + heavy bottom weight render
+   ~15% larger than Atkinson at the same declared size, which overflows the
+   fixed-width popup. Scaling the root rem under the class compensates
+   everywhere (Tailwind + --nd-text-* are rem-based). Comic Neue runs slightly
+   narrow-but-tall; a smaller trim keeps line lengths comparable.
+   Surfaces that set their own root font-size (the tab view's 17px) re-declare
+   the same scale against their base; the in-page island sheet is px-based and
+   carries its own --nd-island-font-scale (see mountIsland.ts). */
+:root.font-opendyslexic {
+  font-size: 85%;
+}
+:root.font-comic {
+  font-size: 95%;
+}

--- a/packages/extension-browser/tests/unit/bootstrap-reader-font.test.tsx
+++ b/packages/extension-browser/tests/unit/bootstrap-reader-font.test.tsx
@@ -65,4 +65,37 @@ describe("island stylesheet font-class contract", () => {
 
     island.destroy();
   });
+
+  it("shadow stylesheet carries the per-font metric compensation scale", () => {
+    // Arrange + Act
+    const island = mountIsland(HOST_ID);
+    const css = island.shadow.querySelector("style")!.textContent ?? "";
+
+    // The island sheet is px-based, so the rem trick in tokens.css does
+    // not reach it. The compensation mechanism is a custom property
+    // (--nd-island-font-scale) defaulting to 1, overridden per font
+    // class, and multiplied into every text-size declaration via calc().
+    expect(css).toMatch(/:host\s*{[^}]*--nd-island-font-scale:\s*1\b/);
+    expect(css).toMatch(
+      /:host\(\.font-opendyslexic\)\s*{[^}]*--nd-island-font-scale:\s*0\.85/,
+    );
+    expect(css).toMatch(
+      /:host\(\.font-comic\)\s*{[^}]*--nd-island-font-scale:\s*0\.95/,
+    );
+
+    // Every px text size must be multiplied by the scale.
+    expect(css).toContain(
+      "font-size: calc(14px * var(--nd-island-font-scale, 1))",
+    );
+    expect(css).toContain(
+      "font-size: calc(13px * var(--nd-island-font-scale, 1))",
+    );
+    // No unscaled px font-size declarations may remain.
+    expect(css).not.toMatch(/font-size:\s*\d+px/);
+
+    // Bigger glyphs must wrap inside the panel, not overflow it.
+    expect(css).toMatch(/\.neurodock-panel\s*{[^}]*overflow-wrap:\s*anywhere/);
+
+    island.destroy();
+  });
 });

--- a/packages/extension-browser/tests/unit/neurodock-header.test.tsx
+++ b/packages/extension-browser/tests/unit/neurodock-header.test.tsx
@@ -21,14 +21,27 @@ describe("NeuroDockHeader", () => {
     expect(screen.getByTestId("theme-mode-toggle")).toBeInTheDocument();
   });
 
-  it("renders an optional gear when onOpenSettings is provided", () => {
+  it("renders an optional full-view button when onOpenSettings is provided", () => {
     let opened = false;
     render(<NeuroDockHeader onOpenSettings={() => (opened = true)} />);
     screen.getByTestId("nd-header-settings").click();
     expect(opened).toBe(true);
   });
 
-  it("omits the gear when onOpenSettings is not provided", () => {
+  it("labels the full-view button clearly and uses an expand icon", () => {
+    render(<NeuroDockHeader onOpenSettings={() => {}} />);
+    const btn = screen.getByTestId("nd-header-settings");
+    // Clear accessible name + hover tooltip ("the icon isn't clear" fix).
+    expect(btn).toHaveAttribute("aria-label", "Open full view");
+    expect(btn).toHaveAttribute("title", "Open full view");
+    // The glyph is an SVG expand icon, hidden from the a11y tree, not text.
+    const svg = btn.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+    expect(btn.textContent).not.toContain("⚙");
+  });
+
+  it("omits the full-view button when onOpenSettings is not provided", () => {
     render(<NeuroDockHeader />);
     expect(screen.queryByTestId("nd-header-settings")).not.toBeInTheDocument();
   });

--- a/packages/extension-browser/tests/unit/reader-font.test.ts
+++ b/packages/extension-browser/tests/unit/reader-font.test.ts
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  * Copyright (c) 2026 NeuroDock contributors.
  */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   DEFAULT_READER_FONT,
@@ -66,5 +68,28 @@ describe("reader-font — applyReaderFontToDocument", () => {
     applyReaderFontToDocument("lexend", shadow);
     expect(host.classList.contains("font-lexend")).toBe(true);
     host.remove();
+  });
+});
+
+describe("reader-font — metric compensation contract (tokens.css)", () => {
+  // jsdom cannot measure layout overflow, but the scale contract is
+  // assertable: OpenDyslexic renders ~15% larger than Atkinson at the
+  // same declared size, so tokens.css MUST scale the root rem under the
+  // font class or the fixed-width popup overflows.
+  // Vitest runs with cwd at the package root; import.meta.url is not a
+  // file: URL under the jsdom environment, so resolve from cwd instead.
+  const tokensCss = readFileSync(
+    resolve(process.cwd(), "src/styles/tokens.css"),
+    "utf8",
+  );
+
+  it("scales the root to 85% under .font-opendyslexic", () => {
+    expect(tokensCss).toMatch(
+      /:root\.font-opendyslexic\s*{[^}]*font-size:\s*85%/,
+    );
+  });
+
+  it("scales the root to 95% under .font-comic", () => {
+    expect(tokensCss).toMatch(/:root\.font-comic\s*{[^}]*font-size:\s*95%/);
   });
 });


### PR DESCRIPTION
## What

Fixes the two findings from the maintainer's manual smoke of the merged redesign (#76):

### 1. OpenDyslexic broke layout (overflow / clipped panels)
OpenDyslexic renders ~15% larger than Atkinson at the same declared size. Fixes:
- **Metric compensation**: root font scaled under the class — `:root.font-opendyslexic { font-size: 85% }`, comic `95%` (everything is rem-based so it compensates globally). The tab view's 17px base gets equal-specificity `calc(17px * …)` overrides so it doesn't silently resolve against the 16px browser default.
- **Island**: its sheet is px-based, so a `--nd-island-font-scale` custom property (1 / 0.85 / 0.95) now multiplies every `font-size` via `calc()`.
- **Defensive responsiveness** (font-independent): header wraps under pressure (`flex-wrap`, `min-width: 0`, select `max-width` + ellipsis), `overflow-wrap: anywhere` on cards and the island panel, `nowrap` wordmark.

### 2. Unclear full-page icon
The `⚙` glyph is now a four-corner **expand** SVG (YouTube-fullscreen style, currentColor), `aria-label`/`title` "Open full view". Testid unchanged.

## Test plan
- [x] 637 tests / 74 files green (3 new contract tests: tokens-CSS scale rules, island scale mechanism incl. "no unscaled px remains", header icon/labels)
- [x] typecheck clean · chrome build green · scale rules confirmed in built popup/tab CSS and all 8 content-script bundles
- [ ] Maintainer re-smoke: switch to OpenDyslexic → popup, full page, and Gmail panel stay within bounds