### PR TITLE
chore: release prep for v0.8.0 and extension 0.0.36

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @neurodock/cli changelog
 
-## [unreleased]
+## 0.8.0 - 2026-06-11
 
 ### Added — `neurodock setup`: install-all + install-hooks in one command
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurodock/cli",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "NeuroDock installer and diagnostic CLI — wires the MCP servers, manages plugins, and validates your profile.",
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/packages/extension-browser/CHANGELOG.md
+++ b/packages/extension-browser/CHANGELOG.md
@@ -1,6 +1,40 @@
 # @neurodock/extension-browser
 
-## [unreleased]
+## 0.0.36 - 2026-06-11
+
+### Added — experience redesign (WS1)
+
+- Reader-font switcher in the header: Atkinson Hyperlegible, Lexend,
+  OpenDyslexic, Comic Neue, or the system font. Same `neurodockFont`
+  contract as docs.neurodock.org; OpenDyslexic and Comic Neue woff2 now
+  ship in the bundle. The choice applies pre-paint (no flash) across the
+  popup, the full-page view, and the in-page panel.
+- Shared branded header (mark + wordmark + font switcher + theme toggle
+  - an expand button that opens the full-page view).
+- Reader preferences are now the first thing in Settings, with settings
+  split into Essentials (open) and Advanced (collapsed). Nothing removed.
+- "Turn on full NeuroDock" power-up card: one copy-paste command with a
+  live "Connected" check against the native host.
+- Identity-first onboarding (~2 steps): how you read best, then connect
+  a model — with a running LM Studio/Ollama auto-detected for a one-tap
+  local connect. Both steps skippable; no CLI command required.
+- Popup slimmed to Home + Notifications; full settings live on the
+  full-page view.
+
+### Changed
+
+- Plain-language copy throughout: "settings sync across browsers"
+  instead of "native host"; "always-on check-ins" instead of
+  daemon/hook jargon; raw commands appear only inside the power-up card.
+- OpenDyslexic/Comic Neue get metric compensation (85%/95% root scale)
+  so large glyphs never overflow the popup; header controls always stay
+  on one row (the font select shrinks with an ellipsis instead).
+
+### Fixed
+
+- The pre-paint font script now loads as an external file —
+  MV3 extension pages block inline scripts at runtime, so the inline
+  version silently never ran.
 
 ### Changed — power-up card now advertises `npx @neurodock/cli setup`
 

--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurodock/extension-browser",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "private": true,
   "description": "NeuroDock browser extension (Chrome, Firefox, Edge). MV3, WXT-built. Area 2 communication translation surface.",
   "license": "AGPL-3.0-or-later",

--- a/packages/mcp-cognitive-graph/CHANGELOG.md
+++ b/packages/mcp-cognitive-graph/CHANGELOG.md
@@ -6,6 +6,26 @@ to [semantic versioning](https://semver.org/spec/v2.0.0.html). Schemas under
 `schemas/` are versioned independently against `v0.1.0` of the contract; the
 package implements that contract.
 
+## [0.0.6] - 2026-06-11
+
+### Fixed
+
+- Decisions recorded as `decision belongs_to project` (with the person
+  credited via `decided_in` on the decision) now surface in
+  `recall_decisions` and `weekly_rollup`. Both read paths previously
+  only joined project and decision through a `decided_in` fact touching
+  the project, so the natural shape an LLM records came back empty.
+  Membership is now `decided_in` OR `belongs_to`, either orientation,
+  across all storage backends (PR #74).
+- `record_fact` accepts a JSON-stringified `subject`/`object` — some MCP
+  clients serialise object arguments for untyped parameters into a JSON
+  string, which the server used to reject as a bare string, failing
+  every write (PR #72).
+- The libSQL/Turso backing applies migrations statement-by-statement,
+  skipping PRAGMAs unsupported over remote connections. `executescript`
+  silently halted on the schema's leading PRAGMAs, leaving hosted
+  databases with no tables (PR #70).
+
 ## [0.0.5] - 2026-05-31
 
 - Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.

--- a/packages/mcp-cognitive-graph/pyproject.toml
+++ b/packages/mcp-cognitive-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-cognitive-graph"
-version = "0.0.5"
+version = "0.0.6"
 description = "NeuroDock cognitive graph MCP server — persistent entity memory and recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/mcp-guardrail/CHANGELOG.md
+++ b/packages/mcp-guardrail/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to `neurodock-mcp-guardrail` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This package follows semantic versioning.
 
+## [0.0.5] - 2026-06-11
+
+### Changed
+
+- `check_sycophancy` gains a praise-density branch on
+  `praise_without_evidence`: two or more distinct absolute-praise
+  markers anywhere in the response — with no citation and no qualifier —
+  now flag, so blatant over-validation that is not positioned as an
+  opener no longer slips through. The published `pattern` and
+  `heuristic.name` enums are unchanged. Clinical-layer change accepted
+  by the maintainer per ETHICS.md commitment 3 / ADR 0006 (PR #75).
+- Nested input models tolerate extra keys and accept common aliases
+  (`prompt`/`message`/`content` for `text`; `timestamp`/`time` for
+  `at`), and `INPUT_INVALID` errors now name the offending field
+  (PR #70).
+- Published input schemas document runtime constraints:
+  `check_hyperfocus.end_of_day_local` as HH:MM and the
+  `chronometric_snapshot` shape (PR #73).
+
 ## [0.0.4] - 2026-05-31
 
 - Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.

--- a/packages/mcp-guardrail/pyproject.toml
+++ b/packages/mcp-guardrail/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-guardrail"
-version = "0.0.4"
+version = "0.0.5"
 description = "NeuroDock guardrail MCP server — rumination, hyperfocus, and sycophancy detection."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/mcp-task-fractionator/CHANGELOG.md
+++ b/packages/mcp-task-fractionator/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] - 2026-06-11
+
+### Changed
+
+- `decompose.time_budget` documents its ISO-8601 duration format (for
+  example `PT2H`, `PT90M`) in the published input schema, so clients
+  stop guessing prose formats (PR #73).
+
 ## [0.0.4] - 2026-05-31
 
 - Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.

--- a/packages/mcp-task-fractionator/pyproject.toml
+++ b/packages/mcp-task-fractionator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-task-fractionator"
-version = "0.0.4"
+version = "0.0.5"
 description = "NeuroDock task fractionator MCP server — goal decomposition and next-action selection."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/mcp-translation/CHANGELOG.md
+++ b/packages/mcp-translation/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `neurodock-mcp-translation` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This package follows semantic versioning per .
 
+## [0.2.2] - 2026-06-11
+
+### Changed
+
+- `check_tone` and `rewrite_outgoing` publish `target_register` as a
+  typed enum (`direct`/`warm`/`formal`/`concise`/`clarifying`) in their
+  input schemas, so clients see the allowed values instead of a bare
+  string (PR #73).
+
 ## [0.2.1] - 2026-05-31
 
 - Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.

--- a/packages/mcp-translation/pyproject.toml
+++ b/packages/mcp-translation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-translation"
-version = "0.2.1"
+version = "0.2.2"
 description = "NeuroDock translation MCP server — deterministic baseline analysis plus structured LLM-refinement prompts for incoming/outgoing message decoding and meeting briefing."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/native-host/CHANGELOG.md
+++ b/packages/native-host/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @neurodock/native-host
 
-## [unreleased]
+## 0.2.0 - 2026-06-11
 
 ### Added — `ping` reports setup capabilities
 

--- a/packages/native-host/package.json
+++ b/packages/native-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurodock/native-host",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Chrome Native Messaging host that exposes ~/.neurodock/profile.yaml to the NeuroDock browser extension.",
   "license": "AGPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
## What

Version bumps + changelogs for everything merged since v0.7.4. Nothing publishes from this PR — publishing happens on the tags after merge.

| Package | From → To | Carries |
|---|---|---|
| `@neurodock/cli` (npm) | 0.7.2 → **0.8.0** | `neurodock setup` (#79) — the command the extension's power-up card advertises |
| `@neurodock/native-host` (npm) | 0.1.0 → **0.2.0** | `ping` capability contract (#79) |
| `neurodock-mcp-cognitive-graph` (PyPI) | 0.0.5 → **0.0.6** | decision surfacing (#74), stringified record_fact args (#72), libSQL migrations (#70) |
| `neurodock-mcp-guardrail` (PyPI) | 0.0.4 → **0.0.5** | sycophancy density (#75, clinical gate accepted), tolerant inputs (#70), schema docs (#73) |
| `neurodock-mcp-translation` (PyPI) | 0.2.1 → **0.2.2** | target_register enum in schema (#73) |
| `neurodock-mcp-task-fractionator` (PyPI) | 0.0.4 → **0.0.5** | time_budget ISO-8601 schema doc (#73) |
| extension-browser (stores) | 0.0.35 → **0.0.36** | the full experience redesign (#76, #77, #80, #81) — changelog has the complete entry |

## After merge (tags)
1. `git tag v0.8.0 && git push origin v0.8.0` → release workflow publishes npm + PyPI + MCP registry (server.json versions auto-sync)
2. `git tag extension-browser@0.0.36 && git push origin extension-browser@0.0.36` → builds zips, attaches them to a GitHub Release; store publishes skip gracefully (no secrets yet)

## Test plan
- [x] All released suites green pre-tag: cognitive-graph 82 · guardrail 83 · translation 50 · task-fractionator 63 · cli 118 · native-host 41
- [x] Chronometric (0.0.3), clinical, evals unchanged — version-gated no-ops in CI