### PR TITLE
fix: connect browser extension to native host and pin onboarding setup command

### DIFF
--- a/.changeset/native-host-real-extension-ids.md
+++ b/.changeset/native-host-real-extension-ids.md
@@ -1,0 +1,23 @@
+---
+"@neurodock/cli": patch
+"@neurodock/native-host": patch
+---
+
+fix(native-host): register the real published extension ids so the extension can connect
+
+The native-messaging host was registered with the literal placeholder
+`__NEURODOCK_EXTENSION_ID__`, which was never substituted — so the host
+manifest's `allowed_origins` matched no extension and the browser
+extension always showed "Not connected yet" even after a successful
+`setup`/`install-all`.
+
+- The published Chrome Web Store id (`lcdaiekokkgniiknejddojkfkoiinopo`)
+  and the Firefox gecko id (`neurodock-extension@neurodock.org`) are now
+  the registered defaults (`PUBLISHED_EXTENSION_IDS` /
+  `withDefaultExtensionIds` in `@neurodock/native-host`), so a
+  store-installed extension connects out of the box.
+- `neurodock setup` and `neurodock install-all` gained a repeatable
+  `--extension-id <id>` flag, threaded down to the host installer, so a
+  locally-loaded unpacked build (whose id differs from the published one)
+  can be allowed in one command. Provided ids are unioned with the
+  published defaults and deduped.

--- a/.changeset/onboarding-setup-command-latest.md
+++ b/.changeset/onboarding-setup-command-latest.md
@@ -1,0 +1,12 @@
+---
+"@neurodock/extension-browser": patch
+---
+
+fix(extension-browser): pin the onboarding full-setup command to @latest
+
+The Power-Up card / onboarding slide showed `npx @neurodock/cli setup`,
+which reuses whatever older copy npx already cached — often one that
+predates the `setup` subcommand, so it fails with "unknown command
+'setup'". The advertised command is now `npx @neurodock/cli@latest setup`,
+forcing npx to resolve the current published version (matching the
+`@latest` form the docs already use).

--- a/packages/cli/src/commands/host.ts
+++ b/packages/cli/src/commands/host.ts
@@ -20,13 +20,9 @@ import {
   register,
   unregister,
   detectPlatform,
+  withDefaultExtensionIds,
 } from "@neurodock/native-host/dist/registration/index.js";
 import type { RegistrationOutcome } from "@neurodock/native-host/dist/registration/index.js";
-
-const DEFAULT_EXTENSION_IDS: ReadonlyArray<string> = [
-  // Placeholder until the Chrome Web Store ID is allocated.
-  "__NEURODOCK_EXTENSION_ID__",
-];
 
 export interface HostInstallOptions {
   readonly extensionIds: ReadonlyArray<string>;
@@ -88,8 +84,9 @@ function resolveHostBinPath(): string {
 }
 
 export function runHostInstall(opts: HostInstallOptions): HostCommandResult {
-  const ids =
-    opts.extensionIds.length > 0 ? opts.extensionIds : DEFAULT_EXTENSION_IDS;
+  // Always register the published store ids; caller-supplied ids (e.g. a
+  // locally-loaded unpacked build) are added on top.
+  const ids = withDefaultExtensionIds(opts.extensionIds);
   const platform = detectPlatform();
   const hostPath = resolveHostBinPath();
   const outcomes = register({ hostPath, allowedExtensionIds: ids });

--- a/packages/cli/src/commands/install-all.ts
+++ b/packages/cli/src/commands/install-all.ts
@@ -28,6 +28,12 @@ export interface InstallAllOptions {
    * command.
    */
   readonly noNativeHost: boolean;
+  /**
+   * Extra browser-extension ids to allow on the native host, on top of the
+   * published store ids. Needed for a locally-loaded unpacked build, whose
+   * id differs from the published one. Empty/omitted = published ids only.
+   */
+  readonly extensionIds?: ReadonlyArray<string>;
 }
 
 export interface NativeHostOutcome {
@@ -308,7 +314,7 @@ function installNativeHost(
     "Installing native-messaging host (browser extension <-> profile.yaml)...",
   );
   try {
-    const result = hostInstall({ extensionIds: [] });
+    const result = hostInstall({ extensionIds: options.extensionIds ?? [] });
     for (const o of result.outcomes) {
       const detail = o.detail ? ` — ${o.detail}` : "";
       messages.push(

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -47,6 +47,12 @@ export interface SetupOptions {
    * autostart. Off by default — see the module comment above.
    */
   readonly daemon: boolean;
+  /**
+   * Extra browser-extension ids to allow on the native host (e.g. a
+   * locally-loaded unpacked build). Passed through to install-all on top
+   * of the published store ids.
+   */
+  readonly extensionIds?: ReadonlyArray<string>;
 }
 
 export interface SetupDependencies {
@@ -84,6 +90,7 @@ export async function runSetup(
     yes: options.yes,
     dryRun: options.dryRun,
     noNativeHost: options.noNativeHost,
+    ...(options.extensionIds ? { extensionIds: options.extensionIds } : {}),
   });
   messages.push(...installAllResult.messages);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -129,6 +129,14 @@ export function buildProgram(): Command {
       "--no-native-host",
       "skip registering the optional native-messaging host (browser extension <-> profile.yaml)",
     )
+    .option(
+      "--extension-id <id>",
+      "extra browser-extension id to allow on the native host, e.g. a " +
+        "locally-loaded unpacked build (repeatable; published store ids are " +
+        "always included)",
+      (value: string, prev: string[]) => [...prev, value],
+      [] as string[],
+    )
     .action(
       async (opts: {
         client: string;
@@ -139,6 +147,7 @@ export function buildProgram(): Command {
         dryRun: boolean;
         // Commander inverts `--no-native-host`: presence of the flag sets this to false.
         nativeHost: boolean;
+        extensionId: string[];
       }) => {
         const client = validateClient(opts.client);
         const profile = validateProfile(opts.profile);
@@ -151,6 +160,9 @@ export function buildProgram(): Command {
           yes: opts.yes === true,
           dryRun: opts.dryRun === true,
           noNativeHost: opts.nativeHost === false,
+          ...(opts.extensionId.length > 0
+            ? { extensionIds: opts.extensionId }
+            : {}),
         });
         for (const m of r.messages) print(m);
         process.exit(r.exitCode);
@@ -196,6 +208,14 @@ export function buildProgram(): Command {
         "autostart (off by default — the Claude Code hook covers the common cases)",
       false,
     )
+    .option(
+      "--extension-id <id>",
+      "extra browser-extension id to allow on the native host, e.g. a " +
+        "locally-loaded unpacked build (repeatable; published store ids are " +
+        "always included)",
+      (value: string, prev: string[]) => [...prev, value],
+      [] as string[],
+    )
     .action(
       async (opts: {
         client: string;
@@ -207,6 +227,7 @@ export function buildProgram(): Command {
         // Commander inverts `--no-native-host`: presence of the flag sets this to false.
         nativeHost: boolean;
         daemon: boolean;
+        extensionId: string[];
       }) => {
         const client = validateClient(opts.client);
         const profile = validateProfile(opts.profile);
@@ -220,6 +241,9 @@ export function buildProgram(): Command {
           dryRun: opts.dryRun === true,
           noNativeHost: opts.nativeHost === false,
           daemon: opts.daemon === true,
+          ...(opts.extensionId.length > 0
+            ? { extensionIds: opts.extensionId }
+            : {}),
         });
         for (const m of r.messages) print(m);
         process.exit(r.exitCode);

--- a/packages/cli/tests/install-all.test.ts
+++ b/packages/cli/tests/install-all.test.ts
@@ -472,6 +472,53 @@ describe("neurodock install-all", () => {
     expect(joined).toContain("What this just did:");
   });
 
+  it("forwards extensionIds through to the native-host install (unpacked-build support)", async () => {
+    const { spawn } = makeFakeSpawn({ uvAvailable: true });
+    let capturedExtensionIds: ReadonlyArray<string> | undefined;
+    const fakeHostInstall = (opts: {
+      extensionIds: ReadonlyArray<string>;
+    }): {
+      platform: string;
+      outcomes: ReadonlyArray<{
+        browser: string;
+        manifestPath: string;
+        action: "create" | "skip" | "update" | "remove";
+        detail?: string;
+      }>;
+    } => {
+      capturedExtensionIds = opts.extensionIds;
+      return { platform: "linux", outcomes: [] };
+    };
+
+    await runInstallAll(
+      {
+        client: "claude-code",
+        profile: "minimal",
+        installer: "auto",
+        skipInstall: false,
+        yes: true,
+        dryRun: false,
+        noNativeHost: false,
+        extensionIds: ["devunpackedid"],
+      },
+      {
+        spawn,
+        runHostInstall: fakeHostInstall,
+        envOverrides: {
+          platform: "linux",
+          home: sandbox.home,
+          cwd: sandbox.cwd,
+          user: "tester",
+          env: {
+            NEURODOCK_PROFILE_PATH: join(sandbox.home, "profile.yaml"),
+          } as NodeJS.ProcessEnv,
+        },
+      },
+    );
+
+    expect(capturedExtensionIds).toEqual(["devunpackedid"]);
+  });
+
   it("--no-native-host skips the native-host install", async () => {
     const { spawn } = makeFakeSpawn({ uvAvailable: true });
     let hostInstallCalls = 0;

--- a/packages/extension-browser/src/components/PowerUpCard.tsx
+++ b/packages/extension-browser/src/components/PowerUpCard.tsx
@@ -14,7 +14,13 @@ import { useFullSetupStatus } from "../lib/full-setup.js";
 // registers the native-messaging host, and installs the Claude Code
 // guardrail hooks in one go (the standalone daemon stays opt-in via
 // --daemon).
-export const FULL_SETUP_COMMAND = "npx @neurodock/cli setup";
+//
+// The `@latest` pin is deliberate: bare `npx @neurodock/cli setup`
+// reuses whatever older copy npx already cached, which can predate the
+// `setup` subcommand and fails with "unknown command 'setup'". `@latest`
+// forces npx to resolve the current published version every time, matching
+// the `npx --yes @neurodock/cli@latest …` form the docs already use.
+export const FULL_SETUP_COMMAND = "npx @neurodock/cli@latest setup";
 
 export function PowerUpCard(): React.ReactElement {
   const { status, recheck } = useFullSetupStatus();

--- a/packages/native-host/manifest.template.json
+++ b/packages/native-host/manifest.template.json
@@ -3,5 +3,5 @@
   "description": "NeuroDock native messaging host. Exposes ~/.neurodock/profile.yaml to the browser extension over the Chrome Native Messaging protocol.",
   "path": "{{HOST_PATH}}",
   "type": "stdio",
-  "allowed_origins": ["chrome-extension://__NEURODOCK_EXTENSION_ID__/"]
+  "allowed_origins": ["chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/"]
 }

--- a/packages/native-host/src/cli.ts
+++ b/packages/native-host/src/cli.ts
@@ -21,6 +21,7 @@ import {
   detectPlatform,
   register,
   unregister,
+  withDefaultExtensionIds,
   HOST_NAME,
 } from "./registration/index.js";
 
@@ -77,10 +78,6 @@ function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
   return { command: "help", extensionIds: [] };
 }
 
-const DEFAULT_EXTENSION_IDS: ReadonlyArray<string> = [
-  "__NEURODOCK_EXTENSION_ID__",
-];
-
 function resolveHostPath(): string {
   try {
     return realpathSync(fileURLToPath(import.meta.url));
@@ -125,10 +122,9 @@ export function main(
     return 0;
   }
   if (parsed.command === "install") {
-    const ids =
-      parsed.extensionIds.length > 0
-        ? parsed.extensionIds
-        : DEFAULT_EXTENSION_IDS;
+    // Always register the published store ids; any --extension-id values
+    // (e.g. a locally-loaded unpacked build) are added on top.
+    const ids = withDefaultExtensionIds(parsed.extensionIds);
     const platformId = detectPlatform();
     process.stdout.write(`Installing ${HOST_NAME} (platform=${platformId})\n`);
     const outcomes = register({

--- a/packages/native-host/src/registration/index.ts
+++ b/packages/native-host/src/registration/index.ts
@@ -75,4 +75,8 @@ export type {
   RegistrationOutcome,
   UnregisterOptions,
 } from "./types.js";
-export { HOST_NAME } from "./types.js";
+export {
+  HOST_NAME,
+  PUBLISHED_EXTENSION_IDS,
+  withDefaultExtensionIds,
+} from "./types.js";

--- a/packages/native-host/src/registration/types.ts
+++ b/packages/native-host/src/registration/types.ts
@@ -13,6 +13,40 @@
  */
 export const HOST_NAME = "com.neurodock.profile";
 
+/**
+ * Extension ids NeuroDock registers by default so a store-installed
+ * extension can reach the native host with zero extra steps.
+ *
+ *   - `lcdaiekokkgniiknejddojkfkoiinopo` — the published Chrome Web Store
+ *     id (used in the Chromium manifest's `allowed_origins`).
+ *   - `neurodock-extension@neurodock.org` — the Firefox gecko id (used in
+ *     the Firefox manifest's `allowed_extensions`).
+ *
+ * Both ids are written into BOTH manifests (each builder maps the same
+ * list). The cross-store entry — e.g. a `chrome-extension://<gecko-id>/`
+ * origin in the Chrome manifest — is simply never matched by that browser,
+ * so carrying one list for both is harmless and keeps a single source of
+ * truth. This replaces the old `__NEURODOCK_EXTENSION_ID__` placeholder,
+ * which was never substituted and so matched no extension at all.
+ */
+export const PUBLISHED_EXTENSION_IDS: ReadonlyArray<string> = [
+  "lcdaiekokkgniiknejddojkfkoiinopo",
+  "neurodock-extension@neurodock.org",
+];
+
+/**
+ * Union the caller-provided extension ids (e.g. a locally-loaded unpacked
+ * build, whose id differs from the published one) with the published
+ * defaults — deduped, defaults first. Always keeping the published ids
+ * means a developer who later installs from the store still works without
+ * re-running the installer.
+ */
+export function withDefaultExtensionIds(
+  provided: ReadonlyArray<string>,
+): string[] {
+  return Array.from(new Set([...PUBLISHED_EXTENSION_IDS, ...provided]));
+}
+
 export type RegistrationAction = "create" | "skip" | "update" | "remove";
 
 export interface RegistrationOutcome {

--- a/packages/native-host/tests/registration.test.ts
+++ b/packages/native-host/tests/registration.test.ts
@@ -3,6 +3,8 @@ import {
   buildManifest,
   buildFirefoxManifest,
   HOST_NAME,
+  PUBLISHED_EXTENSION_IDS,
+  withDefaultExtensionIds,
 } from "../src/registration/types.js";
 
 describe("manifest builders", () => {
@@ -27,5 +29,48 @@ describe("manifest builders", () => {
     });
     expect(m["allowed_extensions"]).toEqual(["addon@example.com"]);
     expect(m["type"]).toBe("stdio");
+  });
+});
+
+describe("default allowed extension ids", () => {
+  it("ships the published Chrome Web Store id and Firefox gecko id, not the old placeholder", () => {
+    // The placeholder `__NEURODOCK_EXTENSION_ID__` was never substituted,
+    // so allowed_origins matched no extension and native messaging was
+    // refused for everyone. The real published ids replace it.
+    expect(PUBLISHED_EXTENSION_IDS).toContain(
+      "lcdaiekokkgniiknejddojkfkoiinopo",
+    );
+    expect(PUBLISHED_EXTENSION_IDS).toContain(
+      "neurodock-extension@neurodock.org",
+    );
+    expect(PUBLISHED_EXTENSION_IDS).not.toContain("__NEURODOCK_EXTENSION_ID__");
+  });
+
+  it("withDefaultExtensionIds unions provided ids with the published defaults, deduped", () => {
+    const out = withDefaultExtensionIds([
+      "devunpackedid",
+      "lcdaiekokkgniiknejddojkfkoiinopo",
+    ]);
+    expect(out).toContain("devunpackedid");
+    expect(out).toContain("lcdaiekokkgniiknejddojkfkoiinopo");
+    expect(out).toContain("neurodock-extension@neurodock.org");
+    // No duplicate of the published id the caller also passed.
+    expect(
+      out.filter((id) => id === "lcdaiekokkgniiknejddojkfkoiinopo"),
+    ).toHaveLength(1);
+  });
+
+  it("withDefaultExtensionIds returns just the published defaults when nothing extra is provided", () => {
+    expect(withDefaultExtensionIds([])).toEqual([...PUBLISHED_EXTENSION_IDS]);
+  });
+
+  it("a Chrome manifest built from the defaults allows the published store id", () => {
+    const m = buildManifest({
+      hostPath: "/x",
+      allowedExtensionIds: withDefaultExtensionIds([]),
+    });
+    expect(m["allowed_origins"]).toContain(
+      "chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes two of the three issues blocking the next extension ship. They live in different packages, so they release separately, but both are here for one review.

### Point 2 — onboarding command (extension, ships in extension-browser 0.0.38)
The Power-Up card / onboarding slide advertised `npx @neurodock/cli setup`. npx can satisfy that from a **stale cached copy** that predates the `setup` subcommand, so users hit `unknown command 'setup'`. Pinned to `npx @neurodock/cli@latest setup` (the `@latest` form the docs already use). `FULL_SETUP_COMMAND` is the single source; the existing test reads the constant, so it stays green.

### Point 3 — native host "Not connected yet" (cli + native-host)
**Root cause:** the host was registered with the literal placeholder `__NEURODOCK_EXTENSION_ID__`, which was **never substituted** — so the manifest's `allowed_origins` matched no extension and the browser extension always showed "Not connected yet", even after a successful `setup`.

- Real published ids are now the registered defaults: Chrome `lcdaiekokkgniiknejddojkfkoiinopo` + Firefox gecko `neurodock-extension@neurodock.org` (`PUBLISHED_EXTENSION_IDS` / `withDefaultExtensionIds` in `@neurodock/native-host`). Store-installed extensions connect out of the box.
- `neurodock setup` and `neurodock install-all` gained a repeatable `--extension-id <id>` flag, threaded to the host installer and **unioned** with the published defaults — so a locally-loaded unpacked build (different id) can be allowed in one command.

## Test plan
- native-host: 45 tests (4 new — published ids present, placeholder gone, union+dedupe, manifest built from defaults). typecheck clean.
- cli: 119 tests (1 new — `extensionIds` forwarded through install-all). typecheck clean.
- extension: power-up-card test green (reads the updated constant).

## Not in this PR
- Point 1 (thorough per-neurotype prompts/schemas) — separate design track.
- A `neurodock host status`/doctor command (suggested follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
