### PR TITLE
fix(extension-browser): lm studio structured output + nested validation strip

### DIFF
--- a/.changeset/lmstudio-json-schema-structured-output.md
+++ b/.changeset/lmstudio-json-schema-structured-output.md
@@ -1,0 +1,37 @@
+---
+"@neurodock/extension-browser": patch
+---
+
+fix(extension): use lm studio structured output (json_schema) so small local models stop failing validation
+
+The LM Studio provider was the only provider that requested plain `text`
+output instead of constrained JSON. Capable models followed the
+"return only JSON" instruction, but small local models (e.g.
+`gemma-4-e4b`) routinely emitted prose, so `extractJson` found no JSON
+object and every call failed with
+`LLM_OUTPUT_VALIDATION_FAILED (Could not locate a JSON object in the
+model completion.)` — while the same request worked fine on OpenRouter.
+
+LM Studio's own 400 ("must be `'json_schema'` or `'text'`") points to the
+fix: it supports OpenAI-style structured output. The provider now sends
+`response_format: { type: "json_schema", json_schema: { name, strict,
+schema } }`, which grammar-constrains decoding (GBNF under the hood) so
+even a 4B model is forced to produce schema-valid JSON.
+
+- New `modelFacingSchema(tool)` builds the structured-output schema with
+  the server-owned fields (`model_provenance`, `eval_corpus_slice`)
+  stripped, so a `strict` grammar can't force the model to hallucinate
+  provenance (ADR 0005). Those fields are still injected by
+  `normaliseLLMOutput` after parsing.
+- Graceful fallback: if a server/model rejects structured output with a
+  400 that names `response_format`/`json_schema`, the provider retries
+  once in plain-text mode (mirrors the OpenRouter and Google providers).
+  Unrelated 400s still surface as real errors.
+- Validation now drops stray properties at any nesting level
+  (`removeAdditional: "all"` in the compiled validators) instead of
+  rejecting. llama.cpp's GBNF grammar doesn't enforce
+  `additionalProperties: false` on nested objects, so a small model adding
+  a stray key to e.g. a `content_translation[].facets[]` entry no longer
+  fails an otherwise-valid response. Required fields and value constraints
+  (types, enums) are still enforced — the recursive version of the
+  existing top-level field stripping.

--- a/packages/extension-browser/scripts/compile-schemas.ts
+++ b/packages/extension-browser/scripts/compile-schemas.ts
@@ -128,6 +128,17 @@ export function compileSchemas(): { written: string } {
   const ajv = new Ajv2020({
     allErrors: true,
     strict: false,
+    // 0.0.38: drop stray properties at ANY nesting level instead of
+    // rejecting. LM Studio's grammar-constrained structured output (GBNF
+    // via llama.cpp) does NOT enforce `additionalProperties: false` on
+    // nested objects, so small local models (gemma-4-e4b) add a stray key
+    // to e.g. a `content_translation[].facets[]` entry and otherwise-valid
+    // output was rejected with "must NOT have additional properties". This
+    // is the recursive, schema-aware version of the explicit top-level
+    // `stripUnknownTopLevelKeys` in validation.ts — same "drop, don't fail"
+    // philosophy we already apply to provider chatter. Required fields and
+    // value constraints (types, enums) are still enforced.
+    removeAdditional: "all",
     code: { source: true, esm: true },
   });
   const refs: Record<string, string> = {};

--- a/packages/extension-browser/src/lib/providers/lmstudio.ts
+++ b/packages/extension-browser/src/lib/providers/lmstudio.ts
@@ -30,6 +30,7 @@
  */
 import type { Provider, ProviderRequest, ProviderResult } from "./provider.js";
 import { logPromptIfEnabled } from "./debug-log.js";
+import { modelFacingSchema } from "../validation.js";
 
 export interface LMStudioOptions {
   readonly baseUrl: string;
@@ -117,6 +118,7 @@ export function createLMStudioProvider(options: LMStudioOptions): Provider {
   async function postOnce(
     request: ProviderRequest,
     stream: boolean,
+    useJsonSchema: boolean,
   ): Promise<Response> {
     await ensurePermitted();
     await logPromptIfEnabled({
@@ -126,11 +128,17 @@ export function createLMStudioProvider(options: LMStudioOptions): Provider {
       prompt: request.prompt,
     });
     const url = `${baseUrl}/chat/completions`;
-    // LM Studio's OpenAI-compat API rejects response_format.type === 'json_object'
-    // (returns HTTP 400 "must be 'json_schema' or 'text'"). The translation
-    // prompts already instruct the model to return JSON, and validation.ts'
-    // extractJson handles raw-text responses, so 'text' is correct here.
-    // OpenAI/OpenRouter keep 'json_object' in their own provider files.
+    // 0.0.38: request grammar-constrained structured output via
+    // `response_format.type === 'json_schema'` — LM Studio's native mode
+    // (backed by llama.cpp GBNF). Plain 'text' left weak local models
+    // (gemma-4-e4b) free to emit prose, so extractJson found no object and
+    // every call failed LLM_OUTPUT_VALIDATION_FAILED. `json_object` is NOT
+    // an option — LM Studio 400s on it ("must be 'json_schema' or 'text'");
+    // json_schema is exactly what that error points to. We send a
+    // model-facing schema (server-owned fields stripped) so a `strict`
+    // grammar can't force the model to invent provenance. `useJsonSchema`
+    // is flipped to false on the one-shot retry below when an older server
+    // or a model without grammar support rejects it.
     //
     // 0.0.16: when `images` is non-empty, build the OpenAI-compatible
     // multimodal content array AND convert every image URL to a base64
@@ -160,11 +168,21 @@ export function createLMStudioProvider(options: LMStudioOptions): Provider {
     // 4096 leaves comfortable headroom for the largest schema we ship
     // (describe_image with 7 key_elements + transcribed_text) without
     // blowing model context windows.
+    const responseFormat = useJsonSchema
+      ? {
+          type: "json_schema" as const,
+          json_schema: {
+            name: request.tool,
+            strict: true,
+            schema: modelFacingSchema(request.tool),
+          },
+        }
+      : { type: "text" as const };
     const body = JSON.stringify({
       model: request.model,
       messages: [{ role: "user", content }],
       stream,
-      response_format: { type: "text" },
+      response_format: responseFormat,
       max_tokens: 4096,
     });
     let res: Response;
@@ -183,6 +201,16 @@ export function createLMStudioProvider(options: LMStudioOptions): Provider {
     }
     if (!res.ok) {
       const detail = await readErrorBody(res);
+      // Some servers/models don't support structured output. Detect a 400
+      // that names response_format / json_schema and let the caller retry
+      // once in plain-text mode. Mirrors the OpenRouter + Google providers.
+      if (
+        res.status === 400 &&
+        useJsonSchema &&
+        isStructuredOutputRejection(detail)
+      ) {
+        throw new ResponseFormatRejected(detail);
+      }
       throw normaliseLMStudioError(res.status, detail);
     }
     return res;
@@ -193,7 +221,7 @@ export function createLMStudioProvider(options: LMStudioOptions): Provider {
       return completeNonStreaming(request);
     }
     try {
-      const res = await postOnce(request, true);
+      const res = await postOnce(request, true, true);
       const ct = res.headers.get("content-type") ?? "";
       if (!ct.toLowerCase().includes("text/event-stream")) {
         const text = await consumeNonStreamBody(res, request.onToken);
@@ -202,6 +230,17 @@ export function createLMStudioProvider(options: LMStudioOptions): Provider {
       const text = await consumeSse(res, request.onToken);
       return resultFor(request, text);
     } catch (cause: unknown) {
+      if (cause instanceof ResponseFormatRejected) {
+        // Retry once on the streaming path in plain-text mode.
+        const res = await postOnce(request, true, false);
+        const ct = res.headers.get("content-type") ?? "";
+        if (!ct.toLowerCase().includes("text/event-stream")) {
+          const text = await consumeNonStreamBody(res, request.onToken);
+          return resultFor(request, text);
+        }
+        const text = await consumeSse(res, request.onToken);
+        return resultFor(request, text);
+      }
       if (cause instanceof Error && /LMSTUDIO_/.test(cause.message)) {
         throw cause;
       }
@@ -224,9 +263,18 @@ export function createLMStudioProvider(options: LMStudioOptions): Provider {
   async function completeNonStreaming(
     request: ProviderRequest,
   ): Promise<ProviderResult> {
-    const res = await postOnce(request, false);
-    const text = await consumeNonStreamBody(res, request.onToken);
-    return resultFor(request, text);
+    try {
+      const res = await postOnce(request, false, true);
+      const text = await consumeNonStreamBody(res, request.onToken);
+      return resultFor(request, text);
+    } catch (cause: unknown) {
+      if (cause instanceof ResponseFormatRejected) {
+        const res = await postOnce(request, false, false);
+        const text = await consumeNonStreamBody(res, request.onToken);
+        return resultFor(request, text);
+      }
+      throw cause;
+    }
   }
 
   return { id: "lmstudio", complete };
@@ -422,6 +470,29 @@ async function readErrorBody(response: Response): Promise<string> {
 function isStreamUnsupported(cause: unknown): boolean {
   if (!(cause instanceof Error)) return false;
   return /event-stream|stream not supported/i.test(cause.message);
+}
+
+/**
+ * Sentinel raised by `postOnce` when LM Studio rejects our structured-
+ * output request with a 400 that names `response_format` / `json_schema`.
+ * The caller retries once in plain-text mode. Same pattern as the
+ * OpenRouter and Google providers.
+ */
+class ResponseFormatRejected extends Error {
+  constructor(detail: string) {
+    super(`LMSTUDIO_STRUCTURED_OUTPUT_REJECTED: ${detail}`);
+    this.name = "ResponseFormatRejected";
+  }
+}
+
+function isStructuredOutputRejection(detail: string): boolean {
+  // Matches messages like "must be 'json_schema' or 'text'", "this model
+  // does not support json_schema response_format", "structured output not
+  // supported", "grammar ...", etc. Deliberately narrow so unrelated 400s
+  // (context length, bad request) still surface as real errors.
+  return /response_format|json[_ ]?schema|structured\s*output|grammar|json[_ ]?object/i.test(
+    detail,
+  );
 }
 
 function normaliseLMStudioError(status: number, detail: string): Error {

--- a/packages/extension-browser/src/lib/validation.ts
+++ b/packages/extension-browser/src/lib/validation.ts
@@ -74,6 +74,35 @@ function buildOutputSchema(tool: TranslationTool): JsonSchema {
   };
 }
 
+/**
+ * Fields the SERVER owns, not the model (ADR 0005). They are part of the
+ * public output schema but `normaliseLLMOutput` injects them after the
+ * model responds — the model must never produce them itself.
+ */
+const SERVER_OWNED_OUTPUT_FIELDS = ["model_provenance", "eval_corpus_slice"];
+
+/**
+ * The output schema reshaped for use as a constrained-decoding grammar
+ * (`response_format: json_schema`) against a local model. Identical to
+ * `buildOutputSchema` but with the server-owned fields removed from both
+ * `properties` and `required`, so a `strict` structured-output request
+ * cannot force a small model (e.g. gemma-4-e4b) to hallucinate provenance.
+ * Those fields are re-injected by `normaliseLLMOutput` after parsing.
+ */
+export function modelFacingSchema(tool: TranslationTool): JsonSchema {
+  const full = buildOutputSchema(tool);
+  const properties = {
+    ...((full.properties ?? {}) as Record<string, unknown>),
+  };
+  for (const field of SERVER_OWNED_OUTPUT_FIELDS) delete properties[field];
+  const required = Array.isArray(full.required)
+    ? (full.required as string[]).filter(
+        (key) => !SERVER_OWNED_OUTPUT_FIELDS.includes(key),
+      )
+    : full.required;
+  return { ...full, properties, required };
+}
+
 export function _resetValidatorsForTests(): void {
   // Validators are precompiled and stateless; nothing to reset. Kept for
   // backwards compatibility with existing tests.

--- a/packages/extension-browser/tests/unit/providers/lmstudio.test.ts
+++ b/packages/extension-browser/tests/unit/providers/lmstudio.test.ts
@@ -134,15 +134,17 @@ describe("lmstudio provider", () => {
     expect(body.model).toBe("qwen2.5-7b-instruct");
     expect(body.stream).toBe(true);
     expect(body.messages).toEqual([{ role: "user", content: "ping" }]);
-    // Regression pin for 0.0.6 fix. LM Studio's OpenAI-compat API rejects
-    // `response_format: { type: "json_object" }` with HTTP 400
-    // (`'response_format.type' must be 'json_schema' or 'text'`).
-    // The body MUST send `text`. Without this assertion the fix could
-    // silently regress to `json_object` and break every LM Studio user.
-    expect(body.response_format).toEqual({ type: "text" });
+    // Contract pin (0.0.38): LM Studio MUST request grammar-constrained
+    // structured output via `response_format.type === "json_schema"`.
+    // Plain `text` mode left weak local models (gemma-4-e4b) free to emit
+    // prose, so `extractJson` found no object and every call failed with
+    // LLM_OUTPUT_VALIDATION_FAILED. `json_object` is NOT usable — LM Studio
+    // 400s on it ("must be 'json_schema' or 'text'"); json_schema is the
+    // mode its own error message points to.
+    expect(body.response_format?.type).toBe("json_schema");
   });
 
-  it("uses response_format=text on the non-streaming fallback too (regression: 0.0.6 LM Studio HTTP 400)", async () => {
+  it("uses response_format=json_schema on the non-streaming path too", async () => {
     const captured: CapturedRequest[] = [];
     const fakeFetch = vi.fn(async (url: string, init?: RequestInit) => {
       captured.push({ url, init });
@@ -166,7 +168,143 @@ describe("lmstudio provider", () => {
       response_format?: { type: string };
     };
     expect(body.stream).toBe(false);
-    expect(body.response_format).toEqual({ type: "text" });
+    expect(body.response_format?.type).toBe("json_schema");
+  });
+
+  it("sends the tool's model-facing output schema (with content fields, without server-owned fields) (0.0.38: fixes gemma-4-e4b prose responses)", async () => {
+    const captured: CapturedRequest[] = [];
+    const fakeFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      captured.push({ url, init });
+      return buildSseResponse(['{"ok":true}']);
+    }) as unknown as typeof fetch;
+
+    const provider = createLMStudioProvider({
+      baseUrl: LMSTUDIO_DEFAULT_BASE_URL,
+      fetchImpl: fakeFetch,
+    });
+    await provider.complete({
+      tool: "translate_incoming",
+      prompt: "ping",
+      model: "gemma-4-e4b",
+    });
+
+    const body = JSON.parse(captured[0]!.init?.body as string) as {
+      response_format?: {
+        type: string;
+        json_schema?: {
+          name: string;
+          strict: boolean;
+          schema: { properties?: Record<string, unknown> };
+        };
+      };
+    };
+    expect(body.response_format?.type).toBe("json_schema");
+    expect(body.response_format?.json_schema?.name).toBe("translate_incoming");
+    expect(body.response_format?.json_schema?.strict).toBe(true);
+    const props = body.response_format?.json_schema?.schema.properties ?? {};
+    expect(Object.keys(props)).toContain("explicit_ask");
+    // The server owns provenance (ADR 0005); a strict grammar must not
+    // force the model to invent it.
+    expect(Object.keys(props)).not.toContain("model_provenance");
+    expect(Object.keys(props)).not.toContain("eval_corpus_slice");
+  });
+
+  it("retries in text mode when LM Studio rejects structured output with a 400 (streaming)", async () => {
+    const bodies: string[] = [];
+    let call = 0;
+    const fakeFetch = vi.fn(async (_url: string, init?: RequestInit) => {
+      bodies.push(init?.body as string);
+      call += 1;
+      if (call === 1) {
+        return buildJsonResponse(400, {
+          error: {
+            message: "this model does not support json_schema response_format",
+          },
+        });
+      }
+      return buildSseResponse(['{"ok":true}']);
+    }) as unknown as typeof fetch;
+
+    const provider = createLMStudioProvider({
+      baseUrl: LMSTUDIO_DEFAULT_BASE_URL,
+      fetchImpl: fakeFetch,
+    });
+    const result = await provider.complete({
+      tool: "translate_incoming",
+      prompt: "ping",
+      model: "gemma-4-e4b",
+    });
+
+    expect(result.text).toBe('{"ok":true}');
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+    const first = JSON.parse(bodies[0]!) as {
+      response_format?: { type: string };
+    };
+    const second = JSON.parse(bodies[1]!) as {
+      response_format?: { type: string };
+    };
+    expect(first.response_format?.type).toBe("json_schema");
+    expect(second.response_format).toEqual({ type: "text" });
+  });
+
+  it("retries in text mode on the non-streaming path too when structured output is rejected", async () => {
+    const bodies: string[] = [];
+    let call = 0;
+    const fakeFetch = vi.fn(async (_url: string, init?: RequestInit) => {
+      bodies.push(init?.body as string);
+      call += 1;
+      if (call === 1) {
+        return buildJsonResponse(400, {
+          error: { message: "Invalid response_format for this model" },
+        });
+      }
+      return buildJsonResponse(200, {
+        choices: [{ message: { content: '{"ok":true}' } }],
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = createLMStudioProvider({
+      baseUrl: LMSTUDIO_DEFAULT_BASE_URL,
+      fetchImpl: fakeFetch,
+      disableStreaming: true,
+    });
+    const result = await provider.complete({
+      tool: "translate_incoming",
+      prompt: "ping",
+      model: "gemma-4-e4b",
+    });
+
+    expect(result.text).toBe('{"ok":true}');
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+    const second = JSON.parse(bodies[1]!) as {
+      response_format?: { type: string };
+    };
+    expect(second.response_format).toEqual({ type: "text" });
+  });
+
+  it("does NOT retry on a 400 unrelated to response_format (e.g. context length)", async () => {
+    const fakeFetch = vi.fn(async () =>
+      buildJsonResponse(400, {
+        error: { message: "context length exceeded" },
+      }),
+    ) as unknown as typeof fetch;
+
+    const provider = createLMStudioProvider({
+      baseUrl: LMSTUDIO_DEFAULT_BASE_URL,
+      fetchImpl: fakeFetch,
+    });
+    let err: unknown;
+    try {
+      await provider.complete({
+        tool: "translate_incoming",
+        prompt: "ping",
+        model: "gemma-4-e4b",
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect((err as Error).message).toMatch(/LMSTUDIO_HTTP_400/);
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
   });
 
   it("attaches Bearer auth when an apiKey is provided", async () => {

--- a/packages/extension-browser/tests/unit/validation.test.ts
+++ b/packages/extension-browser/tests/unit/validation.test.ts
@@ -4,6 +4,7 @@ import {
   validateOutput,
   extractJson,
   normaliseLLMOutput,
+  modelFacingSchema,
   _resetValidatorsForTests,
 } from "../../src/lib/validation.js";
 import type { ModelProvenance } from "../../src/lib/types.js";
@@ -55,6 +56,74 @@ describe("validation", () => {
     const res = parseAndValidate("translate_incoming", "{not-json");
     expect(res.ok).toBe(false);
     expect(res.errors[0]).toMatch(/JSON parse error|Could not locate/);
+  });
+
+  it("strips stray NESTED properties instead of rejecting (gemma-4-e4b facets bug)", () => {
+    // A grammar-constrained local model returns valid describe_image JSON,
+    // but llama.cpp's GBNF grammar does not enforce additionalProperties:false
+    // on nested objects, so a chatty model adds a stray key to a facet. The
+    // strict validator used to reject this with
+    // `/content_translation/0/facets/1: must NOT have additional properties`.
+    // It must now DROP the stray key and accept the otherwise-valid payload.
+    const payload = {
+      description: "A four-quadrant framework diagram.",
+      contains_text: true,
+      transcribed_text: null,
+      key_elements: ["quadrant diagram"],
+      inferred_purpose: "Explain a decision framework.",
+      accessibility_notes: null,
+      content_translation: [
+        {
+          label: "1. Emotional Control",
+          facets: [
+            { kind: "rule", text: "Stay calm under pressure." },
+            {
+              kind: "action",
+              text: "Pause before reacting.",
+              note: "stray key a chatty local model added",
+            },
+          ],
+        },
+      ],
+      eval_corpus_slice: "describe_image-v0.1.0",
+      model_provenance: {
+        mode: "local",
+        provider: "lmstudio",
+        model: "gemma-4-e4b",
+      },
+    };
+    const res = validateOutput<{
+      content_translation: { facets: Record<string, unknown>[] }[];
+    }>("describe_image", payload);
+    expect(res.ok).toBe(true);
+    const strayFacet = res.data?.content_translation[0]?.facets[1];
+    expect(strayFacet).toEqual({
+      kind: "action",
+      text: "Pause before reacting.",
+    });
+  });
+});
+
+describe("modelFacingSchema", () => {
+  it("keeps the content fields the model must produce", () => {
+    const schema = modelFacingSchema("translate_incoming") as {
+      type: string;
+      properties: Record<string, unknown>;
+    };
+    expect(schema.type).toBe("object");
+    expect(Object.keys(schema.properties)).toContain("explicit_ask");
+    expect(Object.keys(schema.properties)).toContain("likely_subtext");
+  });
+
+  it("drops server-owned fields so strict structured output can't force hallucinated provenance (ADR 0005)", () => {
+    const schema = modelFacingSchema("translate_incoming") as {
+      properties: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(Object.keys(schema.properties)).not.toContain("model_provenance");
+    expect(Object.keys(schema.properties)).not.toContain("eval_corpus_slice");
+    expect(schema.required ?? []).not.toContain("model_provenance");
+    expect(schema.required ?? []).not.toContain("eval_corpus_slice");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the LM Studio + local-model translation path end-to-end. Reported symptom: with OpenRouter the extension works, but LM Studio (e.g. `gemma-4-e4b`) failed with `LLM_OUTPUT_VALIDATION_FAILED`.

Two root causes, two fixes:

### 1. LM Studio was the only provider not requesting JSON
OpenRouter/OpenAI/Google all send `response_format: { type: "json_object" }`; LM Studio sent `{ type: "text" }`, relying on the prompt + `extractJson` to dig JSON out of free text. Capable cloud models comply; small local models return prose, so `extractJson` found nothing → `Could not locate a JSON object`.

Fix: the LM Studio provider now requests grammar-constrained structured output — `response_format: { type: "json_schema", json_schema: { name, strict, schema } }` (the mode LM Studio's own 400 points to). A **model-facing schema** strips the server-owned fields (`model_provenance`, `eval_corpus_slice`, per ADR 0005) so a strict grammar can't force hallucinated provenance. If a server/model rejects structured output with a 400 naming `response_format`/`json_schema`, it falls back once to text mode (mirrors the OpenRouter/Google `ResponseFormatRejected` dance). Unrelated 400s still surface.

### 2. Nested `additionalProperties` rejected valid output
Once structured output was on, `gemma-4-e4b` returned valid JSON that then failed `/content_translation/0/facets/1: must NOT have additional properties`. llama.cpp's GBNF grammar doesn't enforce `additionalProperties: false` on nested objects, so the model adds a stray key to a nested `facets[]` entry.

Fix: compiled validators now use `removeAdditional: "all"` — stray properties at any depth are dropped instead of rejected (the recursive version of the existing top-level field stripping). Required fields, types, and enums are still enforced.

## Test plan
- New unit tests (TDD, watched fail first):
  - LM Studio sends `json_schema` with the model-facing schema (content fields present, server-owned fields absent).
  - Retries in text mode on a structured-output 400 (streaming + non-streaming); does **not** retry unrelated 400s.
  - `modelFacingSchema` drops server-owned fields.
  - Validator drops a stray nested `facets[]` key instead of rejecting; still rejects unknown enum values + missing required fields.
- Full extension suite: **649 passing**. `tsc --noEmit`: clean.

## Notes
- Patch changeset included → `@neurodock/extension-browser` 0.0.37 → 0.0.38.
- Not addressed here (separate follow-ups): obliterated/uncensored fine-tunes whose engine 500s on grammars (model quality), the describe_image CSP image-fetch limitation, and `pnpm dev`'s esbuild target.
