### PR TITLE
chore: sync mcpb manifest versions to released servers

### DIFF
--- a/mcpb/neurodock-mcp-chronometric/manifest.json
+++ b/mcpb/neurodock-mcp-chronometric/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "neurodock-mcp-chronometric",
   "display_name": "NeuroDock Chronometric",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Externalises time-of-day, session boundaries, and break prompts for time-blind users.",
   "long_description": "Time, idle, and break-management MCP server for neurodivergent professionals. Externalises time-of-day context, opens and closes work sessions around the user's verbatim stated intent, prompts for breaks, and reports OS idle status (with consent). Part of NeuroDock, a local-first cognitive substrate. All session state is held locally.",
   "author": {

--- a/mcpb/neurodock-mcp-cognitive-graph/manifest.json
+++ b/mcpb/neurodock-mcp-cognitive-graph/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "neurodock-mcp-cognitive-graph",
   "display_name": "NeuroDock Cognitive Graph",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "A local typed-edge graph of people, projects, and decisions that externalises memory.",
   "long_description": "Persistent entity-memory MCP server for neurodivergent professionals. Stores a local typed-edge property graph of people, projects, decisions, and concepts so a hyperfocused or context-switched session does not start from zero. Records facts as subject-predicate-object triples, recalls entities and decisions, and produces a weekly rollup. Part of NeuroDock, a local-first cognitive substrate. The graph is stored in a local SQLite database under ~/.neurodock and never leaves the device.",
   "author": {

--- a/mcpb/neurodock-mcp-guardrail/manifest.json
+++ b/mcpb/neurodock-mcp-guardrail/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "neurodock-mcp-guardrail",
   "display_name": "NeuroDock Guardrail",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "Advisory detectors for rumination, hyperfocus, and sycophancy. Never silently blocks.",
   "long_description": "Clinical-guardrail MCP server for neurodivergent professionals. Provides advisory detectors for three patterns that unmodified LLM interaction tends to amplify: rumination loops (OCD), unregulated hyperfocus (ADHD), and sycophancy / over-validation. Every detector is advisory only — it never silently blocks an action and always returns override options. Part of NeuroDock, a local-first cognitive substrate. The detectors are stateless and make no network calls.",
   "author": {

--- a/mcpb/neurodock-mcp-task-fractionator/manifest.json
+++ b/mcpb/neurodock-mcp-task-fractionator/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "neurodock-mcp-task-fractionator",
   "display_name": "NeuroDock Task Fractionator",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "Decompose a vague goal into atomic 5-90 minute tasks and surface the next safe action.",
   "long_description": "Local-first goal-decomposition MCP server for neurodivergent professionals. Turns a vague goal into a small ordered list of atomic 5-90 minute tasks, each with acceptance criteria and dependencies, against an 'I can start now' bar. Also surfaces the single safe next action from pending work. Part of NeuroDock, a local-first cognitive substrate.",
   "author": {

--- a/mcpb/neurodock-mcp-translation/manifest.json
+++ b/mcpb/neurodock-mcp-translation/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "neurodock-mcp-translation",
   "display_name": "NeuroDock Translation",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Decode subtext, tone, and ambiguity in messages; rewrite outgoing replies; brief meetings.",
   "long_description": "Communication-decoding MCP server for neurodivergent professionals. Decodes the implicit ask and ranked subtext in an incoming corporate message, anchors every ambiguous span verbatim to the source, checks the tone of a draft, rewrites outgoing replies, and briefs meetings. Part of NeuroDock, a local-first cognitive substrate. The server performs no LLM calls of its own — it orchestrates prompt templates against whatever model your MCP client is configured to use.",
   "author": {


### PR DESCRIPTION
Bumps the five Claude Desktop `.mcpb` manifests to match the published PyPI versions (chronometric 0.0.3, cognitive-graph 0.0.6, guardrail 0.0.5, task-fractionator 0.0.5, translation 0.2.2) so packed bundles advertise the correct version. All five `@anthropic-ai/mcpb validate` clean. Thin `uvx` launchers unchanged.