### PR TITLE
ci: publish extension to web stores on extension-browser tags

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -8,6 +8,11 @@ on:
     paths:
       - "packages/extension-browser/**"
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Submit the current commit to the web stores (normally driven by extension-browser@* tags)"
+        type: boolean
+        default: false
 
 concurrency:
   group: extension-${{ github.ref }}
@@ -64,3 +69,155 @@ jobs:
         with:
           name: extension-bundles
           path: packages/extension-browser/.output/**
+
+  # Store submission. Runs only on `extension-browser@X.Y.Z` tag pushes (or a
+  # manual dispatch with the `publish` confirmation input). Each store step is
+  # skipped gracefully when its secrets are not configured, so the job never
+  # fails just because a store has no credentials yet. Credentials setup and
+  # the first-submission caveat are documented in
+  # packages/extension-browser/PUBLISHING.md.
+  publish:
+    name: Publish to web stores
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/extension-browser@') || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to create the GitHub release that carries the zips.
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.1.2
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/extension-browser@')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#extension-browser@}"
+          PKG_VERSION="$(node -p "require('./packages/extension-browser/package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::tag version ($TAG_VERSION) does not match packages/extension-browser/package.json version ($PKG_VERSION). Bump the package version or re-tag as extension-browser@$PKG_VERSION."
+            exit 1
+          fi
+          echo "Tag and package agree: publishing $PKG_VERSION"
+
+      # `wxt zip` rebuilds per browser, so the publish job does not depend on
+      # the build job's unzipped artefacts — only on its green status.
+      - name: Build store zips
+        run: pnpm --filter @neurodock/extension-browser zip
+
+      - name: Locate zip artefacts
+        id: zips
+        working-directory: packages/extension-browser
+        run: |
+          set -eu
+          shopt -s nullglob
+          chrome=(.output/*-chrome.zip)
+          firefox=(.output/*-firefox.zip)
+          edge=(.output/*-edge.zip)
+          sources=(.output/*-sources.zip)
+          for pair in "chrome_zip ${chrome[0]:-}" "firefox_zip ${firefox[0]:-}" "edge_zip ${edge[0]:-}" "sources_zip ${sources[0]:-}"; do
+            key="${pair%% *}"
+            val="${pair#* }"
+            if [ -z "$val" ] || [ "$val" = "$key" ]; then
+              echo "::error::expected $key not found under packages/extension-browser/.output/"
+              exit 1
+            fi
+            echo "$key=$val" >> "$GITHUB_OUTPUT"
+          done
+          ls -la .output/*.zip
+
+      # One output per store: has_chrome / has_firefox / has_edge. A store is
+      # "configured" only when every secret it needs is non-empty. Stores
+      # without credentials are skipped with a notice rather than failing the
+      # release — see packages/extension-browser/PUBLISHING.md.
+      - name: Detect configured stores
+        id: stores
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+        run: |
+          configured=0
+          check_store() {
+            local store="$1"
+            shift
+            local ok=true
+            local var
+            for var in "$@"; do
+              if [ -z "${!var:-}" ]; then
+                ok=false
+              fi
+            done
+            if [ "$ok" = true ]; then
+              configured=$((configured + 1))
+              echo "$store: secrets configured — will submit"
+            else
+              echo "::notice::$store publish skipped: secrets not configured — see packages/extension-browser/PUBLISHING.md"
+            fi
+            echo "has_$store=$ok" >> "$GITHUB_OUTPUT"
+          }
+          check_store chrome CHROME_EXTENSION_ID CHROME_CLIENT_ID CHROME_CLIENT_SECRET CHROME_REFRESH_TOKEN
+          check_store firefox FIREFOX_EXTENSION_ID FIREFOX_JWT_ISSUER FIREFOX_JWT_SECRET
+          check_store edge EDGE_PRODUCT_ID EDGE_CLIENT_ID EDGE_API_KEY
+          if [ "$configured" -eq 0 ]; then
+            echo "::warning::no web-store credentials configured — nothing was submitted to any store. The zips are still attached to the GitHub release. See packages/extension-browser/PUBLISHING.md to set up store secrets."
+          fi
+
+      - name: Publish to Chrome Web Store
+        if: steps.stores.outputs.has_chrome == 'true'
+        working-directory: packages/extension-browser
+        run: pnpm exec wxt submit --chrome-zip "${{ steps.zips.outputs.chrome_zip }}"
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+
+      - name: Publish to Firefox Add-ons (AMO)
+        if: steps.stores.outputs.has_firefox == 'true'
+        working-directory: packages/extension-browser
+        run: pnpm exec wxt submit --firefox-zip "${{ steps.zips.outputs.firefox_zip }}" --firefox-sources-zip "${{ steps.zips.outputs.sources_zip }}"
+        env:
+          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+
+      - name: Publish to Edge Add-ons
+        if: steps.stores.outputs.has_edge == 'true'
+        working-directory: packages/extension-browser
+        run: pnpm exec wxt submit --edge-zip "${{ steps.zips.outputs.edge_zip }}"
+        env:
+          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+
+      # release.yml does not create GitHub releases (npm / PyPI only), so this
+      # is the repo's first release-creating step. softprops/action-gh-release
+      # is pinned by major tag, matching how the other third-party actions in
+      # .github/workflows are pinned.
+      - name: Attach zips to GitHub release
+        if: startsWith(github.ref, 'refs/tags/extension-browser@')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          files: packages/extension-browser/.output/*.zip
+          generate_release_notes: true

--- a/packages/extension-browser/PUBLISHING.md
+++ b/packages/extension-browser/PUBLISHING.md
@@ -1,0 +1,99 @@
+# Publishing the browser extension to the web stores
+
+CI publishes the extension to the Chrome Web Store, Firefox Add-ons (AMO),
+and Microsoft Edge Add-ons automatically when an `extension-browser@X.Y.Z`
+tag is pushed. The publish job lives in
+[`.github/workflows/extension.yml`](../../.github/workflows/extension.yml)
+and submits via `wxt submit` (a thin wrapper around the
+[`publish-browser-extension`](https://www.npmjs.com/package/publish-browser-extension)
+CLI).
+
+## The release flow
+
+1. Bump `version` in `packages/extension-browser/package.json` (and the
+   package `CHANGELOG.md`).
+2. Merge to `main`.
+3. Tag and push:
+
+   ```sh
+   git tag extension-browser@X.Y.Z
+   git push --tags
+   ```
+
+CI then:
+
+- builds the extension for Chrome, Firefox, and Edge;
+- verifies the tag version matches `package.json` (the job fails with a
+  clear message if they disagree);
+- zips each browser bundle (`pnpm --filter @neurodock/extension-browser zip`);
+- submits each zip to every store whose secrets are configured;
+- attaches all zips to a GitHub release named after the tag.
+
+A manual run is also possible from the Actions tab: pick the
+"Browser extension" workflow, "Run workflow", and tick the **publish**
+input. That path skips the tag check and does not create a GitHub
+release — it submits whatever version is on the selected commit.
+
+## Graceful skipping
+
+Each store step is guarded: if any of that store's secrets are missing or
+empty, the step is skipped with a notice
+("chrome publish skipped: secrets not configured") and the job still
+succeeds. If no store is configured at all, the run emits a warning but
+still attaches the zips to the GitHub release. This means the tag-driven
+flow is safe to use before any store credentials exist.
+
+## Secrets
+
+All secrets are configured in the GitHub repository settings under
+**Settings → Secrets and variables → Actions**. Names follow the
+`publish-browser-extension` convention (verified against v4.0.5, which is
+what WXT 0.20 resolves).
+
+| Secret                 | Store   | Where to obtain it                                                                                                                           |
+| ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CHROME_EXTENSION_ID`  | Chrome  | The 32-character id in the Chrome Web Store listing URL (`chromewebstore.google.com/detail/...../<id>`).                                     |
+| `CHROME_CLIENT_ID`     | Chrome  | Google Cloud console: create a project, enable the **Chrome Web Store API**, then create an **OAuth client ID** (type: Desktop app).         |
+| `CHROME_CLIENT_SECRET` | Chrome  | Same OAuth client as above.                                                                                                                  |
+| `CHROME_REFRESH_TOKEN` | Chrome  | Run `npx publish-extension init` locally — the wizard walks the OAuth consent flow with your client id/secret and prints the refresh token.  |
+| `FIREFOX_EXTENSION_ID` | Firefox | The add-on UUID or the `browser_specific_settings.gecko.id` from the AMO listing (Developer Hub → your add-on → "Manage Status & Versions"). |
+| `FIREFOX_JWT_ISSUER`   | Firefox | AMO Developer Hub → [Manage API Keys](https://addons.mozilla.org/developers/addon/api/key/) — the "JWT issuer" value.                        |
+| `FIREFOX_JWT_SECRET`   | Firefox | Same API-keys page — the "JWT secret" value.                                                                                                 |
+| `EDGE_PRODUCT_ID`      | Edge    | Microsoft Partner Center → your extension → the **Product ID** on the overview page.                                                         |
+| `EDGE_CLIENT_ID`       | Edge    | Partner Center → Account settings → **Publish API** → enable the API and copy the client id.                                                 |
+| `EDGE_API_KEY`         | Edge    | Same Publish API page — generate an API key. (This is the current API-key flow; the older v1.1 client-secret flow is not used.)              |
+
+A store is treated as configured only when **all** of its secrets are
+non-empty.
+
+## First submission must be manual
+
+Every store requires the first listing to be created by hand — the
+publish APIs can only update an existing listing:
+
+- **Chrome**: upload an initial zip in the
+  [developer dashboard](https://chrome.google.com/webstore/devconsole),
+  fill in the listing, and get it through review once. The extension id
+  only exists after this.
+- **Firefox**: submit the first version through the
+  [AMO Developer Hub](https://addons.mozilla.org/developers/). AMO review
+  may ask for the sources zip; CI uploads it alongside the build on
+  subsequent submissions.
+- **Edge**: create the product in
+  [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/)
+  and submit the first package manually. The product id only exists after
+  this.
+
+Until a store's first listing exists (and its secrets are added), CI
+simply skips that store and notes it in the job log.
+
+## Notes
+
+- Submissions go to each store's normal review queue; "published by CI"
+  still means "pending review" until the store approves it.
+- The zips CI submits are also attached to the GitHub release for the
+  tag, so the exact submitted artefacts are always auditable.
+- `publish-browser-extension` supports extra knobs (Chrome publish
+  target, Firefox channel, skipping review submission). They are not
+  wired into the workflow; add the matching env vars to the publish
+  steps in `extension.yml` if ever needed.


### PR DESCRIPTION
## What

WS3 of the extension overhaul: automated store publishing wired into CI. Tagging `extension-browser@X.Y.Z` now builds, version-checks, publishes to every configured store, and attaches the zips to a GitHub Release — with stores **skipping gracefully** until their secrets exist.

### Publish job (extends `extension.yml`)
- `needs: build`, runs only on `extension-browser@*` tag push (or `workflow_dispatch` with an explicit `publish: true` confirm input).
- **Tag ↔ `package.json` version check** with a clear error on mismatch.
- `pnpm --filter @neurodock/extension-browser zip` → glob-locates the four zips (chrome/firefox/edge/sources), hard-fails with a clear error if any is missing.
- **Per-store skip-guards**: a gate step emits `has_chrome/has_firefox/has_edge` only when ALL of that store's secrets are set; skipped stores log a `::notice::` pointing at the guide; all-three-missing logs a `::warning::`. The job never fails for unconfigured stores.
- Submissions via `wxt submit` (wraps `publish-browser-extension`); Firefox gets `--firefox-sources-zip` (AMO requirement).
- `softprops/action-gh-release@v2` attaches `.output/*.zip` to a release with generated notes. `contents: write` on the publish job only.

### Secret names — verified, not guessed
Extracted from the installed `publish-browser-extension@4.0.5` (what the repo's wxt 0.20.26 actually spawns):

| Store | Secrets |
|---|---|
| Chrome Web Store | `CHROME_EXTENSION_ID` `CHROME_CLIENT_ID` `CHROME_CLIENT_SECRET` `CHROME_REFRESH_TOKEN` |
| Firefox AMO | `FIREFOX_EXTENSION_ID` `FIREFOX_JWT_ISSUER` `FIREFOX_JWT_SECRET` |
| Edge Add-ons | `EDGE_PRODUCT_ID` `EDGE_CLIENT_ID` `EDGE_API_KEY` |

### Docs
`packages/extension-browser/PUBLISHING.md`: the secrets table with where to obtain each credential, the **manual-first-submission caveat** (every store requires the first listing to be created by hand with a zip upload before API publishing works), the tag-driven flow, and the skip behaviour.

## Test plan
- [x] YAML validated (`yaml.safe_load`) + every embedded `run:` script `bash -n` checked
- [x] Pre-commit hooks green (check-yaml, prettier, commitlint)
- [ ] Live store handshake is untestable until the maintainer creates the listings + adds secrets — by design the steps skip until then
- [ ] After merge: cut `extension-browser@0.0.36` to watch the publish job run end-to-end in skip mode

## Notes
- Store steps stay skipped until you create each store listing manually (first submission) and add its secrets — exact walkthrough in PUBLISHING.md.
- IDE may lint `secrets.*` as "context access might be invalid" until the secrets exist in repo settings; expected.