### PR TITLE
ci: attach .mcpb bundles to v* releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,3 +219,43 @@ jobs:
             echo "::error::every registry publish failed"
             exit 1
           fi
+
+  mcpb-bundles:
+    name: Attach Claude Desktop bundles (.mcpb)
+    # Runs after PyPI so the bundles are only attached to a release whose
+    # underlying servers actually published. The bundles themselves are thin
+    # `uvx neurodock-mcp-<server>` launchers (no embedded code), so packing
+    # them needs only Node — but we gate on a successful publish.
+    needs: [pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release for the v* tag + upload assets
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Validate and pack .mcpb bundles
+        run: |
+          set -e
+          mkdir -p dist
+          for s in chronometric cognitive-graph guardrail task-fractionator translation; do
+            dir="mcpb/neurodock-mcp-$s"
+            npx --yes @anthropic-ai/mcpb validate "$dir/manifest.json"
+            npx --yes @anthropic-ai/mcpb pack "$dir" "dist/neurodock-mcp-$s.mcpb"
+          done
+          echo "Packed bundles:"
+          ls -la dist/*.mcpb
+
+      # Creates (or updates) the GitHub Release for the triggering v* tag and
+      # attaches the five Claude Desktop bundles. v* tags previously produced
+      # no GitHub Release at all — only npm/PyPI/registry publishes.
+      - name: Attach bundles to the GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.mcpb
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,7 @@ docs/decisions/0010-opt-in-hosted-full-experience.md
 packages/extension-browser/store-listings/
 packages/extension-browser/store/
 packages/extension-browser/STORE-SUBMISSION.md
+# Connectors Directory submission kit (one-time form copy; internal).
+packages/remote/CONNECTORS-SUBMISSION.md
+# Brainstorming / design working docs (internal; not published).
+docs/superpowers/


### PR DESCRIPTION
## What

Adds an `mcpb-bundles` job to the Release workflow so every `v*` tag packs the five Claude Desktop bundles and attaches them to a GitHub Release.

- `needs: [pypi]` — bundles only attach to a release whose servers actually published.
- Validates then `npx @anthropic-ai/mcpb pack`s each of the five `mcpb/neurodock-mcp-*` manifests.
- `softprops/action-gh-release@v2` (same pin the extension workflow uses) creates the Release for the tag with auto-generated notes + the `.mcpb` assets. **`v*` tags previously produced no GitHub Release at all** — only npm/PyPI/registry publishes — so this also gives the Python release line a proper release page.
- `permissions: contents: write` scoped to the new job only.

Also: `.gitignore` now excludes `packages/remote/CONNECTORS-SUBMISSION.md` (a one-time Connectors Directory submission kit, internal — same pattern as the extension's `STORE-SUBMISSION.md`) and the pre-existing `docs/superpowers/` working-docs dir.

## Test plan
- [x] `release.yml` parses (`yaml.safe_load`); jobs = npm, pypi, mcp-registry, **mcpb-bundles**
- [x] All five manifests `@anthropic-ai/mcpb validate` clean (verified in PR #85)
- [ ] Exercised on the next `v*` tag — the bundles appear on the release and the manifest versions match the published servers (PR #85 synced them)