### PR TITLE
fix: keep header controls on one row; font select shrinks instead of wrapping

### DIFF
--- a/packages/extension-browser/entrypoints/popup/styles.css
+++ b/packages/extension-browser/entrypoints/popup/styles.css
@@ -128,9 +128,9 @@ samp {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  /* Survive width pressure from large reader fonts: flex children that
-     contain text must be allowed to shrink below their content size. */
-  min-width: 0;
+  /* The brand never shrinks or wraps; the font select absorbs all the
+     width pressure instead (see .nd-font-switcher below). */
+  flex-shrink: 0;
   text-decoration: none;
   color: var(--nd-color-fg-accent);
   font-family: var(--nd-font-heading);
@@ -142,16 +142,32 @@ samp {
 .nd-header-controls {
   display: inline-flex;
   align-items: center;
-  /* Wrap rather than overflow when a wide reader font inflates the
-     font select + toggles past the popup width. */
-  flex-wrap: wrap;
+  /* SINGLE row, always. Wrapping orphaned the last control onto its own
+     line (long font names made the select wide enough to wrap even in the
+     default font). Instead the select is the one shrinkable element: this
+     container may shrink (min-width: 0) and the switcher flexes down with
+     ellipsis while the icon buttons keep their size. */
+  flex-wrap: nowrap;
   min-width: 0;
   gap: 0.5rem;
+}
+.nd-header-controls > button {
+  /* Icon buttons (theme toggle, expand) keep their size; only the
+     select shrinks. */
+  flex-shrink: 0;
+}
+.nd-font-switcher {
+  /* The designated shrink absorber for the whole header row. */
+  display: inline-flex;
+  min-width: 0;
+  flex: 0 1 auto;
 }
 .nd-font-switcher select {
   appearance: auto;
   font-family: inherit;
   font-size: 0.8125rem;
+  width: 100%;
+  min-width: 4.5rem;
   max-width: 11rem;
   text-overflow: ellipsis;
   padding: 0.2rem 0.4rem;

--- a/packages/extension-browser/entrypoints/tab/styles.css
+++ b/packages/extension-browser/entrypoints/tab/styles.css
@@ -155,9 +155,9 @@ samp {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  /* Survive width pressure from large reader fonts: flex children that
-     contain text must be allowed to shrink below their content size. */
-  min-width: 0;
+  /* The brand never shrinks or wraps; the font select absorbs all the
+     width pressure instead (see .nd-font-switcher below). */
+  flex-shrink: 0;
   text-decoration: none;
   color: var(--nd-color-fg-accent);
   font-family: var(--nd-font-heading);
@@ -169,16 +169,32 @@ samp {
 .nd-header-controls {
   display: inline-flex;
   align-items: center;
-  /* Wrap rather than overflow when a wide reader font inflates the
-     font select + toggles past the popup width. */
-  flex-wrap: wrap;
+  /* SINGLE row, always. Wrapping orphaned the last control onto its own
+     line (long font names made the select wide enough to wrap even in the
+     default font). Instead the select is the one shrinkable element: this
+     container may shrink (min-width: 0) and the switcher flexes down with
+     ellipsis while the icon buttons keep their size. */
+  flex-wrap: nowrap;
   min-width: 0;
   gap: 0.5rem;
+}
+.nd-header-controls > button {
+  /* Icon buttons (theme toggle, expand) keep their size; only the
+     select shrinks. */
+  flex-shrink: 0;
+}
+.nd-font-switcher {
+  /* The designated shrink absorber for the whole header row. */
+  display: inline-flex;
+  min-width: 0;
+  flex: 0 1 auto;
 }
 .nd-font-switcher select {
   appearance: auto;
   font-family: inherit;
   font-size: 0.8125rem;
+  width: 100%;
+  min-width: 4.5rem;
   max-width: 11rem;
   text-overflow: ellipsis;
   padding: 0.2rem 0.4rem;


### PR DESCRIPTION
## What

Fixes the header placement issue from the maintainer's screenshots: the expand button wrapped onto its own orphaned row under the brand — even with the default font — because #77's `flex-wrap: wrap` overflow guard let the long font names ("Atkinson Hyperlegible") push the last control off the row.

## Fix (CSS only, popup + tab)

Inverted strategy: **never wrap — shrink the select instead.**
- `.nd-header-controls`: `flex-wrap: nowrap` (single row, always)
- `.nd-font-switcher`: the designated shrink absorber (`min-width: 0; flex: 0 1 auto`), select gets `width: 100%; min-width: 4.5rem; max-width: 11rem` + ellipsis
- Brand and icon buttons (theme toggle, expand) get `flex-shrink: 0` — they keep their size and position

Result: brand left · select (ellipsizes under pressure) + theme toggle + expand right, on one row at any font/width.

## Test plan
- [x] 642 tests / 75 files green · typecheck clean · chrome build verified (rules present in minified CSS)
- [ ] Maintainer: reload → header is a single row in Atkinson AND OpenDyslexic; select truncates with … if cramped