### PR TITLE
chore(deps): bump transitive high-severity deps (starlette, python-multipart, form-data, ws, dompurify)

### DIFF
--- a/packages/cli/src/assets/hooks/proactive_guardrail.py
+++ b/packages/cli/src/assets/hooks/proactive_guardrail.py
@@ -518,7 +518,7 @@ def _is_past_end_of_day(now: datetime, end_of_day_local: str | None) -> bool:
     hour, minute = int(match.group(1)), int(match.group(2))
     if not (0 <= hour <= 23 and 0 <= minute <= 59):
         return _clock_band(now) in ("late_night", "deep_night")
-    # Deep night (00:00–05:59) is always "past end of day" regardless of the
+    # Deep night (00:00-05:59) is always "past end of day" regardless of the
     # configured clock-out — nobody sets end_of_day to 03:00 and means it.
     if now.hour < 6:
         return True

--- a/packages/cli/src/assets/hooks/proactive_guardrail.py
+++ b/packages/cli/src/assets/hooks/proactive_guardrail.py
@@ -174,9 +174,7 @@ def _on_session_start(_payload: dict[str, Any], settings: dict[str, Any]) -> Non
     state["tool_count"] = 0
     _save_session(state)
     band = _clock_band(now)
-    break_minutes = settings.get(
-        "hyperfocus_break_minutes", HYPERFOCUS_BREAK_MINUTES_DEFAULT
-    )
+    break_minutes = settings.get("hyperfocus_break_minutes", HYPERFOCUS_BREAK_MINUTES_DEFAULT)
     if band in ("deep_night", "late_night"):
         _emit_banner(
             f"NeuroDock: it's {band.replace('_', ' ')} local time. "
@@ -208,17 +206,13 @@ def _on_pre_tool(payload: dict[str, Any], settings: dict[str, Any]) -> None:
     if state["tool_count"] % PRETOOL_CHECK_EVERY_N != 0:
         return
 
-    break_minutes = settings.get(
-        "hyperfocus_break_minutes", HYPERFOCUS_BREAK_MINUTES_DEFAULT
-    )
+    break_minutes = settings.get("hyperfocus_break_minutes", HYPERFOCUS_BREAK_MINUTES_DEFAULT)
     end_of_day = settings.get("end_of_day_local")
     hyperfocus_banner = _evaluate_hyperfocus(state, break_minutes, end_of_day)
     if hyperfocus_banner:
         _emit_banner(hyperfocus_banner)
     threshold = settings.get("rumination_threshold", RUMINATION_THRESHOLD_DEFAULT)
-    window = settings.get(
-        "rumination_window_minutes", RUMINATION_WINDOW_MINUTES_DEFAULT
-    )
+    window = settings.get("rumination_window_minutes", RUMINATION_WINDOW_MINUTES_DEFAULT)
     rumination_banner = _evaluate_rumination(threshold, window)
     if rumination_banner:
         _emit_banner(rumination_banner)
@@ -576,21 +570,15 @@ def _parse_profile_text(text: str) -> dict[str, Any]:
 
     hyperfocus = _extract_int(text, "hyperfocus_break_minutes")
     if hyperfocus is not None:
-        settings["hyperfocus_break_minutes"] = _clamp(
-            hyperfocus, *HYPERFOCUS_BREAK_MIN_RANGE
-        )
+        settings["hyperfocus_break_minutes"] = _clamp(hyperfocus, *HYPERFOCUS_BREAK_MIN_RANGE)
 
     threshold = _extract_int(text, "rumination_threshold")
     if threshold is not None:
-        settings["rumination_threshold"] = _clamp(
-            threshold, *RUMINATION_THRESHOLD_RANGE
-        )
+        settings["rumination_threshold"] = _clamp(threshold, *RUMINATION_THRESHOLD_RANGE)
 
     window = _extract_int(text, "rumination_window_minutes")
     if window is not None:
-        settings["rumination_window_minutes"] = _clamp(
-            window, *RUMINATION_WINDOW_RANGE
-        )
+        settings["rumination_window_minutes"] = _clamp(window, *RUMINATION_WINDOW_RANGE)
 
     eod = _extract_str(text, "end_of_day_local")
     if eod is not None and re.match(r"^\d{1,2}:\d{2}$", eod):
@@ -805,15 +793,15 @@ def _self_test() -> int:
 
     # Profile parsing: extract scalars from a representative profile snippet.
     sample_profile = (
-        "schema_version: \"0.1.0\"\n"
+        'schema_version: "0.1.0"\n'
         "chronometric:\n"
         "  # how long before a nudge\n"
         "  hyperfocus_break_minutes: 60\n"
-        "  end_of_day_local: \"18:30\"\n"
+        '  end_of_day_local: "18:30"\n'
         "guardrails:\n"
         "  rumination_threshold: 4\n"
         "  rumination_window_minutes: 120\n"
-        "  sycophancy_check: \"off\"\n"
+        '  sycophancy_check: "off"\n'
     )
     parsed = _parse_profile_text(sample_profile)
     expected = {
@@ -834,7 +822,7 @@ def _self_test() -> int:
         ok = False
 
     # Profile parsing: an empty / commented profile yields no overrides.
-    if _parse_profile_text("# just a comment\nschema_version: \"0.1.0\"\n") != {}:
+    if _parse_profile_text('# just a comment\nschema_version: "0.1.0"\n') != {}:
         sys.stderr.write("FAIL: bare profile should yield no overrides\n")
         ok = False
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ overrides:
   tmp: ^0.2.6
   esbuild: '>=0.28.1'
   shell-quote: '>=1.8.4'
+  form-data: '>=4.0.6'
+  ws: '>=8.21.0'
+  dompurify: '>=3.4.9'
 
 importers:
 
@@ -150,7 +153,7 @@ importers:
         version: 8.0.3
       openai:
         specifier: ^6.42.0
-        version: 6.42.0(ws@8.20.1)(zod@4.4.3)
+        version: 6.42.0(ws@8.21.0)(zod@4.4.3)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -3002,8 +3005,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.5:
-    resolution: {integrity: sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==}
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3259,8 +3262,8 @@ packages:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
     engines: {node: '>= 18'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formdata-node@6.0.3:
@@ -3389,6 +3392,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-embedded@3.0.0:
@@ -4372,7 +4379,7 @@ packages:
   openai@6.42.0:
     resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
     peerDependencies:
-      ws: ^8.18.0
+      ws: '>=8.21.0'
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
@@ -5836,8 +5843,8 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8693,7 +8700,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.5:
+  dompurify@3.4.10:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8962,12 +8969,12 @@ snapshots:
 
   form-data-encoder@4.1.0: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formdata-node@6.0.3: {}
@@ -9106,6 +9113,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -9504,7 +9515,7 @@ snapshots:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -9520,7 +9531,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.1
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -9996,7 +10007,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.5
+      dompurify: 3.4.10
       es-toolkit: 1.46.1
       katex: 0.16.47
       khroma: 2.1.0
@@ -10423,9 +10434,9 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.42.0(ws@8.20.1)(zod@4.4.3):
+  openai@6.42.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.1
+      ws: 8.21.0
       zod: 4.4.3
 
   os-shim@0.1.3: {}
@@ -12230,7 +12241,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,3 +34,15 @@ overrides:
   # (critical). fx-runner@1.4.0 (web-ext tooling) + wrangler still pull
   # shell-quote@1.7.3. Force the patched version.
   "shell-quote": ">=1.8.4"
+  # form-data <4.0.6 uses an unsafe random boundary, enabling CRLF
+  # injection via unescaped multipart field names/filenames (high,
+  # GHSA dependabot #53). Transitive via tooling. Force the patched version.
+  "form-data": ">=4.0.6"
+  # ws >=8.0.0 <8.21.0 can be driven to memory-exhaustion DoS from tiny
+  # fragments/data chunks (high, dependabot #48). Transitive. Force the fix.
+  "ws": ">=8.21.0"
+  # dompurify <3.4.9 carries a cluster of sanitizer-bypass advisories
+  # (dependabot #54-#60). Transitive. Force the latest patched line.
+  # Note: #57 (IN_PLACE attacker-controlled nodeName) has no upstream fix
+  # yet and is low-risk for our usage; this raises everything else to 3.4.9.
+  "dompurify": ">=3.4.9"

--- a/uv.lock
+++ b/uv.lock
@@ -2163,11 +2163,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.28"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -2569,15 +2569,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

After merging the open Dependabot PRs (#88, #89), 20 of the 29 Dependabot alerts
still had **no PR** — they're **transitive** deps (not declared in any manifest),
so Dependabot doesn't open version-update PRs for them. This PR closes the
high-severity transitive gap via lockfile/override bumps.

CodeQL and secret-scanning are clean (0 alerts each).

## Changes

**npm** — `pnpm-workspace.yaml` overrides (same mechanism already used for
esbuild/tmp/uuid/shell-quote) + regenerated `pnpm-lock.yaml`:

| package | from | to | alert |
|---|---|---|---|
| form-data | <4.0.6 | **4.0.6** | #53 **high** — CRLF injection |
| ws | 8.x <8.21.0 | **8.21.0** | #48 **high** — memory-exhaustion DoS |
| dompurify | ≤3.4.7 | **3.4.10** | #54–#60 (med/low) |

**python** — `uv lock --upgrade-package` (transitive via fastmcp/uvicorn):

| package | from | to | alert |
|---|---|---|---|
| starlette | 1.0.1 | **1.3.1** | #65/#67 **high** + #64/#66 |
| python-multipart | 0.0.28 | **0.0.32** | #46 **high** + #43/#44/#45 |

## Not included (tracked follow-up)

- **cryptography #63 (high)** — `clerk-backend-api 5.0.7` pins
  `cryptography<47.0.0`, so the OpenSSL-bundle fix (≥48.0.1) is **unreachable by
  lockfile bump**. clerk-backend-api **6.0.1** lifts the cap to `<49.0.0`, but
  that's a **Clerk SDK major** touching the remote auth path → its own PR with
  auth-path testing.
- **dompurify #57** — no upstream patch exists yet; low-risk for our usage.

## Held PRs (not merged)

- **#90** vite 6.4.3→7.3.5 — the vite CVEs (#51/#52) were already patched in
  6.4.3 (current lockfile); this is an unneeded **major** with regression risk.
- **#87** softprops/action-gh-release 2→3 — CI-only **major**; needs a v3
  breaking-changes review (it's in the release pipeline that just shipped v0.8.1).

## Verification (local)

- Python: remote **38 passed**, mcp servers + state **366 passed** (starlette 1.3.1)
- Extension: **642 passed** (dompurify 3.4.10)
- Docs: `astro build` clean, 53 pages

No package versions changed (pure dependency hygiene), so no changeset/release.
