### PR TITLE
fix: declare firefox data collection permissions; bump extension to 0.0.37

### DIFF
--- a/packages/extension-browser/CHANGELOG.md
+++ b/packages/extension-browser/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @neurodock/extension-browser
 
+## 0.0.37 - 2026-06-12
+
+### Fixed
+
+- Declare `data_collection_permissions: { required: ["none"] }` in the
+  gecko manifest block — AMO now rejects submissions without it. "None"
+  is the truthful value: the developer collects nothing; selected text
+  only goes to endpoints the user configures (localhost by default,
+  cloud only with explicit opt-in and the user's own key).
+
 ## 0.0.36 - 2026-06-11
 
 ### Added — experience redesign (WS1)

--- a/packages/extension-browser/package.json
+++ b/packages/extension-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neurodock/extension-browser",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "private": true,
   "description": "NeuroDock browser extension (Chrome, Firefox, Edge). MV3, WXT-built. Area 2 communication translation surface.",
   "license": "AGPL-3.0-or-later",

--- a/packages/extension-browser/wxt.config.ts
+++ b/packages/extension-browser/wxt.config.ts
@@ -185,6 +185,17 @@ export default defineConfig({
       gecko: {
         id: "neurodock-extension@neurodock.org",
         strict_min_version: "115.0",
+        // AMO validation requirement (hard error since late 2025): every
+        // extension must declare what data it collects. NeuroDock's honest
+        // answer is "none" — the developer collects and receives nothing.
+        // Selected text is only ever sent to endpoints the USER configures:
+        // localhost (LM Studio / Ollama) by default, or a cloud provider the
+        // user explicitly opts into with their own API key. That opt-in flow
+        // and its trade-offs are documented in PRIVACY.md and the AMO
+        // listing's privacy section; no data ever flows to NeuroDock.
+        data_collection_permissions: {
+          required: ["none"],
+        },
       },
     },
     // Tab view (entrypoints/tab/ → tab.html). Marked web-accessible so


### PR DESCRIPTION
## What

AMO rejected the 0.0.36 Firefox submission: `The "data_collection_permissions" property is missing` — a hard validation requirement on addons.mozilla.org since late 2025.

## Fix

Declare it in the gecko manifest block with the truthful value:

```json
"data_collection_permissions": { "required": ["none"] }
```

"None" is accurate: the developer collects and receives nothing. Selected text only goes to endpoints the **user** configures — localhost (LM Studio/Ollama) by default, a cloud provider only with explicit opt-in and the user's own API key — documented in PRIVACY.md and the AMO listing's privacy section.

Version bumped to **0.0.37** so the re-submission zip matches a public GitHub release (and the AMO sources zip stays consistent with the uploaded artifact).

## Test plan
- [x] Firefox build: manifest carries the declaration (verified in `.output/firefox-mv3/manifest.json`)
- [x] Chrome build unaffected (the gecko block has always shipped in chrome manifests and is ignored)
- [x] 642 tests / 75 files green · typecheck clean
- [ ] After merge: tag `extension-browser@0.0.37` → upload the new firefox + sources zips to AMO