### PR TITLE
fix: move pre-paint font script to external file for mv3 csp

### DIFF
--- a/packages/extension-browser/entrypoints/popup/index.html
+++ b/packages/extension-browser/entrypoints/popup/index.html
@@ -2,31 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- Apply the reader-font class before first paint (no flash of unhinted
-         text). Mirrors docs/src/overrides/SiteTitle.astro. Keep in sync with
-         src/lib/reader-font.ts. -->
-    <script>
-      (function () {
-        var KEY = "neurodockFont";
-        var ALLOWED = { atkinson: 1, lexend: 1, opendyslexic: 1, comic: 1, system: 1 };
-        var stored;
-        try {
-          stored = localStorage.getItem(KEY);
-        } catch (e) {
-          stored = null;
-        }
-        var choice = stored && ALLOWED[stored] ? stored : "atkinson";
-        var root = document.documentElement;
-        root.classList.remove(
-          "font-atkinson",
-          "font-lexend",
-          "font-opendyslexic",
-          "font-comic",
-          "font-system"
-        );
-        root.classList.add("font-" + choice);
-      })();
-    </script>
+    <!-- Pre-paint reader-font application. External classic script (NOT inline,
+         NOT a module): MV3 pages block inline scripts at runtime, and a classic
+         parser-blocking script still runs before first paint. -->
+    <script src="/prepaint.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NeuroDock</title>
   </head>

--- a/packages/extension-browser/entrypoints/tab/index.html
+++ b/packages/extension-browser/entrypoints/tab/index.html
@@ -2,31 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- Apply the reader-font class before first paint (no flash of unhinted
-         text). Mirrors docs/src/overrides/SiteTitle.astro. Keep in sync with
-         src/lib/reader-font.ts. -->
-    <script>
-      (function () {
-        var KEY = "neurodockFont";
-        var ALLOWED = { atkinson: 1, lexend: 1, opendyslexic: 1, comic: 1, system: 1 };
-        var stored;
-        try {
-          stored = localStorage.getItem(KEY);
-        } catch (e) {
-          stored = null;
-        }
-        var choice = stored && ALLOWED[stored] ? stored : "atkinson";
-        var root = document.documentElement;
-        root.classList.remove(
-          "font-atkinson",
-          "font-lexend",
-          "font-opendyslexic",
-          "font-comic",
-          "font-system"
-        );
-        root.classList.add("font-" + choice);
-      })();
-    </script>
+    <!-- Pre-paint reader-font application. External classic script (NOT inline,
+         NOT a module): MV3 pages block inline scripts at runtime, and a classic
+         parser-blocking script still runs before first paint. -->
+    <script src="/prepaint.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NeuroDock</title>
   </head>

--- a/packages/extension-browser/public/prepaint.js
+++ b/packages/extension-browser/public/prepaint.js
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * Pre-paint reader-font application for extension pages (popup + tab).
+ * Loaded as a CLASSIC (non-module) script from <head>, so it is
+ * parser-blocking and runs before <body> renders — no flash of unhinted
+ * text. MUST be an external file: MV3 extension pages enforce
+ * script-src 'self' and block ALL inline scripts at runtime.
+ * Keep in sync with src/lib/reader-font.ts.
+ */
+(function () {
+  var KEY = "neurodockFont";
+  var ALLOWED = {
+    atkinson: 1,
+    lexend: 1,
+    opendyslexic: 1,
+    comic: 1,
+    system: 1,
+  };
+  var stored;
+  try {
+    stored = localStorage.getItem(KEY);
+  } catch (e) {
+    stored = null;
+  }
+  var choice = stored && ALLOWED[stored] ? stored : "atkinson";
+  var root = document.documentElement;
+  root.classList.remove(
+    "font-atkinson",
+    "font-lexend",
+    "font-opendyslexic",
+    "font-comic",
+    "font-system",
+  );
+  root.classList.add("font-" + choice);
+})();

--- a/packages/extension-browser/tests/unit/prepaint-csp.test.ts
+++ b/packages/extension-browser/tests/unit/prepaint-csp.test.ts
@@ -28,14 +28,13 @@ describe("prepaint csp contract", () => {
   it.each([
     ["popup", popupHtml],
     ["tab", tabHtml],
-  ])("%s html has no inline script bodies", (_name, html) => {
-    // Any <script> tag with content between the tags is an inline script.
-    const inline =
-      html.match(/<script(?![^>]*\bsrc=)[^>]*>[\s\S]*?<\/script>/g) ?? [];
-    const nonEmpty = inline.filter(
-      (s) => s.replace(/<\/?script[^>]*>/g, "").trim() !== "",
-    );
-    expect(nonEmpty).toEqual([]);
+  ])("%s html has no inline scripts", (_name, html) => {
+    // An opening <script> tag without a src attribute is an inline script.
+    // Checking opening tags only (case-insensitively) is stricter than
+    // inspecting bodies and avoids HTML-rewriting heuristics entirely.
+    const openingTags = html.match(/<script\b[^>]*>/gi) ?? [];
+    const inlineTags = openingTags.filter((tag) => !/\bsrc\s*=/i.test(tag));
+    expect(inlineTags).toEqual([]);
   });
 
   it.each([

--- a/packages/extension-browser/tests/unit/prepaint-csp.test.ts
+++ b/packages/extension-browser/tests/unit/prepaint-csp.test.ts
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * MV3 extension pages enforce script-src 'self' and block ALL inline
+ * scripts at runtime (hashes/nonces are not honored). The pre-paint
+ * reader-font logic must therefore live in an external classic script.
+ * Guards: (1) no inline <script> bodies in entrypoint HTML, (2) the
+ * external prepaint script is referenced, (3) prepaint.js stays in sync
+ * with the reader-font contract.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(process.cwd());
+const popupHtml = readFileSync(
+  resolve(root, "entrypoints/popup/index.html"),
+  "utf8",
+);
+const tabHtml = readFileSync(
+  resolve(root, "entrypoints/tab/index.html"),
+  "utf8",
+);
+const prepaint = readFileSync(resolve(root, "public/prepaint.js"), "utf8");
+
+describe("prepaint csp contract", () => {
+  it.each([
+    ["popup", popupHtml],
+    ["tab", tabHtml],
+  ])("%s html has no inline script bodies", (_name, html) => {
+    // Any <script> tag with content between the tags is an inline script.
+    const inline =
+      html.match(/<script(?![^>]*\bsrc=)[^>]*>[\s\S]*?<\/script>/g) ?? [];
+    const nonEmpty = inline.filter(
+      (s) => s.replace(/<\/?script[^>]*>/g, "").trim() !== "",
+    );
+    expect(nonEmpty).toEqual([]);
+  });
+
+  it.each([
+    ["popup", popupHtml],
+    ["tab", tabHtml],
+  ])("%s html references the external prepaint script", (_name, html) => {
+    expect(html).toMatch(/<script\s+src="\/prepaint\.js"><\/script>/);
+  });
+
+  it("prepaint.js carries the reader-font contract", () => {
+    expect(prepaint).toContain('"neurodockFont"');
+    for (const f of ["atkinson", "lexend", "opendyslexic", "comic", "system"]) {
+      expect(prepaint).toContain(f);
+    }
+  });
+});


### PR DESCRIPTION
## What

Fixes the runtime CSP violation reported from a live Chrome install:

> Executing inline script violates the following Content Security Policy directive 'script-src 'self'' — popup.html:8

MV3 extension pages block **all** inline scripts at runtime (hashes/nonces are not honored), so the inline pre-paint reader-font script never ran. The build pipeline accepted it, which is why CI stayed green — only a live install surfaces it.

## Fix

- Pre-paint logic moved verbatim to **`public/prepaint.js`** — an external **classic** (non-module) script. Classic scripts in `<head>` are parser-blocking, so it still executes before `<body>` renders: the no-flash guarantee is preserved, and `'self'` makes it CSP-clean.
- Both `popup/index.html` and `tab/index.html` now reference `<script src="/prepaint.js"></script>` in the same head position.
- New regression test (`prepaint-csp.test.ts`): asserts **no inline script bodies** in either entrypoint HTML, the external reference exists, and `prepaint.js` carries the reader-font contract (key + all five values).

## Test plan
- [x] 642 tests / 75 files green · typecheck clean
- [x] Chrome + Firefox builds: `prepaint.js` ships at output root; tag survives Vite untouched; **zero** inline scripts in built popup.html/tab.html
- [ ] Maintainer: reload the unpacked extension — no CSP error in the console, and the chosen font applies with no flash on popup open