### PR TITLE
feat: unified setup command, native-host capability ping, and power-up repoint

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @neurodock/cli changelog
 
+## [unreleased]
+
+### Added — `neurodock setup`: install-all + install-hooks in one command
+
+The "turn on full NeuroDock" path the browser extension advertises is
+now a single command. `neurodock setup` runs the existing `install-all`
+runner (6 Python MCP servers, MCP client wiring, native-messaging host)
+followed by the existing `install-hooks` runner (proactive-guardrail
+hooks in `~/.claude/settings.json`) — a thin orchestrator, no duplicated
+install logic. Mirrors `install-all`'s flags (`--client`, `--profile`,
+`--installer`, `--skip-install`, `--yes`, `--dry-run`,
+`--no-native-host`). The standalone Phase 3 daemon stays opt-in via
+`--daemon`, matching `install-hooks --install-daemon`, because the
+daemon is the optional piece — the Claude Code hook covers the common
+cases and `setup` should not register login autostart by default. The
+hooks step runs even when install-all reports a PATH problem (the
+guardrails only need Python); the exit code preserves install-all's
+failure first, else reports the hooks failure.
+
 ## 0.7.2
 
 ### Fixed — `npx @neurodock/cli install-all` failed on `init` with "Could not locate template: profile.example.yaml"

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,0 +1,141 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * `neurodock setup` — the "turn on full NeuroDock" command the browser
+ * extension advertises. A thin orchestrator over the two existing
+ * installers, in order:
+ *
+ *   1. `runInstallAll` — install the 6 Python MCP servers, wire the
+ *      MCP clients, and register the native-messaging host (unless
+ *      `--no-native-host`).
+ *   2. `runInstallHooks` — wire the proactive-guardrail hooks into
+ *      `~/.claude/settings.json`.
+ *
+ * The standalone Phase 3 daemon stays opt-in (`--daemon`), mirroring
+ * `install-hooks --install-daemon`: the daemon is documented there as
+ * optional — the Phase 1 Claude Code hook plus the Phase 2 extension
+ * watchdog cover the common cases, so the default `setup` path does not
+ * register login autostart on the user's machine.
+ *
+ * No installation logic lives here — both steps call the same runners
+ * the standalone `install-all` / `install-hooks` commands use, so the
+ * behaviours can never drift apart.
+ */
+import {
+  runInstallAll as defaultRunInstallAll,
+  type InstallAllResult,
+  type InstallerChoice,
+} from "./install-all.js";
+import {
+  runInstallHooks as defaultRunInstallHooks,
+  type InstallHooksResult,
+} from "./install-hooks.js";
+import type { ClientId } from "../types.js";
+
+export interface SetupOptions {
+  readonly client: ClientId | "all";
+  readonly profile: "minimal" | "example";
+  readonly installer: InstallerChoice;
+  readonly skipInstall: boolean;
+  readonly yes: boolean;
+  readonly dryRun: boolean;
+  readonly noNativeHost: boolean;
+  /**
+   * Opt-in: also register the standalone guardrail daemon at user-login
+   * autostart. Off by default — see the module comment above.
+   */
+  readonly daemon: boolean;
+}
+
+export interface SetupDependencies {
+  /** Override the install-all runner. Tests inject a stub. */
+  readonly runInstallAll?: typeof defaultRunInstallAll;
+  /** Override the install-hooks runner. Tests inject a stub. */
+  readonly runInstallHooks?: typeof defaultRunInstallHooks;
+}
+
+export interface SetupResult {
+  readonly installAll: InstallAllResult;
+  readonly hooks: InstallHooksResult;
+  readonly messages: ReadonlyArray<string>;
+  /** install-all's exit code wins when non-zero; else 1 if hooks failed. */
+  readonly exitCode: number;
+}
+
+export async function runSetup(
+  options: SetupOptions,
+  deps: SetupDependencies = {},
+): Promise<SetupResult> {
+  const installAll = deps.runInstallAll ?? defaultRunInstallAll;
+  const installHooks = deps.runInstallHooks ?? defaultRunInstallHooks;
+  const messages: string[] = [];
+
+  messages.push(
+    "Step 1/2: install MCP servers, wire clients, register native host",
+  );
+  messages.push("");
+  const installAllResult = await installAll({
+    client: options.client,
+    profile: options.profile,
+    installer: options.installer,
+    skipInstall: options.skipInstall,
+    yes: options.yes,
+    dryRun: options.dryRun,
+    noNativeHost: options.noNativeHost,
+  });
+  messages.push(...installAllResult.messages);
+
+  // Run the hooks step even when install-all reported a problem: the
+  // guardrail hooks only need Python, so a PATH hiccup with the MCP
+  // entrypoints should not leave the user without proactive guardrails.
+  messages.push("");
+  messages.push("Step 2/2: install Claude Code guardrail hooks");
+  messages.push("");
+  const hooksResult = await installHooks({
+    dryRun: options.dryRun,
+    selfTest: false,
+    uninstall: false,
+    installDaemon: options.daemon,
+  });
+  messages.push(...hooksResult.messages);
+
+  const exitCode =
+    installAllResult.exitCode !== 0
+      ? installAllResult.exitCode
+      : hooksResult.exitCode !== 0
+        ? 1
+        : 0;
+
+  messages.push("");
+  if (exitCode === 0) {
+    messages.push(
+      options.dryRun
+        ? "Dry run finished — nothing was written."
+        : "Setup complete. NeuroDock is fully wired.",
+    );
+    if (!options.daemon) {
+      messages.push(
+        "Optional: 'neurodock setup --daemon' also registers the standalone guardrail daemon at login.",
+      );
+    }
+  } else {
+    messages.push(
+      "Setup finished with problems — see the messages above. Re-run the failing step directly:",
+    );
+    if (installAllResult.exitCode !== 0) {
+      messages.push("  neurodock install-all");
+    }
+    if (hooksResult.exitCode !== 0) {
+      messages.push("  neurodock install-hooks");
+    }
+  }
+
+  return {
+    installAll: installAllResult,
+    hooks: hooksResult,
+    messages,
+    exitCode,
+  };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import { runHostInstall, runHostUninstall } from "./commands/host.js";
 import { runInstallHooks } from "./commands/install-hooks.js";
 import { runGuardrailStatus } from "./commands/guardrail.js";
 import { runInstallAll, type InstallerChoice } from "./commands/install-all.js";
+import { runSetup } from "./commands/setup.js";
 import { runExamples } from "./commands/examples.js";
 import {
   runPluginAdd,
@@ -150,6 +151,75 @@ export function buildProgram(): Command {
           yes: opts.yes === true,
           dryRun: opts.dryRun === true,
           noNativeHost: opts.nativeHost === false,
+        });
+        for (const m of r.messages) print(m);
+        process.exit(r.exitCode);
+      },
+    );
+
+  program
+    .command("setup")
+    .description(
+      "full setup in one command: runs install-all (6 MCP servers + client " +
+        "wiring + native-messaging host) then install-hooks (Claude Code " +
+        "guardrail hooks); the standalone daemon is opt-in via --daemon",
+    )
+    .option(
+      "--client <id>",
+      "claude-desktop | claude-code | cursor | all",
+      "all",
+    )
+    .option("--profile <id>", "minimal | example", "example")
+    .option("--installer <id>", "uv | pip | auto", "auto")
+    .option(
+      "--skip-install",
+      "skip the Python install step (only wire clients + hooks)",
+      false,
+    )
+    .option(
+      "--yes",
+      "answer yes to all prompts (idempotent re-runs, collisions)",
+      false,
+    )
+    .option(
+      "--dry-run",
+      "print what would happen without writing anything",
+      false,
+    )
+    .option(
+      "--no-native-host",
+      "skip registering the optional native-messaging host (browser extension <-> profile.yaml)",
+    )
+    .option(
+      "--daemon",
+      "also register the optional standalone guardrail daemon at user-login " +
+        "autostart (off by default — the Claude Code hook covers the common cases)",
+      false,
+    )
+    .action(
+      async (opts: {
+        client: string;
+        profile: string;
+        installer: string;
+        skipInstall: boolean;
+        yes: boolean;
+        dryRun: boolean;
+        // Commander inverts `--no-native-host`: presence of the flag sets this to false.
+        nativeHost: boolean;
+        daemon: boolean;
+      }) => {
+        const client = validateClient(opts.client);
+        const profile = validateProfile(opts.profile);
+        const installer = validateInstaller(opts.installer);
+        const r = await runSetup({
+          client,
+          profile,
+          installer,
+          skipInstall: opts.skipInstall === true,
+          yes: opts.yes === true,
+          dryRun: opts.dryRun === true,
+          noNativeHost: opts.nativeHost === false,
+          daemon: opts.daemon === true,
         });
         for (const m of r.messages) print(m);
         process.exit(r.exitCode);

--- a/packages/cli/tests/setup.test.ts
+++ b/packages/cli/tests/setup.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import { runSetup, type SetupOptions } from "../src/commands/setup.js";
+import type {
+  InstallAllOptions,
+  InstallAllResult,
+} from "../src/commands/install-all.js";
+import type {
+  InstallHooksOptions,
+  InstallHooksResult,
+} from "../src/commands/install-hooks.js";
+
+function makeInstallAllResult(
+  overrides: Partial<InstallAllResult> = {},
+): InstallAllResult {
+  return {
+    installer: "uv",
+    packages: [],
+    initResult: null,
+    nativeHost: { status: "installed" },
+    messages: ["[install-all] fake message"],
+    exitCode: 0,
+    ...overrides,
+  };
+}
+
+function makeHooksResult(
+  overrides: Partial<InstallHooksResult> = {},
+): InstallHooksResult {
+  return {
+    messages: ["[install-hooks] fake message"],
+    exitCode: 0,
+    ...overrides,
+  };
+}
+
+interface StubHarness {
+  readonly installAllCalls: InstallAllOptions[];
+  readonly hooksCalls: InstallHooksOptions[];
+  readonly callOrder: string[];
+  readonly deps: {
+    runInstallAll: (opts: InstallAllOptions) => Promise<InstallAllResult>;
+    runInstallHooks: (opts: InstallHooksOptions) => Promise<InstallHooksResult>;
+  };
+}
+
+function makeStubs(
+  installAllResult: InstallAllResult = makeInstallAllResult(),
+  hooksResult: InstallHooksResult = makeHooksResult(),
+): StubHarness {
+  const installAllCalls: InstallAllOptions[] = [];
+  const hooksCalls: InstallHooksOptions[] = [];
+  const callOrder: string[] = [];
+  return {
+    installAllCalls,
+    hooksCalls,
+    callOrder,
+    deps: {
+      runInstallAll: (opts: InstallAllOptions) => {
+        installAllCalls.push(opts);
+        callOrder.push("install-all");
+        return Promise.resolve(installAllResult);
+      },
+      runInstallHooks: (opts: InstallHooksOptions) => {
+        hooksCalls.push(opts);
+        callOrder.push("install-hooks");
+        return Promise.resolve(hooksResult);
+      },
+    },
+  };
+}
+
+function makeOptions(overrides: Partial<SetupOptions> = {}): SetupOptions {
+  return {
+    client: "all",
+    profile: "example",
+    installer: "auto",
+    skipInstall: false,
+    yes: false,
+    dryRun: false,
+    noNativeHost: false,
+    daemon: false,
+    ...overrides,
+  };
+}
+
+describe("neurodock setup", () => {
+  it("invokes install-all then install-hooks exactly once each", async () => {
+    const stubs = makeStubs();
+
+    const r = await runSetup(makeOptions(), stubs.deps);
+
+    expect(stubs.installAllCalls).toHaveLength(1);
+    expect(stubs.hooksCalls).toHaveLength(1);
+    expect(stubs.callOrder).toEqual(["install-all", "install-hooks"]);
+    expect(r.exitCode).toBe(0);
+  });
+
+  it("passes install-all flags through unchanged", async () => {
+    const stubs = makeStubs();
+
+    await runSetup(
+      makeOptions({
+        client: "claude-code",
+        profile: "minimal",
+        installer: "pip",
+        skipInstall: true,
+        yes: true,
+        noNativeHost: true,
+      }),
+      stubs.deps,
+    );
+
+    expect(stubs.installAllCalls[0]).toEqual({
+      client: "claude-code",
+      profile: "minimal",
+      installer: "pip",
+      skipInstall: true,
+      yes: true,
+      dryRun: false,
+      noNativeHost: true,
+    });
+  });
+
+  it("--dry-run propagates to both underlying runners", async () => {
+    const stubs = makeStubs();
+
+    await runSetup(makeOptions({ dryRun: true }), stubs.deps);
+
+    expect(stubs.installAllCalls[0]?.dryRun).toBe(true);
+    expect(stubs.hooksCalls[0]?.dryRun).toBe(true);
+  });
+
+  it("daemon install is opt-in: off by default, on with --daemon", async () => {
+    const off = makeStubs();
+    await runSetup(makeOptions(), off.deps);
+    expect(off.hooksCalls[0]?.installDaemon).toBe(false);
+
+    const on = makeStubs();
+    await runSetup(makeOptions({ daemon: true }), on.deps);
+    expect(on.hooksCalls[0]?.installDaemon).toBe(true);
+  });
+
+  it("never asks install-hooks to uninstall or self-test", async () => {
+    const stubs = makeStubs();
+
+    await runSetup(makeOptions(), stubs.deps);
+
+    expect(stubs.hooksCalls[0]?.uninstall).toBe(false);
+    expect(stubs.hooksCalls[0]?.selfTest).toBe(false);
+  });
+
+  it("combines messages from both runners with step headers and a summary", async () => {
+    const stubs = makeStubs();
+
+    const r = await runSetup(makeOptions(), stubs.deps);
+
+    const joined = r.messages.join("\n");
+    expect(joined).toContain("Step 1/2");
+    expect(joined).toContain("Step 2/2");
+    expect(joined).toContain("[install-all] fake message");
+    expect(joined).toContain("[install-hooks] fake message");
+    expect(joined).toContain("Setup complete");
+  });
+
+  it("reports a combined outcome with both sub-results", async () => {
+    const stubs = makeStubs();
+
+    const r = await runSetup(makeOptions(), stubs.deps);
+
+    expect(r.installAll.installer).toBe("uv");
+    expect(r.hooks.exitCode).toBe(0);
+  });
+
+  it("preserves install-all's non-zero exit code", async () => {
+    const stubs = makeStubs(makeInstallAllResult({ exitCode: 2 }));
+
+    const r = await runSetup(makeOptions(), stubs.deps);
+
+    expect(r.exitCode).toBe(2);
+    expect(r.messages.join("\n")).not.toContain("Setup complete");
+  });
+
+  it("still runs install-hooks when install-all fails, and exits non-zero", async () => {
+    const stubs = makeStubs(makeInstallAllResult({ exitCode: 1 }));
+
+    const r = await runSetup(makeOptions(), stubs.deps);
+
+    expect(stubs.hooksCalls).toHaveLength(1);
+    expect(r.exitCode).toBe(1);
+  });
+
+  it("exits 1 when install-hooks fails even if install-all succeeded", async () => {
+    const stubs = makeStubs(
+      makeInstallAllResult(),
+      makeHooksResult({ exitCode: 1 }),
+    );
+
+    const r = await runSetup(makeOptions(), stubs.deps);
+
+    expect(r.exitCode).toBe(1);
+    expect(r.messages.join("\n")).not.toContain("Setup complete");
+  });
+});

--- a/packages/extension-browser/CHANGELOG.md
+++ b/packages/extension-browser/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @neurodock/extension-browser
 
+## [unreleased]
+
+### Changed — power-up card now advertises `npx @neurodock/cli setup`
+
+`FULL_SETUP_COMMAND` pointed at `install-all` while the unified setup
+command was still a later workstream. The CLI now ships `neurodock
+setup` (install-all + install-hooks in one go), so the card's
+copy-paste command is repointed to it. No UI change otherwise.
+
 ## 0.0.35
 
 ### Added — notifications inbox in the full-tab view

--- a/packages/extension-browser/src/components/PowerUpCard.tsx
+++ b/packages/extension-browser/src/components/PowerUpCard.tsx
@@ -4,15 +4,17 @@
  *
  * "Turn on full NeuroDock" — one copy-paste command + live connection state.
  * Replaces the three scattered CLI commands the settings used to list.
- * The exact command string is owned by a later workstream; FULL_SETUP_COMMAND
- * is the single place it is referenced so it can be updated in one edit.
+ * FULL_SETUP_COMMAND is the single place the command string is referenced
+ * so it can be updated in one edit.
  */
 import React, { useEffect, useRef, useState } from "react";
 import { useFullSetupStatus } from "../lib/full-setup.js";
 
-// One command installs the 6 MCP servers, wires MCP clients, and sets up
-// the native-host + hooks together. A future `setup` alias may replace it.
-export const FULL_SETUP_COMMAND = "npx @neurodock/cli install-all";
+// `neurodock setup` installs the 6 MCP servers, wires MCP clients,
+// registers the native-messaging host, and installs the Claude Code
+// guardrail hooks in one go (the standalone daemon stays opt-in via
+// --daemon).
+export const FULL_SETUP_COMMAND = "npx @neurodock/cli setup";
 
 export function PowerUpCard(): React.ReactElement {
   const { status, recheck } = useFullSetupStatus();

--- a/packages/native-host/CHANGELOG.md
+++ b/packages/native-host/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [unreleased]
 
+### Added — `ping` reports setup capabilities
+
+The `ping` response `data` now carries a `capabilities` object — the
+"fully set up" contract the browser extension's power-up card consumes:
+
+- `profile: true` — the host can read/write profile.yaml (always true
+  when the host responds at all).
+- `hooks` — NeuroDock guardrail hook entries are present in
+  `~/.claude/settings.json` (the merge target of
+  `neurodock install-hooks`).
+- `daemon` — the standalone daemon's user-login autostart marker exists
+  (HKCU Run value `NeuroDockGuardrail` on Windows, LaunchAgent plist on
+  macOS, systemd --user unit on Linux). The daemon _script_ on disk is
+  deliberately not a marker — `install-hooks` copies it even when the
+  daemon was never enabled.
+
+Additive and backwards compatible: `{ pong, version }` are unchanged,
+so clients that ignore `capabilities` keep working. Detection lives in
+`src/capabilities.ts` with injectable fs/os/registry probes for tests,
+and mirrors the markers `neurodock guardrail status` checks.
+
 ### Security — registration scaffolds use atomic writes
 
 `registerLinux`, `registerDarwin`, and `writeProfile` (profile-io) previously called

--- a/packages/native-host/src/capabilities.ts
+++ b/packages/native-host/src/capabilities.ts
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * Setup-capability detection for the `ping` op.
+ *
+ * The browser extension treats a reachable native host as "the one-command
+ * setup ran"; these flags tell it *how much* of the setup ran, so the
+ * power-up card can distinguish "profile sync only" from "hooks wired"
+ * from "daemon registered". Detection is read-only and checks the same
+ * on-disk markers that `neurodock guardrail status` reports:
+ *
+ *   hooks  → NeuroDock hook entries inside `~/.claude/settings.json`
+ *            (the merge target of `neurodock install-hooks`).
+ *   daemon → the user-login autostart marker written by
+ *            `neurodock install-hooks --install-daemon`:
+ *            HKCU Run value `NeuroDockGuardrail` on Windows,
+ *            `~/Library/LaunchAgents/com.neurodock.guardrail.plist` on
+ *            macOS, `~/.config/systemd/user/neurodock-guardrail.service`
+ *            on Linux.
+ *
+ * Note: the daemon *script* (`~/.neurodock/hooks/neurodock_daemon.py`)
+ * is NOT a daemon marker — `install-hooks` copies it unconditionally
+ * even when the daemon was never enabled. Only the autostart
+ * registration proves intent. Whether the daemon is currently *running*
+ * is deliberately not reported: the only liveness signal is the mtime
+ * of `~/.neurodock/state/daemon-log.jsonl`, which is a heuristic, not a
+ * capability.
+ */
+import {
+  existsSync as defaultExistsSync,
+  readFileSync as defaultReadFileSync,
+} from "node:fs";
+import {
+  homedir as defaultHomedir,
+  platform as defaultPlatform,
+} from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import type { SetupCapabilities } from "./protocol.js";
+
+/** Markers written by `neurodock install-hooks` into settings.json. */
+const HOOK_SCRIPT_MARKER = "proactive_guardrail.py";
+const HOOK_DESCRIPTION_MARKER = "neurodock-proactive-guardrail";
+
+/** Registry value name registered by the daemon's Windows autostart. */
+const WINDOWS_RUN_VALUE = "NeuroDockGuardrail";
+
+export interface CapabilityProbeDeps {
+  readonly homedir?: () => string;
+  readonly platform?: () => string;
+  readonly existsSync?: (path: string) => boolean;
+  readonly readFileSync?: (path: string) => string;
+  /**
+   * Windows only: returns true when the HKCU Run autostart value is
+   * registered. Defaults to a `reg query` probe; tests inject a stub.
+   */
+  readonly windowsRunKeyRegistered?: () => boolean;
+}
+
+export function detectCapabilities(
+  deps: CapabilityProbeDeps = {},
+): SetupCapabilities {
+  return {
+    profile: true,
+    hooks: detectHooks(deps),
+    daemon: detectDaemon(deps),
+  };
+}
+
+function detectHooks(deps: CapabilityProbeDeps): boolean {
+  const home = (deps.homedir ?? defaultHomedir)();
+  const exists = deps.existsSync ?? defaultExistsSync;
+  const read = deps.readFileSync ?? defaultReadFile;
+  const settingsPath = join(home, ".claude", "settings.json");
+  if (!exists(settingsPath)) return false;
+  try {
+    const parsed = JSON.parse(read(settingsPath)) as { hooks?: unknown };
+    const hooksText = JSON.stringify(parsed.hooks ?? {});
+    return (
+      hooksText.includes(HOOK_SCRIPT_MARKER) ||
+      hooksText.includes(HOOK_DESCRIPTION_MARKER)
+    );
+  } catch {
+    // Unreadable / unparseable settings.json: report not-installed rather
+    // than guess. The CLI's `guardrail status` surfaces the parse error.
+    return false;
+  }
+}
+
+function detectDaemon(deps: CapabilityProbeDeps): boolean {
+  const home = (deps.homedir ?? defaultHomedir)();
+  const os = (deps.platform ?? defaultPlatform)();
+  const exists = deps.existsSync ?? defaultExistsSync;
+  if (os === "win32") {
+    const probe = deps.windowsRunKeyRegistered ?? defaultWindowsRunKeyProbe;
+    return probe();
+  }
+  if (os === "darwin") {
+    return exists(
+      join(home, "Library", "LaunchAgents", "com.neurodock.guardrail.plist"),
+    );
+  }
+  return exists(
+    join(home, ".config", "systemd", "user", "neurodock-guardrail.service"),
+  );
+}
+
+function defaultReadFile(path: string): string {
+  return defaultReadFileSync(path, "utf8");
+}
+
+function defaultWindowsRunKeyProbe(): boolean {
+  try {
+    // execFileSync (no shell) with a fully static argument list — the
+    // registry path and value name are constants, never user input.
+    const out = execFileSync(
+      "reg",
+      [
+        "query",
+        "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+        "/v",
+        WINDOWS_RUN_VALUE,
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return out.includes(WINDOWS_RUN_VALUE);
+  } catch {
+    // reg query exits non-zero when the value is absent.
+    return false;
+  }
+}

--- a/packages/native-host/src/handler.ts
+++ b/packages/native-host/src/handler.ts
@@ -8,8 +8,14 @@
  * Filesystem access goes through the injected `io` adapter so the tests
  * can drive the protocol round-trip in memory.
  */
-import type { HostRequest, HostResponse } from "./protocol.js";
+import type {
+  HostRequest,
+  HostResponse,
+  PingData,
+  SetupCapabilities,
+} from "./protocol.js";
 import { HOST_VERSION, isHostRequest } from "./protocol.js";
+import { detectCapabilities } from "./capabilities.js";
 import { validateProfile } from "./validator.js";
 
 export interface ProfileIoAdapter {
@@ -69,6 +75,11 @@ export interface SetResult {
 export function handleRequest(
   raw: unknown,
   io: ProfileIoAdapter,
+  /**
+   * Setup-capability detector used by `ping`. Defaults to the real
+   * on-disk probe; tests inject a stub so they stay hermetic.
+   */
+  detect: () => SetupCapabilities = detectCapabilities,
 ): HostResponse {
   if (!isHostRequest(raw)) {
     const id =
@@ -81,7 +92,12 @@ export function handleRequest(
   const req: HostRequest = raw;
 
   if (req.op === "ping") {
-    return ok(req, { pong: true, version: HOST_VERSION });
+    const data: PingData = {
+      pong: true,
+      version: HOST_VERSION,
+      capabilities: detect(),
+    };
+    return ok(req, data);
   }
 
   if (req.op === "get") {

--- a/packages/native-host/src/index.ts
+++ b/packages/native-host/src/index.ts
@@ -100,6 +100,13 @@ if (invokedFromCli) {
 }
 
 export { handleRequest } from "./handler.js";
+export { detectCapabilities } from "./capabilities.js";
+export type { CapabilityProbeDeps } from "./capabilities.js";
 export { encodeMessage, tryDecodeMessage, HOST_VERSION } from "./protocol.js";
 export { resolveProfilePath, readProfile, writeProfile } from "./profile-io.js";
-export type { HostRequest, HostResponse } from "./protocol.js";
+export type {
+  HostRequest,
+  HostResponse,
+  PingData,
+  SetupCapabilities,
+} from "./protocol.js";

--- a/packages/native-host/src/protocol.ts
+++ b/packages/native-host/src/protocol.ts
@@ -34,6 +34,41 @@ export interface HostResponse<T = unknown> {
 
 export const HOST_VERSION = "0.1.0";
 
+/**
+ * Capability flags reported by the `ping` op — the "fully set up"
+ * contract the browser extension's power-up card consumes. Additive to
+ * the original `{ pong, version }` ping data: clients that ignore
+ * `capabilities` keep working unchanged.
+ */
+export interface SetupCapabilities {
+  /**
+   * The host can read/write profile.yaml. Always true when the host is
+   * responding at all — a ping reply is itself the proof.
+   */
+  readonly profile: true;
+  /**
+   * The proactive-guardrail hooks appear installed: NeuroDock hook
+   * entries are present in `~/.claude/settings.json` (written by
+   * `neurodock install-hooks` / `neurodock setup`).
+   */
+  readonly hooks: boolean;
+  /**
+   * The standalone guardrail daemon appears installed: its user-login
+   * autostart marker exists (HKCU Run value on Windows, LaunchAgent
+   * plist on macOS, systemd --user unit on Linux — written by
+   * `neurodock install-hooks --install-daemon` / `neurodock setup
+   * --daemon`).
+   */
+  readonly daemon: boolean;
+}
+
+/** Shape of `HostResponse.data` for a successful `ping`. */
+export interface PingData {
+  readonly pong: true;
+  readonly version: string;
+  readonly capabilities: SetupCapabilities;
+}
+
 export class ProtocolError extends Error {
   readonly code: string;
 

--- a/packages/native-host/tests/capabilities.test.ts
+++ b/packages/native-host/tests/capabilities.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectCapabilities,
+  type CapabilityProbeDeps,
+} from "../src/capabilities.js";
+
+const HOME = "/home/tester";
+
+const SETTINGS_PATH = `${HOME}/.claude/settings.json`.replace(/\//g, sep());
+
+function sep(): string {
+  // node:path join uses the platform separator; tests build expected paths
+  // the same way the implementation does.
+  return process.platform === "win32" ? "\\" : "/";
+}
+
+function joinHome(...parts: string[]): string {
+  return [HOME.replace(/\//g, sep()), ...parts].join(sep());
+}
+
+interface FakeFsOptions {
+  readonly files?: Record<string, string>;
+}
+
+function makeDeps(
+  opts: FakeFsOptions & {
+    platform?: string;
+    windowsRunKeyRegistered?: () => boolean;
+  } = {},
+): CapabilityProbeDeps {
+  const files = opts.files ?? {};
+  return {
+    homedir: () => HOME.replace(/\//g, sep()),
+    platform: () => opts.platform ?? "linux",
+    existsSync: (path: string) => path in files,
+    readFileSync: (path: string) => {
+      const content = files[path];
+      if (content === undefined) throw new Error(`ENOENT: ${path}`);
+      return content;
+    },
+    ...(opts.windowsRunKeyRegistered !== undefined
+      ? { windowsRunKeyRegistered: opts.windowsRunKeyRegistered }
+      : {}),
+  };
+}
+
+function settingsWithHookCommand(command: string): string {
+  return JSON.stringify({
+    hooks: {
+      PreToolUse: [{ matcher: "", hooks: [{ type: "command", command }] }],
+    },
+  });
+}
+
+describe("detectCapabilities", () => {
+  it("always reports profile: true (the host is responding)", () => {
+    const caps = detectCapabilities(makeDeps());
+    expect(caps.profile).toBe(true);
+  });
+
+  describe("hooks", () => {
+    it("is true when settings.json wires proactive_guardrail.py", () => {
+      const caps = detectCapabilities(
+        makeDeps({
+          files: {
+            [SETTINGS_PATH]: settingsWithHookCommand(
+              'python "/home/tester/.neurodock/hooks/proactive_guardrail.py" pre-tool',
+            ),
+          },
+        }),
+      );
+      expect(caps.hooks).toBe(true);
+    });
+
+    it("is true when only the neurodock marker description is present", () => {
+      const settings = JSON.stringify({
+        hooks: {
+          Stop: [
+            {
+              matcher: "",
+              hooks: [
+                {
+                  type: "command",
+                  command: "some-renamed-wrapper stop",
+                  description: "neurodock-proactive-guardrail",
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const caps = detectCapabilities(
+        makeDeps({ files: { [SETTINGS_PATH]: settings } }),
+      );
+      expect(caps.hooks).toBe(true);
+    });
+
+    it("is false when settings.json does not exist", () => {
+      const caps = detectCapabilities(makeDeps());
+      expect(caps.hooks).toBe(false);
+    });
+
+    it("is false when settings.json has hooks from other tools only", () => {
+      const caps = detectCapabilities(
+        makeDeps({
+          files: {
+            [SETTINGS_PATH]: settingsWithHookCommand("other-tool format"),
+          },
+        }),
+      );
+      expect(caps.hooks).toBe(false);
+    });
+
+    it("is false when settings.json is unparseable", () => {
+      const caps = detectCapabilities(
+        makeDeps({ files: { [SETTINGS_PATH]: "{not json" } }),
+      );
+      expect(caps.hooks).toBe(false);
+    });
+  });
+
+  describe("daemon", () => {
+    it("linux: true when the systemd --user unit exists", () => {
+      const unit = joinHome(
+        ".config",
+        "systemd",
+        "user",
+        "neurodock-guardrail.service",
+      );
+      const caps = detectCapabilities(
+        makeDeps({ platform: "linux", files: { [unit]: "" } }),
+      );
+      expect(caps.daemon).toBe(true);
+    });
+
+    it("linux: false when the systemd --user unit is missing", () => {
+      const caps = detectCapabilities(makeDeps({ platform: "linux" }));
+      expect(caps.daemon).toBe(false);
+    });
+
+    it("darwin: true when the LaunchAgent plist exists", () => {
+      const plist = joinHome(
+        "Library",
+        "LaunchAgents",
+        "com.neurodock.guardrail.plist",
+      );
+      const caps = detectCapabilities(
+        makeDeps({ platform: "darwin", files: { [plist]: "" } }),
+      );
+      expect(caps.daemon).toBe(true);
+    });
+
+    it("darwin: false when the LaunchAgent plist is missing", () => {
+      const caps = detectCapabilities(makeDeps({ platform: "darwin" }));
+      expect(caps.daemon).toBe(false);
+    });
+
+    it("win32: reflects the HKCU Run autostart probe", () => {
+      const registered = detectCapabilities(
+        makeDeps({ platform: "win32", windowsRunKeyRegistered: () => true }),
+      );
+      expect(registered.daemon).toBe(true);
+
+      const missing = detectCapabilities(
+        makeDeps({ platform: "win32", windowsRunKeyRegistered: () => false }),
+      );
+      expect(missing.daemon).toBe(false);
+    });
+  });
+});

--- a/packages/native-host/tests/handler.test.ts
+++ b/packages/native-host/tests/handler.test.ts
@@ -40,6 +40,45 @@ describe("handler", () => {
     expect(r.id).toBe("1");
   });
 
+  it("ping reports setup capabilities from the injected detector", () => {
+    const store: FakeStore = {
+      path: "/tmp/profile.yaml",
+      raw: null,
+      exists: false,
+    };
+    const r = handleRequest({ op: "ping" }, makeIo(store), () => ({
+      profile: true,
+      hooks: true,
+      daemon: false,
+    }));
+    expect(r.ok).toBe(true);
+    const data = r.data as {
+      pong: boolean;
+      version: string;
+      capabilities: { profile: boolean; hooks: boolean; daemon: boolean };
+    };
+    // Additive shape: pong + version stay for clients that predate
+    // capabilities.
+    expect(data.pong).toBe(true);
+    expect(typeof data.version).toBe("string");
+    expect(data.capabilities).toEqual({
+      profile: true,
+      hooks: true,
+      daemon: false,
+    });
+  });
+
+  it("ping includes capabilities even with the default detector", () => {
+    const store: FakeStore = {
+      path: "/tmp/profile.yaml",
+      raw: null,
+      exists: false,
+    };
+    const r = handleRequest({ op: "ping" }, makeIo(store));
+    const data = r.data as { capabilities?: { profile: boolean } };
+    expect(data.capabilities?.profile).toBe(true);
+  });
+
   it("rejects a payload that does not match the request shape", () => {
     const store: FakeStore = {
       path: "/tmp/profile.yaml",


### PR DESCRIPTION
## What

WS2 of the extension overhaul: the real one-command install the extension's power-up card advertises, plus the capability contract that lets the card tell the truth about what's running.

### 1. `npx @neurodock/cli setup`
Thin orchestrator over the existing runners — no duplicated install logic:
1. `runInstallAll` (Python MCP servers + MCP client wiring + native-messaging host)
2. `runInstallHooks` (Claude Code guardrail hooks)

- Flags mirror `install-all` (`--client` · `--profile` · `--installer` · `--skip-install` · `--yes` · `--dry-run` · `--no-native-host`) plus **`--daemon`** — the standalone daemon stays **opt-in** because its own code documents it as optional and it registers login autostart (HKCU Run / LaunchAgent / systemd --user); too invasive for a default. `--help` says so honestly.
- Hooks still run when install-all partially fails (guardrails only need Python); exit codes preserve the failing step's meaning.

### 2. Native-host ping → `capabilities`
`ping` data is now `{ pong, version, capabilities: { profile, hooks, daemon } }` — **additive**, today's extension keeps working unchanged.

Detection is marker-based and deliberately conservative:
- `profile: true` — a ping reply is itself the proof.
- `hooks` — the exact hook entries `install-hooks` writes into `~/.claude/settings.json`.
- `daemon` — the login-autostart marker only (registry value / plist / systemd unit), **not** the daemon script on disk, because `install-hooks` copies that unconditionally and checking it would report a daemon that was never enabled.

### 3. Extension repoint
`FULL_SETUP_COMMAND` → `npx @neurodock/cli setup` (the command now exists).

## Test plan
- [x] cli: 118 tests green (10 new TDD tests for `setup`: runner order, flag pass-through, dry-run propagation, daemon opt-in, exit codes) · tsc clean
- [x] native-host: 41 tests green (11 new capability-detection tests + ping handler tests, injectable fs/os/registry probes) · typecheck clean
- [x] extension-browser: full suite 633 green · typecheck clean
- [x] CHANGELOG entries: cli, native-host, extension-browser
- [ ] Maintainer: run `npx @neurodock/cli setup --dry-run` locally; after a real run, the extension power-up card should flip to "Connected ✓"

## Notes
- The ping's Windows daemon probe spawns `reg query` per poll (popup-lifetime only, ~tens of ms); a TTL cache is the noted fix if it ever matters — left uncached so a just-run `setup` reflects instantly.
- Follow-up (WS1 polish): surface `capabilities.hooks/daemon` granularly in the power-up card instead of treating ping-active as fully-on.