### PR TITLE
feat: bundle per-neurotype skills into the claude code plugin (r8 part a)

### DIFF
--- a/claude-code/neurodock/README.md
+++ b/claude-code/neurodock/README.md
@@ -41,9 +41,18 @@ time it runs.
 
 ### Skills (`skills/`)
 
+Twelve ND-aware skills ship with the plugin, in two groups.
+
+**Substrate skills** — each teaches Claude the exact tool contract and the
+ND-aware "voice" for surfacing one server's results:
 `translate-incoming`, `record-fact`, `decompose-task`, `check-rumination`,
-`chronometric-mark-start`, `chronometric-mark-end` — each teaches Claude the
-exact tool contract and the ND-aware "voice" for surfacing results.
+`chronometric-mark-start`, `chronometric-mark-end`.
+
+**Per-neurotype skills** — higher-level workflows tuned to a specific
+neurotype (authored in `packages/skills/` and bundled here verbatim via
+`scripts/sync-skills.mjs`, with a CI drift guard keeping the two in sync):
+`adhd-daily-planner`, `asd-meeting-translator`, `audhd-context-recovery`,
+`hyperfocus-formatter`, `ocd-decision-finalizer`, `visual-organizer`.
 
 ## Privacy
 

--- a/claude-code/neurodock/skills/adhd-daily-planner/SKILL.md
+++ b/claude-code/neurodock/skills/adhd-daily-planner/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: adhd-daily-planner
+version: 0.1.0
+description: Morning brief — what changed overnight, what matters today, one next-action per project.
+neurotypes: ["adhd", "audhd"]
+status: stable
+triggers:
+  - command: "/resume monday"
+  - command: "/morning-brief"
+  - phrase: "what's on today"
+  - phrase: "plan my day"
+  - phrase: "what should I do today"
+mcp_dependencies:
+  - server: mcp-chronometric
+    tools: [get_time_context]
+  - server: mcp-cognitive-graph
+    tools: [weekly_rollup, recall_decisions]
+  - server: mcp-task-fractionator
+    tools: [next_one]
+profile_dependencies:
+  - identity.neurotypes
+  - preferences.output_format
+  - preferences.max_chunk_size
+  - chronometric.end_of_day_local
+license: AGPL-3.0-or-later
+authors:
+  - neurodock-core
+---
+
+# adhd-daily-planner
+
+This skill produces a morning brief: what changed overnight in the user's projects, what matters today, and one concrete next-action per project. On Monday it is the full weekly stack. On other weekdays it is a lighter daily-pulse.
+
+## Activation criteria
+
+Activate when any of the following is true:
+
+- The user types `/resume monday` or `/morning-brief`.
+- The user's message contains one of: `what's on today`, `plan my day`, `what should I do today`, `monday morning`.
+- This is the user's first interaction of a new local day AND `preferences.output_format` is `answer_first` (treat as an implicit invitation, not an obligation — see "Do not" below).
+
+Do not activate inside a session that has already been running for more than thirty minutes; that conversation has its own context already.
+
+## Operating instructions
+
+Follow these steps in order. Do not skip steps. Do not improvise additional tool calls.
+
+1. **Anchor the day.** Call `mcp-chronometric.get_time_context()`. Note `day_of_week`, `energy_zone`, and `current_session_length`. If `day_of_week` is `Monday`, this is a **weekly brief**. Otherwise it is a **daily-light brief**.
+
+2. **Pull the weekly rollup, scoped or unscoped.**
+
+   - For a weekly brief: call `mcp-cognitive-graph.weekly_rollup()` with no project filter to discover which projects had activity in the trailing seven days. Rank projects by the most recent `decisions[].decided_on` (falling back to most recent `blockers[].recorded_at` when there are no decisions).
+   - For a daily-light brief: same call, same ranking.
+   - Cap the project list at `preferences.max_chunk_size` (default 5). If more projects had activity, note the count of elided projects in the closing line — do not name them.
+
+3. **For each retained project, get its rollup.** Call `mcp-cognitive-graph.weekly_rollup(project=<name>)` once per project. Use the returned `decisions`, `blockers`, and `next_actions` fields verbatim. Do not paraphrase decision names.
+
+4. **Decide whether to surface decision detail.** If a project has decisions in the last seven days but `weekly_rollup.next_actions` is empty for that project, call `mcp-cognitive-graph.recall_decisions(project=<name>, since=<thirty days ago>)` once to surface up to two recent decisions that may need follow-up. Skip this call when `next_actions` is already populated.
+
+5. **Get one concrete next-action per project.** Call `mcp-task-fractionator.next_one(project=<name>)` for each project. Three outcomes:
+
+   - Success with `confidence >= 0.7` — quote the task title and the confidence value.
+   - Success with `confidence < 0.7` — quote the title and explicitly say "low confidence" with the value. Do not pretend certainty.
+   - Error `NO_TASKS_AVAILABLE` — say "no decomposed tasks for this project; consider `decompose` if it's time to plan it." Do not fabricate a task.
+   - Any other error — note the error code in the project section and move on.
+
+6. **Render the brief.** See "Output format" below.
+
+7. **Stop.** Do not propose a calendar rearrangement, a follow-up question, or "shall I start the first task?". The brief is the deliverable.
+
+## Output format
+
+Strict "Answer First" structure. The first sentence must fit in 80 characters and must name the day's shape in plain prose.
+
+```
+<One paragraph, ≤ 80 chars in the first sentence, plain prose. State which day it is,
+the brief type (weekly or daily-light), and the count of projects covered. No
+exclamation marks. No "let's crush it" register.>
+
+### <Project name>
+- Most recent decision: <decision name> (<decided_on>, conf <confidence>)
+- Blocker: <blocker literal or "none">
+- Next: <next_one.task.title> (<estimated_minutes> min, conf <confidence>)
+
+### <Project name>
+- ...
+
+---
+Elided <N> further projects with activity this week.
+Energy zone right now: <energy_zone>. End-of-day stated as <chronometric.end_of_day_local>.
+This brief is not a productivity scorecard. Yesterday's incomplete items are not graded.
+```
+
+Rules:
+
+- Maximum three bullets per project. If a project has no blocker, write `Blocker: none` — do not invent one.
+- Project sections appear in the order produced by step 2's ranking.
+- Confidence is always rendered as a number with two decimal places, never as a word.
+- The closing block is mandatory. The "not a scorecard" line grounds the LLM and the user.
+
+If `weekly_rollup()` returned zero projects in the trailing seven days, emit the empty-graph response instead:
+
+```
+No projects in the last 30 days. Nothing to brief against.
+
+If you'd like to start one, the next step is `mark_session_start(intent=<your intent>)`
+in mcp-chronometric — that anchors today and gives tomorrow's brief something to draw on.
+```
+
+## Distress signal handling
+
+If the user's invoking message contains overwhelm phrases — `I can't`, `too much`, `everything is on fire`, `I'm stuck`, `exhausted`, `burned out` — reduce the project cap to **3** instead of `preferences.max_chunk_size`, omit the confidence numbers (state "high" / "medium" / "low" instead), and append one sentence to the closing block: `If three is still too many right now, ask for "just one project" and I'll narrow further.` Do not lecture. Do not diagnose.
+
+## Do not
+
+- Do not use the words "superpower", "crusher", "smash", "let's go", "you got this", "differently abled".
+- Do not enumerate yesterday's incomplete items.
+- Do not compute or display a productivity score.
+- Do not propose calendar buffer transitions unless the user's MCP environment surfaces calendar data through a tool you can call. **Calendar integration is not in scope for v0.1.0 of this skill** — if no calendar tool is wired, omit the "buffer transitions" feature silently.
+- Do not call `next_one` for a project with no decisions and no blockers — that project does not need a next-action surfaced, it needs the user to decide whether to retire it.
+- Do not invent project names. Only use names that came back from `weekly_rollup`.
+- Do not exceed three bullets per project even if more data exists.
+- Do not activate inside an ongoing >30 min session.
+
+## What this skill is not
+
+It is not a productivity maximiser. It is not a guilt trip about yesterday. It is a once-a-day surface area for projects, decisions, and one tangible next thing.
+
+## Examples
+
+See `tests/01-monday-morning-brief.md`, `tests/02-empty-graph-fallback.md`, and `tests/03-multi-project-stack.md` for the full invocation traces.

--- a/claude-code/neurodock/skills/asd-meeting-translator/SKILL.md
+++ b/claude-code/neurodock/skills/asd-meeting-translator/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: asd-meeting-translator
+version: 0.1.0
+description: Transcript → four-section brief (my asks, others' asks, decisions, ambiguous items with verbatim quotes). Records decisions into the cognitive graph.
+neurotypes: ["asd"]
+status: beta
+triggers:
+  - command: "/brief"
+  - command: "/meeting"
+  - phrase_pattern: "summarize this meeting"
+  - phrase_pattern: "summarise this meeting"
+  - phrase_pattern: "what did we agree"
+  - phrase_pattern: "what did I commit to"
+  - file_pattern: "*.transcript.txt"
+  - file_pattern: "*.meeting.md"
+  - context: "user pasted ≥ 200 lines of speaker-labelled prose without a specific instruction"
+mcp_dependencies:
+  - server: mcp-translation
+    tools: [brief_meeting]
+  - server: mcp-cognitive-graph
+    tools: [record_fact, recall_decisions]
+  - server: mcp-task-fractionator
+    tools: [decompose]
+    optional: true
+profile_dependencies:
+  - identity.neurotypes
+  - identity.display_name
+license: AGPL-3.0-or-later
+authors:
+  - neurodock-core
+---
+
+# asd-meeting-translator
+
+This skill takes a meeting transcript and produces a four-section brief: decisions reached, explicit asks of the user, explicit asks of others, and ambiguous items quoted verbatim from the transcript. It also surfaces prior decisions already recorded against the project and writes the new decisions back into the cognitive graph. It does not interpret motivation, infer subtext, or fabricate asks — the `brief_meeting` server enforces verbatim anchoring on every ambiguous span and rejects fabrications with `VERBATIM_ANCHOR_FAILED`.
+
+## Activation criteria
+
+Activate when any of the following is true:
+
+- The user types `/brief` or `/meeting`.
+- The user's message contains one of: `summarize this meeting`, `summarise this meeting`, `what did we agree`, `what did I commit to`.
+- The user attaches or references a file matching `*.transcript.txt` or `*.meeting.md`.
+- The user pastes a block of text that is ≥ 200 lines AND contains speaker-labelled prose (e.g. lines that begin with `Name:`) AND the message contains no other specific instruction. In this case the skill offers the brief rather than running silently — one short line: `Looks like a transcript. Want a brief? (decisions, asks, ambiguous items)`.
+
+Do not activate inside an ongoing conversation that already has the brief on screen. Do not activate on chat logs that are not meeting transcripts (e.g. PR review threads, Slack DMs) — those are translation-layer work, not meeting-brief work.
+
+## Required inputs
+
+The skill requires two things before it can call `brief_meeting`:
+
+1. A transcript of 20–200,000 characters. Shorter than 20 chars → tell the user the input is too short to brief. Longer than 200,000 chars (roughly a 90-minute meeting) → tell the user to chunk and call the skill once per chunk.
+
+2. A `me` label that identifies the user in the transcript. Resolve as follows, in order:
+   - If `profile.identity.display_name` is set, use that string.
+   - Otherwise, ask exactly one question: `Which name in this transcript is you?` Do not guess. Do not pick the most-quoted speaker. The verbatim-anchor enforcement downstream will reject fabricated attributions, so ambiguity here is silently fatal.
+
+If the user supplies the answer, proceed. If they do not, stop. Do not call `brief_meeting` without `me`.
+
+## Operating instructions
+
+Follow these steps in order. Do not improvise extra tool calls.
+
+1. **Detect the project, if possible.** Look for an explicit project name in the user's invoking message (e.g. `/brief neurodock`) or in the first 1000 characters of the transcript (subject lines like `Project:` or `Re:`). If found, remember it as `project`. If not, leave `project` unset — do not invent one.
+
+2. **Call `brief_meeting`.** Invoke `mcp-translation.brief_meeting(transcript=<full transcript>, me=<resolved name>, project=<project or omitted>)`. Pass `speakers` only if the user supplied a roster; do not fabricate one from the transcript.
+
+3. **Handle errors plainly.**
+
+   - `VERBATIM_ANCHOR_FAILED`: surface this verbatim and stop: `I couldn't anchor one of the ambiguous items to the transcript. This usually means the transcript wasn't captured verbatim, or the model paraphrased a span. Want to retry with a cleaner transcript, or skip the ambiguous-items section?` Do not retry silently. Do not fall back to a non-verbatim brief.
+   - `TRANSCRIPT_TOO_LONG`: tell the user the cap is 90 minutes / 200,000 characters and to chunk.
+   - `ME_REQUIRED`: ask the clarifying question from "Required inputs" and re-run.
+   - `MODEL_UNAVAILABLE`: tell the user the configured LLM is unreachable; do not retry automatically.
+   - Any other error: name the error code and stop. Do not paper over.
+
+4. **Pull prior project decisions, when a project is known.** If `project` is set, call `mcp-cognitive-graph.recall_decisions(project=<project>, since=<30 days ago, ISO date>)` once. Keep up to three most-recent. If `project` is not set, skip this step — do not query an unscoped graph.
+
+5. **Render the four-section brief.** See "Output format" below. The brief is the deliverable; do not append a question, a follow-up offer, or a "shall I…" prompt.
+
+6. **Record decisions back into the graph.** For each item in `output.decisions`, call `mcp-cognitive-graph.record_fact` exactly once:
+
+   - `subject = { type: "decision", name: <decision.text truncated to 200 chars> }`
+   - `predicate = "decided_in"`
+   - `object = { type: "project", name: <project> }` if `project` is set, otherwise skip the entire write (do not invent a project name to satisfy the predicate).
+   - `source = "meeting transcript via asd-meeting-translator"`
+   - `confidence = 0.85`
+     Do not write asks, ambiguous items, or `my_asks` rows. Decisions only. Cap at 10 writes per invocation; if the brief contains more decisions, write the first 10 in transcript order and note the truncation count in the closing line.
+
+6a. **Fractionate the asks of you into atomic tasks.** For each entry in `output.my_asks`, call `mcp-task-fractionator.decompose` exactly once, passing the ask text as the `goal` argument. The tool returns a list of atomic tasks sized 5–90 minutes each. Render the returned tasks back to the user under their parent ask, appended to the brief in a new section titled `### Atomic tasks from asks of you`, grouped one block per ask:
+
+    ```
+    ### Atomic tasks from asks of you
+    **<ask.text>**
+    - <task.title> · <task.estimate_minutes> min
+    - <task.title> · <task.estimate_minutes> min
+    ```
+
+    Rules:
+
+    - If `mcp-task-fractionator` is not configured or the tool is unavailable, skip this step entirely. Do not block the brief. Do not mention the missing tool in the output. The asks already appear in the `### Asks of you` section — that is the fallback surface.
+    - If `output.my_asks` is empty, skip this step. Do not render the section header.
+    - Cap at 5 asks fractionated per invocation. If more exist, fractionate the first 5 in transcript order and append a single trailing line: `(N further asks not fractionated)`.
+    - If `mcp-cognitive-graph.record_fact` is available, persist each fractionation once per parent ask: `subject = { type: "task_group", name: <ask.text truncated to 200 chars> }`, `predicate = "fractionated_from"`, `object = { type: "meeting", name: <project or "untitled meeting"> }`, `source = "asd-meeting-translator step 6a"`, `confidence = 0.8`. If `mcp-cognitive-graph` is not configured, skip the persistence — do not block on it.
+    - Errors from `decompose` are surfaced literally by error code on a single trailing line (e.g. `Fractionator error: GOAL_TOO_VAGUE`). Do not retry. Do not fall back to a paraphrase.
+
+7. **Stop.** No follow-up question.
+
+## Output format
+
+Strict "Answer First" structure. The first sentence must fit in 80 characters and must state the count of decisions, asks-of-you, asks-of-others, and ambiguous items in plain prose.
+
+```
+<One sentence, ≤ 80 chars, plain prose, e.g.: "Brief: 4 decisions, 2 asks of you, 3 asks of others, 2 ambiguous items.">
+
+### Decisions
+- <decision.text> · decided by <decided_by joined with ", "> (or "unattributed")
+- <decision.text> · ...
+
+### Asks of you
+- <ask.text> · due <ask.due> (or "(no deadline stated)") · asked by <ask.asker or "unattributed">
+- ...
+
+### Asks of others
+- <ask.text> · asked by <ask.asker or "unattributed"> · due <ask.due> (or "(no deadline stated)")
+- ...
+
+### Ambiguous items
+- "<quoted_span.text>" — <ambiguous_item.reason>
+- ...
+
+### Prior decisions on this project (last 30 days)
+- <decision name> (<decided_on>)
+- ...
+```
+
+Rules:
+
+- The first sentence MUST contain four integers in the order decisions / asks of you / asks of others / ambiguous items. If any count is zero, render `0` — do not omit the section header in the body either; render `- (none)` under that header so the structure stays predictable.
+- Ambiguous items quote the `quoted_span.text` returned by the server, character-for-character. Wrap in double quotes. Do not paraphrase, do not normalise punctuation, do not strip speaker labels.
+- The reason code is rendered literally (e.g. `vague_timeline`, `unassigned_owner`, `hedged_commitment`). If the server returns an unknown reason code, render it as `other`.
+- The "Prior decisions on this project" section is omitted entirely when `project` is unset OR when `recall_decisions` returned an empty list. Do not render an empty header.
+- Closing line (always last, on its own paragraph): `Source: meeting transcript. Model: <model_provenance.provider>/<model_provenance.model> (<model_provenance.mode>). Decisions written to graph: <N>.` If `model_provenance.mode == "cloud"`, prepend `Cloud mode.` to that line so the user can see where their transcript was sent.
+- No exclamation marks anywhere. No second-person directives. No "let me know if…", no "happy to dig in", no "let's circle back".
+
+## Distress signal handling
+
+If the user's invoking message contains overwhelm phrases — `I can't`, `too much`, `overwhelmed`, `I'm stuck`, `exhausted`, `burned out` — keep the brief but trim each section to **3 bullets maximum** (transcript order, drop the rest into an `(N further items in the transcript)` line), and replace the closing line's `Model:` portion with `Model: configured LLM`. Do not lecture. Do not diagnose. Do not refuse the brief.
+
+## Do not
+
+- Do not interpret motivation. The skill does not say "Priya seemed frustrated" or "the team is hesitant". It surfaces what was said.
+- Do not paraphrase ambiguous items. Quote the verbatim span returned by `brief_meeting`.
+- Do not invent asker names. `decided_by`, `asker`, and speaker labels come from the server response; if they are `null`, render `unattributed`.
+- Do not retry on `VERBATIM_ANCHOR_FAILED`. Surface it; the user decides whether to try again.
+- Do not record asks or ambiguous items into the cognitive graph. Only decisions, only with `decided_in`, only when `project` is set.
+- Do not record more than 10 decisions per invocation. Mention the truncation in the closing line if it applies.
+- Do not use the words `autistic`, `neurodivergent`, `spectrum`, `executive function`, `neurotype`, `clinical`, or `symptom` in user-facing output.
+- Do not use the words `superpower`, `crusher`, `smash`, `you got this`, `let's go`, `differently abled`.
+- Do not call `brief_meeting` without a resolved `me`. Ask one question; if no answer, stop.
+- Do not call `recall_decisions` with an empty or guessed project name.
+- Do not append a follow-up question. The brief is the deliverable.
+
+## What this skill is not
+
+- It is not an interpretation. It surfaces what is in the transcript verbatim.
+- It is not a recommendation. Suggested actions only appear if a speaker actually stated them.
+- It is not a clinical tool. It does not diagnose, treat, or comment on any condition.
+- It is not a translator of subtext. That is the job of `translate_incoming` in the same MCP server, on individual messages — not meetings.
+- It is not a planner. `adhd-daily-planner` plans the day; this skill briefs one meeting.
+
+## Voice
+
+Direct, plain, non-clinical. Speaker names, decision text, timestamps, project names — those are concrete and welcome. Adjectives about people's emotional states are not. The user is the authority on what the meeting meant; the skill is responsible only for what the meeting said.
+
+## Examples
+
+See `tests/01-30min-product-meeting.md`, `tests/02-ambiguous-revisit-language.md`, and `tests/03-multi-stakeholder-decision.md` for the full invocation traces. CI replays these against a reference MCP client on every PR.

--- a/claude-code/neurodock/skills/audhd-context-recovery/SKILL.md
+++ b/claude-code/neurodock/skills/audhd-context-recovery/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: audhd-context-recovery
+version: 0.1.0
+description: /resume command — reconstruct yesterday's mental state from the cognitive graph, without inventing facts.
+neurotypes: ["audhd", "asd", "adhd"]
+status: stable
+triggers:
+  - command: "/resume"
+  - command: "/where-was-i"
+  - phrase: "where was I"
+  - phrase: "what was I working on"
+mcp_dependencies:
+  - server: mcp-cognitive-graph
+    tools: [recall_entity, weekly_rollup, recall_decisions]
+  - server: mcp-chronometric
+    tools: [get_time_context]
+profile_dependencies:
+  - preferences.output_format
+  - preferences.max_chunk_size
+license: AGPL-3.0-or-later
+---
+
+# audhd-context-recovery
+
+A `/resume` command. Reconstructs the user's last working context — active project, recent decisions, open threads — from the local cognitive graph, so the user does not have to remember it.
+
+## When to activate
+
+Activate when any of the following is true:
+
+1. The user types `/resume` or `/where-was-i`.
+2. The user's message contains the literal phrases "where was I" or "what was I working on".
+3. A session has just opened AND `get_time_context.time_since_last_prompt` is greater than `PT8H`. In this case, do not activate silently — offer it: "It's been a while. Want a /resume?"
+
+Do not activate on every session start. Do not activate mid-conversation. This is a session-opener for a returning user, not a status report.
+
+## Step-by-step
+
+Follow this order. Stop early if a step returns nothing useful and say so plainly.
+
+1. **Read the clock.** Call `get_time_context()`. Note `time_since_last_prompt`. Use this to scope the recap:
+   - ≤ 24h: recall the last 7 days of decisions.
+   - 1–7 days: recall the last 14 days.
+   - > 7 days: recall the last 30 days, and explicitly tell the user the gap.
+2. **Find the project.** Parse the trigger for a named project (e.g. `/resume Phase 0 RFC`).
+   - If named: `recall_entity(name_or_alias=<that name>)`.
+   - If not named: `weekly_rollup()` (no project arg) and use the first project mentioned in `summary` / `decisions` as the most recent.
+3. **Resolution check.** If `recall_entity.resolution.method` is `alias`, `fuzzy`, or `embedding`, surface the score and the resolved entity name. Ask the user to confirm before continuing. Do not silently assume the match is right. If `entity` is `null`, stop and tell the user the graph has no record matching that name.
+4. **Pull decisions.** Call `recall_decisions(project=<resolved name>, since=<scoped date from step 1>)`. Keep the three most recent.
+5. **Pull blockers.** Call `weekly_rollup(project=<resolved name>)`. Use `blockers` and `next_actions`. Keep up to three open threads (a blocker is an open thread; a recent decision without follow-up is an open thread).
+6. **Compose the output** in the format below.
+7. **Suggest one concrete next move.** Draw it from `weekly_rollup.next_actions` if present, otherwise from the most recent decision lacking follow-up. If neither exists, say "Nothing in the graph suggests an obvious next move — what's on your mind?" Do not invent.
+
+## Output format
+
+Three short sections plus one closing sentence. Plain text. No headings deeper than H3. No tables.
+
+```
+You were on: <project name> · last activity <relative timestamp, e.g. "yesterday 16:42">
+
+Recent decisions
+- <decision 1, one line, with date>
+- <decision 2, one line, with date>
+- <decision 3, one line, with date>
+
+Open threads
+- <blocker or follow-up 1>
+- <blocker or follow-up 2>
+- <blocker or follow-up 3>
+
+Next: <one concrete move drawn from the graph>.
+```
+
+When the graph is thin, shorten honestly — for example: "Two decisions recorded, no open blockers. Next: nothing obvious — your call."
+
+## Confidence handling
+
+- Alias/fuzzy/embedding resolution: surface the entity name and score before producing the recap. Example: "I read 'Phase 0 RFC' as the entity 'Phase 0 RFC' (alias match, score 0.92). Continue?"
+- `entity == null`: do not fabricate. Say "No entity matches '<input>'. Want to try a different name, or run /resume with no argument?"
+- `decisions == []` and `blockers == []`: say so. Do not pad.
+- Truncation flags (`truncated_facts`, `truncated`): mention them briefly. "Older items were truncated."
+
+## What this skill is NOT
+
+- Not a session-opener for every session. Only on explicit request or after an 8-hour gap.
+- Not a productivity rebuke. The skill never comments on the length of the gap.
+- Not a moral judgement on time away. No "welcome back!", no "you've been gone a while", no warmth-performance.
+- Not a planner. It reconstructs context; `adhd-daily-planner` plans the day.
+- Not a fact-inventor. If the graph does not say it, the skill does not say it.
+
+## Voice
+
+Direct. Plain. Past tense for what was decided; present tense for what is open. Talk about the work — projects, decisions, threads — not about the user's neurotype. No clinical framing. No "executive function". No "context-switching tax".

--- a/claude-code/neurodock/skills/hyperfocus-formatter/SKILL.md
+++ b/claude-code/neurodock/skills/hyperfocus-formatter/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: hyperfocus-formatter
+version: 0.1.0
+description: Reformats responses to Answer-First when sessions run long; surfaces the user's own prior intent if past their break threshold. Also activates on design-critique contexts (Figma reviews, comp reviews, prototype walk-throughs, spec reviews) so the verdict lands before the reasoning.
+neurotypes: ["adhd", "audhd"]
+status: stable
+triggers:
+  - on_every_response: true # passive activation — applies a formatting transform
+  # Design-critique surfaces: the verdict must land first, then the reasoning.
+  # These phrase triggers force aggressive Answer-First (Tier B) shaping regardless
+  # of session length, because critique without a top-line verdict is unusable.
+  - phrase: "give me crit on this design"
+  - phrase: "review the comps I just sent"
+  - phrase: "Figma review please"
+  - phrase: "let me get spec review feedback"
+  - phrase: "design critique on the new flow"
+  - phrase: "walk through the prototype"
+mcp_dependencies:
+  - server: mcp-chronometric
+    tools: [get_time_context, request_break_if_needed]
+profile_dependencies:
+  - preferences.output_format
+  - preferences.max_chunk_size
+  - chronometric.hyperfocus_break_minutes
+license: AGPL-3.0-or-later
+---
+
+# hyperfocus-formatter
+
+A passive output transform. After the LLM has decided what to say, this skill reshapes how to say it based on how long the current session has been open. Short sessions get a light Answer-First touch. Longer sessions get an aggressive Answer-First structure with a hard chunk limit. Sessions past the user's own pre-configured break threshold get one verbatim line of their own prior intent prepended — never a lecture, never a block.
+
+# TODO: phase-2 mcp-guardrail integration — once `mcp-guardrail.check_hyperfocus` lands, fold its signal into the threshold tier alongside `request_break_if_needed`.
+
+## When to activate
+
+- **Every response.** This skill runs passively on every LLM turn. It is a transform, not a generator.
+- **Opt-out via profile.** If `preferences.output_format == "conventional"`, skip this skill entirely and emit the response unchanged.
+- **Design-critique phrase triggers.** When the user's prompt contains any of the design-critique phrases listed in frontmatter (e.g. "give me crit on this design", "Figma review please", "walk through the prototype"), force Tier B shaping for this turn regardless of session length. The verdict line must precede the reasoning — critique that buries the call is unusable on a deadline.
+- **No other phrase triggers.** Outside the design-critique set, there is no user-facing command. The user opts in once via profile and the transform stays on.
+
+## Operating instructions
+
+1. Read `preferences.output_format` from the user profile.
+   - If `"conventional"`: skip this skill. Emit the response as-is. Stop.
+   - If `"answer_first"` (default) or `"bullet_first"`: continue.
+2. Call `get_time_context()`. Parse `current_session_length` (ISO 8601 duration) into minutes.
+3. Read `chronometric.hyperfocus_break_minutes` from profile. Default to 90 if absent.
+4. Read `preferences.max_chunk_size` from profile. Default to 5 if absent. Clamp to range [1, 7].
+5. **Design-critique override.** If the user's prompt matches any of the design-critique phrase triggers in frontmatter (case-insensitive, substring match), skip the session-length tier selection in step 6 and apply Tier B directly. The verdict (the answer line) must be the design call — ship/don't-ship/iterate/blocker — not a preamble. Reasoning bullets follow.
+6. Otherwise, pick the tier based on `current_session_length`:
+   - **Tier A — under 30 minutes.** Apply light Answer-First: one summary sentence (≤ 80 characters) as the first line. Blank line. Then the full original response unchanged.
+   - **Tier B — 30 minutes up to `hyperfocus_break_minutes`.** Apply aggressive Answer-First: first line is the answer (≤ 80 characters). Next N lines are supporting bullets where `N == max_chunk_size`. Anything that would not fit goes into a single `<details><summary>More detail</summary>…</details>` block. Never exceed the chunk limit in the visible (non-collapsed) section.
+   - **Tier C — at or above `hyperfocus_break_minutes`.** Call `request_break_if_needed(threshold_minutes = hyperfocus_break_minutes)`. If it returns `null`, fall back to Tier B. If it returns an object, prepend exactly ONE line to the Tier-B output that quotes `prior_intent` verbatim and names the `suggested_action`. Format: `Session length: <M> minutes. You set the threshold at <T>. Your stated intent: "<prior_intent>". Suggested next action: <suggested_action>.` Then a blank line, then the Tier-B response. Do not block. Do not repeat the line on subsequent responses unless the session length crosses another full threshold multiple.
+7. Emit the transformed response.
+
+## Outputs
+
+- **Tier A.** One-sentence answer, blank line, original response.
+- **Tier B.** Answer line, blank line, up to `max_chunk_size` bullets, optional collapsed details block.
+- **Tier C.** One data line (session length, threshold, quoted prior intent, suggested action), blank line, Tier-B-shaped response.
+
+The visible word count above any collapsed block must not exceed roughly 120 words in Tier B/C. If the underlying response is genuinely longer, the surplus belongs in the details block, not in the visible chunk.
+
+## Do not
+
+- Do not editorialise time. Never write "you've been at this a while", "wow, long session", "time flies". State the data plainly: `Session length: 102 minutes. You set the threshold at 90.`
+- Do not use the word "hyperfocus" in user-facing output. It is a clinical term. The skill name uses it for developer-facing reasons only.
+- Do not block, refuse, or withhold the user's response. The transform reshapes — it never gates.
+- Do not use second-person directives: no "you should", no "you need to", no "you've been". State data; the user reads it.
+- Do not paraphrase `prior_intent`. Quote it verbatim, inside double-quotes.
+- Do not exceed `preferences.max_chunk_size` bullets in the visible section.
+- Do not repeat the threshold line on every subsequent response — only when a new threshold multiple is crossed.
+- Do not invent a `suggested_action` value. Use the exact string returned by `request_break_if_needed`. If the enum value is unfamiliar, render it literally (e.g. `switch_context`).
+
+## What this skill is not
+
+- Not a productivity coach.
+- Not a wellness nudge.
+- Not a moral judgement on session length.
+- Not a clinical intervention. The skill emits structured data the user has pre-consented to see; nothing more.
+
+## Examples
+
+See `tests/`:
+
+- `01-short-session-no-change.md` — Tier A: light Answer-First on a 12-minute session.
+- `02-long-session-answer-first.md` — Tier B: aggressive Answer-First on a 75-minute session.
+- `03-past-threshold-soft-nudge.md` — Tier C: one verbatim-intent line on a 102-minute session past the 90-minute threshold.
+- `04-design-critique.md` — Tier B forced by a design-critique phrase trigger on an 8-minute session; verdict line precedes the reasoning bullets.

--- a/claude-code/neurodock/skills/ocd-decision-finalizer/SKILL.md
+++ b/claude-code/neurodock/skills/ocd-decision-finalizer/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ocd-decision-finalizer
+version: 0.1.0
+description: Surfaces prior decision evidence on repeat-validation requests; declines further re-analysis until new information appears.
+neurotypes: ["ocd"]
+status: beta
+triggers:
+  - phrase_pattern: "should I really"
+  - phrase_pattern: "is this okay"
+  - phrase_pattern: "am I sure"
+  - phrase_pattern: "should we revisit"
+mcp_dependencies:
+  - server: mcp-cognitive-graph
+    tools: [recall_decisions, recall_entity, record_fact]
+profile_dependencies:
+  - identity.neurotypes
+  - guardrails.sycophancy_check
+license: AGPL-3.0-or-later
+authors:
+  - neurodock-core
+---
+
+# ocd-decision-finalizer
+
+This skill responds to repeat re-validation of an already-made decision by surfacing the prior decision verbatim from the cognitive graph and declining to re-analyse it until the user supplies new information. It is a workflow tool, not a clinical intervention. The user remains the authority and can override at any time.
+
+# TODO: phase-2 mcp-guardrail integration — once `mcp-guardrail.check_rumination` is shipped, this skill will defer count-keeping to that server and only handle the response shape.
+
+## Activation criteria
+
+Activate only when **all** of the following are true:
+
+- `profile.identity.neurotypes` contains `"ocd"`. If the user has not self-IDed OCD, this skill does not run. Never infer the neurotype from the user's text.
+- The user's current message contains one of the trigger phrase patterns: `should I really`, `is this okay`, `am I sure`, `should we revisit`.
+- The user's message names, or clearly references, a decision (a named technology, vendor, person, plan, or named project decision). If no decision is identifiable, do not activate — respond normally.
+
+Do not activate if the user's message includes an explicit override token (see step 5).
+
+## Operating instructions
+
+Follow these steps in order. Do not improvise extra tool calls.
+
+1. **Resolve the decision.** If the user names the decision directly (e.g. "Postgres" or "the v0.2 release plan"), call `mcp-cognitive-graph.recall_entity(name_or_alias=<the named thing>)`. If `entity` is null or `entity.type` is not `decision`, fall through to step 2. Otherwise remember `decision_id = entity.id`.
+
+2. **List recent decisions for the project.** Call `mcp-cognitive-graph.recall_decisions(project=<the project the user is working in>, since=<14 days ago, ISO date>)`. Match the decision the user is asking about by string similarity against `decisions[].name`. If no match crosses 0.6 similarity, do not activate — respond normally and note "I do not have a prior decision record matching this; treating it as a fresh question." Stop.
+
+3. **Count prior re-validations.** From the `facts` array on a `recall_entity(name_or_alias=decision_id)` call, count facts where `predicate == "tagged"` and `object.literal == "re-validated"`, scoped to the current local day. Call this count `N`.
+
+4. **Detect fresh context in the current message.** If the user's message contains an explicit fresh-context marker — `this is new`, `since I last asked`, `new information`, `update:`, or a clearly novel fact not present in the existing facts — treat this as fresh context. Skip finality. Record the new fact: `record_fact(subject={type: "decision", id: decision_id}, predicate="mentioned_in", object={literal: <the new fact, verbatim, max 200 chars>}, source="ocd-decision-finalizer", confidence=0.8)`. Then respond normally. Stop.
+
+5. **Detect explicit override.** If the user's message ends with `--override "fresh-context"` (or any `--override "<reason>"` form), respect it. Record the override locally only: `record_fact(subject={type: "decision", id: decision_id}, predicate="tagged", object={literal: "override:<reason>"}, source="ocd-decision-finalizer", confidence=1.0)`. Respond normally. The override is not transmitted; it is a local audit row. Stop.
+
+6. **Log this re-validation request.** Before producing a response, call `record_fact(subject={type: "decision", id: decision_id}, predicate="tagged", object={literal: "re-validated"}, source="ocd-decision-finalizer", confidence=1.0)`. This call must happen on every activation that reaches this step so a future call sees the correct `N`.
+
+7. **Branch on N.**
+   - If the post-write `N` is less than 3 (i.e. before this call there were fewer than 2 prior re-validations today): respond normally to the user's question, with one extra sentence: `This is the Nth time we have revisited this today; previously concluded: <decision.name> on <decided_on>.` Stop.
+   - If the post-write `N` is 3 or greater: enter **decision-finality mode** below.
+
+## Decision-finality mode (output shape when N ≥ 3)
+
+Render the following four-section response, in this order. Plain prose. No headers above the first section other than a one-line opener.
+
+```
+Opener (≤ 80 chars): direct, factual, names the decision and the count.
+
+### What was decided
+> "<decision.name>"
+Decided on <decided_on>. Confidence at recording: <confidence with two decimals>.
+Attribution: <decided_by[*].name comma-separated, or "unattributed">.
+Source: <source verbatim if non-null, otherwise omit this line>.
+
+### What you weighed
+<Up to 5 bullets from facts on the decision entity where predicate is "mentioned_in"
+ and object.literal contains a trade-off marker (e.g. "trade-off:", "vs", "weighed").
+ Quote each literal verbatim. If no such facts exist, write the single line:
+ "No trade-offs recorded against this decision in the graph.">
+
+### The grounded reply
+I will not re-analyse this decision unless you give me new information. If something has changed, tell me what changed.
+
+### Override
+If you want me to run the analysis again anyway, repeat the message with `--override "fresh-context"` appended. The override is logged locally only.
+```
+
+Rules:
+
+- Every quoted decision name must come back verbatim from the graph. Do not paraphrase, summarise, or "polish" the title.
+- The opener is one line. It states "This is the Nth time today" with the integer, and the decision name. No softening adjectives. No "I notice that".
+- The "what you weighed" section is bounded at 5 bullets. If more than 5 candidate facts exist, take the 5 with the most recent `recorded_at` and append one closing line `(<M> further trade-off facts in the graph; ask for them if you want the full list.)`
+- The override line is always present when finality fires. Without it the response is non-overridable, which violates the ethics contract (see ethics framework, items 2 and 3).
+
+## What this skill is not
+
+This is not a clinical intervention. It is not a refusal to help. It is not a judgement about the user. It surfaces prior reasoning from the graph and asks the user to add new information before more analysis. The user is the authority on whether to override. There is no diagnosis here, no treatment claim, no implication that the user is doing something wrong.
+
+## Do not
+
+- Do not use the words `rumination`, `anxiety`, `obsessive`, `compulsive`, `spiral`, `loop`, `executive function`, `neurodivergent`, `executive dysfunction`, or `intrusive` in user-facing output.
+- Do not lecture about repetition. Do not say "you've asked this before — try to let it go".
+- Do not paraphrase the decision name. Quote it verbatim from the graph.
+- Do not fabricate a decision when `recall_decisions` returned none. Fall through to normal response.
+- Do not fire when `"ocd"` is absent from `profile.identity.neurotypes`. The skill is opt-in by neurotype self-ID.
+- Do not transmit the override anywhere; it is a local audit row only.
+- Do not enter finality mode without surfacing the override path in the same response.
+- Do not call `record_fact` more than twice per activation (one re-validation tag, optionally one fresh-context fact). Extra writes pollute the graph.
+
+## Examples
+
+See `tests/01-fourth-revalidation-same-day.md`, `tests/02-new-information-resets-counter.md`, and `tests/03-explicit-override.md` for full invocation traces.

--- a/claude-code/neurodock/skills/visual-organizer/SKILL.md
+++ b/claude-code/neurodock/skills/visual-organizer/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: visual-organizer
+version: 0.1.0
+description: Converts prose, meeting notes, or overwhelm-dumps into Mermaid diagrams (flowchart / sequence / mindmap).
+neurotypes: ["adhd", "audhd", "asd"]
+status: stable
+triggers:
+  - command: "/visualize"
+  - command: "/diagram"
+  - phrase: "draw this out"
+  - phrase: "make a diagram"
+  - phrase: "i can't see the structure"
+  - phrase: "make a mermaid chart of this"
+  - phrase: "show me the flow visually"
+  - phrase: "map out the relationships"
+mcp_dependencies: []
+profile_dependencies:
+  - preferences.motion # if "reduced", the diagram MUST have animation: false
+license: AGPL-3.0-or-later
+---
+
+# visual-organizer
+
+Turns a wall of related ideas into a Mermaid diagram so the user can see structure instead of paragraphs. Pure formatting skill — no MCP calls in v0.1.0.
+
+## Activation
+
+Activate when any of the following holds:
+
+1. The user invokes `/visualize` or `/diagram`.
+2. The user says any of these (case-insensitive): "draw this out", "make a diagram", "make a mermaid chart of this", "show me the flow visually", "map out the relationships".
+3. The user says they can't see the structure, can't hold it all in their head, or otherwise signals that prose isn't loading — e.g. "I can't see the structure", "I've lost the thread of this", "I can't picture how these connect". Treat these as a request for a structural view alongside the prose answer.
+4. The user has just pasted a wall of interlinked items (≥ 6 distinct concepts, references between them) and a structural view would help. Use judgement; the prose answer still goes first. Offer the diagram, don't impose it.
+
+The user picked the trigger. Respect it. Do not editorialise their state.
+
+## Pick the diagram type
+
+| Input shape                                       | Diagram                                         |
+| ------------------------------------------------- | ----------------------------------------------- |
+| Linear cause-and-effect, a process, or a pipeline | `flowchart TD`                                  |
+| Interactions between named actors over time       | `sequenceDiagram`                               |
+| Loose related concepts the user dumped in one go  | `mindmap`                                       |
+| Branching decisions and consequences              | `flowchart LR` with diamond `{decision?}` nodes |
+
+If two fit, pick the one with fewer nodes. Cognitive load cap below is the tie-breaker.
+
+## Generate the Mermaid block
+
+1. Open a fenced ` ```mermaid ` code block. Close it cleanly.
+2. Use 2-space indentation throughout.
+3. Node IDs: short, no spaces, `camelCase` (e.g. `prRaised`, `staging`, `merge`).
+4. Node labels: human-readable inside `[brackets]` (rectangles), `("parens")` (rounded), or `{braces}` (decisions).
+5. Edge labels: `-- short label -->`. Keep them under five words.
+6. Group with `subgraph name["Label"] ... end` when grouping clarifies; do not over-group.
+
+## Required directives (every diagram)
+
+Put both at the very top of the block, before any other content.
+
+1. `%%{init: {'theme':'neutral'}}%%` — single neutral hue, matches the project palette.
+2. If `profile.preferences.motion == "reduced"`, also add `%%{init: {'flowchart': {'animation': false}}}%%`.
+
+The two init blocks can be merged into one when both apply. Either form is acceptable as long as both keys are honoured.
+
+## Cognitive load cap
+
+**Hard cap: 25 nodes per diagram.** If the input has more, split into two diagrams or roll up sub-concepts into a single node and surface the detail in prose underneath. This is the project default — do not exceed it without an explicit user instruction.
+
+## Output structure (every invocation)
+
+In this order, every time:
+
+1. One sentence stating what the diagram represents. No preamble.
+2. The fenced Mermaid block.
+3. An accessible-description line directly below the block, in the exact format:
+   `_Accessible description: <plain-prose summary>_`
+   Length: 20–200 characters. Screen-reader users get the same content as sighted users.
+4. Optional: 1–3 bullets calling out the most important relationships shown. Only include if they add information the diagram alone doesn't make obvious.
+
+## Do not
+
+- Do not produce a diagram **instead of** a prose answer when the user asked a question. The diagram is a structural view alongside prose, not a replacement.
+- Do not editorialise the user's state ("looks like you're overwhelmed!"). Just turn the text into a diagram.
+- Do not exceed 25 nodes without an explicit instruction.
+- Do not omit the accessible-description line. It is mandatory.
+- Do not use colour to convey meaning — the neutral theme is single-hue by design.
+- Do not animate. The neutral theme plus `animation: false` (when set) keeps motion out.
+
+# TODO: phase-2 enrichment — when `mcp-cognitive-graph` is available, optionally call `recall_entity` to populate node labels with the user's existing terminology and link concepts to prior decisions.
+
+## Examples
+
+See `tests/01-flowchart-from-prose.md`, `tests/02-sequence-from-meeting-notes.md`, `tests/03-mindmap-from-overwhelm-dump.md`, and `tests/04-flowchart-from-cant-see-structure.md` for full input → output pairs that the CI replays against a reference client.

--- a/docs/src/content/docs/contribute/write-a-skill.mdx
+++ b/docs/src/content/docs/contribute/write-a-skill.mdx
@@ -86,11 +86,16 @@ pnpm --filter @neurodock/skills test:a11y -- --skill <your-skill-name>
 
 This catches: max-chunk-size violations, animation references, gradient references, and patronising voice patterns. (Per the [accessibility-auditor agent spec](https://github.com/tlennon-ie/neurodock/blob/main/.claude/agents/accessibility-auditor.md).)
 
-## 6. Open a draft PR
+## 6. Bundle into the plugin, then open a draft PR
+
+Per-neurotype skills authored in `packages/skills/` are bundled into the Claude
+Code plugin verbatim. Run the sync first and commit both copies — a CI drift
+guard fails the build if the plugin copy is missing or out of date:
 
 ```bash
 git checkout -b feat/skills/<your-skill-name>
-git add packages/skills/<your-skill-name>
+node scripts/sync-skills.mjs
+git add packages/skills/<your-skill-name> claude-code/neurodock/skills/<your-skill-name>
 git commit -m "feat: add <your-skill-name> skill"
 git push -u origin feat/skills/<your-skill-name>
 gh pr create --draft --title "feat: add <your-skill-name> skill"

--- a/packages/repo-tooling/package.json
+++ b/packages/repo-tooling/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@neurodock/repo-tooling",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Private monorepo tooling and drift guards (not published). Hosts CI-run checks such as the skills bundling drift guard.",
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "scripts": {
+    "build": "echo 'repo-tooling: nothing to build'",
+    "lint": "echo 'repo-tooling: lint via prettier at repo root'",
+    "test": "vitest run",
+    "typecheck": "echo 'repo-tooling: no typed source to check'",
+    "clean": "rm -rf .turbo"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/repo-tooling/tests/skills-bundle-drift.test.ts
+++ b/packages/repo-tooling/tests/skills-bundle-drift.test.ts
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+
+/**
+ * Drift guard: every per-neurotype skill under packages/skills/ that carries a
+ * SKILL.md MUST be bundled verbatim into the Claude Code plugin at
+ * claude-code/neurodock/skills/<name>/SKILL.md.
+ *
+ * packages/skills is intentionally NOT a workspace package (no test runner of
+ * its own), so this guard lives in the private @neurodock/repo-tooling package,
+ * which `turbo run test` (and therefore the CI "TypeScript (lint, typecheck,
+ * test, build)" job) executes.
+ *
+ * To make this pass, run: node scripts/sync-skills.mjs
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..", "..", "..");
+const SOURCE_DIR = join(REPO_ROOT, "packages", "skills");
+const PLUGIN_DIR = join(REPO_ROOT, "claude-code", "neurodock", "skills");
+
+/** Per-neurotype skills shipped from packages/skills (the launch set). */
+const EXPECTED_SKILLS = [
+  "adhd-daily-planner",
+  "asd-meeting-translator",
+  "audhd-context-recovery",
+  "hyperfocus-formatter",
+  "ocd-decision-finalizer",
+  "visual-organizer",
+] as const;
+
+/** Source skill directories = any child of packages/skills with a SKILL.md. */
+function discoverSourceSkills(): string[] {
+  return readdirSync(SOURCE_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(join(SOURCE_DIR, name, "SKILL.md")))
+    .sort();
+}
+
+describe("skills bundle drift guard", () => {
+  it("discovers exactly the expected per-neurotype skills in packages/skills", () => {
+    const discovered = discoverSourceSkills();
+    expect(discovered).toEqual([...EXPECTED_SKILLS].sort());
+  });
+
+  it("bundles every source skill into the Claude Code plugin", () => {
+    const missing = discoverSourceSkills().filter(
+      (name) => !existsSync(join(PLUGIN_DIR, name, "SKILL.md")),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  for (const name of EXPECTED_SKILLS) {
+    it(`bundles ${name}/SKILL.md verbatim into the plugin`, () => {
+      const sourcePath = join(SOURCE_DIR, name, "SKILL.md");
+      const pluginPath = join(PLUGIN_DIR, name, "SKILL.md");
+
+      expect(existsSync(sourcePath), `missing source ${sourcePath}`).toBe(true);
+      expect(existsSync(pluginPath), `missing plugin copy ${pluginPath}`).toBe(
+        true,
+      );
+
+      const source = readFileSync(sourcePath, "utf8");
+      const plugin = readFileSync(pluginPath, "utf8");
+      expect(plugin).toBe(source);
+    });
+
+    it(`${name}/SKILL.md has name + description frontmatter`, () => {
+      const source = readFileSync(join(SOURCE_DIR, name, "SKILL.md"), "utf8");
+      expect(source).toMatch(/^---\r?\n/);
+      expect(source).toMatch(/\bname:\s*\S+/);
+      expect(source).toMatch(/\bdescription:\s*\S+/);
+    });
+  }
+});

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,18 +1,39 @@
 # NeuroDock skills
 
-The skill library. Each skill lives in its own directory and ships a `SKILL.md` with standard frontmatter, plus a `tests/` directory with at least three example invocations replayed in CI.
+The per-neurotype skill library. Each skill lives in its own directory and ships a `SKILL.md` with standard frontmatter, plus a `tests/` directory with at least three example invocations replayed in CI.
 
-This directory is intentionally not a workspace package — skills are content, not code. They are bundled into the substrate at install time via `@neurodock/cli`.
+This directory is intentionally **not** a workspace package — skills are content, not code. `packages/skills/` is the **source of truth**; users receive the skills through the delivery paths below.
 
-Phase 0: stub frontmatter for the six launch skills only. Real prompts and tests land in Phase 1 and Phase 2.
+## How a skill reaches a user
 
-Launch skills (see Section 6):
+### Claude Code plugin (implemented)
 
-- `adhd-daily-planner` — Morning ritual, generates 1–3 things that matter today.
-- `audhd-context-recovery` — `/resume` command; reconstructs yesterday from the cognitive graph.
-- `asd-meeting-translator` — Transcript to structured asks. Depends on the translation server (Phase 2).
-- `ocd-decision-finalizer` — Enforces decision-finality on repeat validation.
-- `hyperfocus-formatter` — "Answer First" output structure under distress signals.
+The Claude Code plugin at `claude-code/neurodock/` auto-discovers skills from its own `claude-code/neurodock/skills/<name>/` directory. Each source skill's `SKILL.md` is **bundled verbatim** into that directory by the sync script:
+
+```bash
+node scripts/sync-skills.mjs          # write/refresh the plugin copies (idempotent)
+node scripts/sync-skills.mjs --check  # verify only; exits non-zero on drift (CI)
+```
+
+The sync copies every `packages/skills/<name>/` that contains a `SKILL.md`, **excluding** the `tests/` directory (CI-only, never shipped) and the per-skill `README.md` / `CHANGELOG.md` (author docs). The top-level `packages/skills/README.md` is never copied.
+
+A **drift guard** in `@neurodock/repo-tooling` (`packages/repo-tooling/tests/skills-bundle-drift.test.ts`) runs in the CI `TypeScript (lint, typecheck, test, build)` job. It fails the build if any source skill is missing from the plugin or differs from its bundled copy, so the bundle can never silently fall out of sync. The same invariant is enforced locally by `scripts/sync-skills.mjs --check`.
+
+### CLI install (coming in a follow-up)
+
+A `@neurodock/cli` install path that bundles these skills into the local substrate is planned as a separate change. Until it lands, the Claude Code plugin is the user-facing delivery path.
+
+## Launch skills
+
+- `adhd-daily-planner` — Morning brief: what changed overnight, what matters today, one next-action per project.
+- `audhd-context-recovery` — `/resume` command; reconstructs yesterday's mental state from the cognitive graph.
+- `asd-meeting-translator` — Transcript to a four-section brief (my asks, others' asks, decisions, ambiguous).
+- `ocd-decision-finalizer` — Surfaces prior decision evidence on repeat-validation requests; declines re-analysis without new information.
+- `hyperfocus-formatter` — "Answer First" output structure on long sessions and design-critique surfaces.
 - `visual-organizer` — Mermaid generation for overwhelm states.
 
-Authoring a new skill: fork, copy an existing `SKILL.md`, fill in the frontmatter, add three test invocations to `tests/`, open a PR.
+## Authoring a new skill
+
+1. Create `packages/skills/<name>/` with a `SKILL.md` (valid `name` + `description` frontmatter required by Claude Code) and a `tests/` directory with at least three example invocations.
+2. Run `node scripts/sync-skills.mjs` to bundle it into the Claude Code plugin.
+3. Commit both the source skill and the synced plugin copy. The CI drift guard enforces that they stay identical.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,12 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.21)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  packages/repo-tooling:
+    devDependencies:
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@25.9.3)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+
 packages:
 
   '@1natsu/wait-element@4.2.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "packages/core"
+  - "packages/repo-tooling"
   - "packages/cli"
   - "packages/extension-browser"
   - "packages/native-host"

--- a/scripts/sync-skills.mjs
+++ b/scripts/sync-skills.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026 NeuroDock contributors.
+/**
+ * sync-skills.mjs
+ *
+ * Bundles the per-neurotype end-user skills from packages/skills/ into the
+ * Claude Code plugin at claude-code/neurodock/skills/ so they actually reach
+ * plugin / marketplace users.
+ *
+ * For every directory under packages/skills/ that contains a SKILL.md, this
+ * copies that skill's content VERBATIM into claude-code/neurodock/skills/<name>/,
+ * EXCLUDING:
+ *   - the tests/ directory (CI-only; must not ship to users)
+ *   - per-skill human docs: README.md and CHANGELOG.md (author-facing, they
+ *     mirror the excluded top-level packages/skills/README.md and the plugin
+ *     convention is SKILL.md-only)
+ *
+ * The top-level packages/skills/README.md is never copied (it is not a skill).
+ *
+ * Usage:
+ *   node scripts/sync-skills.mjs           # write/refresh the plugin copies (idempotent)
+ *   node scripts/sync-skills.mjs --check   # verify only; exit 1 if missing/differs (CI / drift guard)
+ *
+ * The drift-guard test (@neurodock/repo-tooling) asserts the same invariant so
+ * the bundle can never silently fall out of sync.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolve the repo root. fileURLToPath handles every Windows URL form.
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
+
+const SOURCE_DIR = path.join(REPO_ROOT, "packages", "skills");
+const PLUGIN_DIR = path.join(REPO_ROOT, "claude-code", "neurodock", "skills");
+
+const CHECK_MODE = process.argv.includes("--check");
+
+// File / directory names that must NOT be bundled into the plugin.
+const EXCLUDED_DIRS = new Set(["tests"]);
+const EXCLUDED_FILES = new Set(["README.md", "CHANGELOG.md"]);
+
+// ---- discovery --------------------------------------------------------------
+
+/** Skill dirs = direct children of packages/skills/ that carry a SKILL.md. */
+function discoverSkills() {
+  let entries;
+  try {
+    entries = fs.readdirSync(SOURCE_DIR, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => fs.existsSync(path.join(SOURCE_DIR, name, "SKILL.md")))
+    .sort();
+}
+
+/** Files to bundle for a given skill (relative to the skill dir). */
+function bundledFiles(skillName) {
+  const skillRoot = path.join(SOURCE_DIR, skillName);
+  const out = [];
+
+  const walk = (absDir, relDir) => {
+    for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (EXCLUDED_DIRS.has(entry.name)) continue;
+        walk(path.join(absDir, entry.name), path.join(relDir, entry.name));
+      } else if (entry.isFile()) {
+        if (relDir === "" && EXCLUDED_FILES.has(entry.name)) continue;
+        out.push(path.join(relDir, entry.name));
+      }
+    }
+  };
+
+  walk(skillRoot, "");
+  return out.sort();
+}
+
+// ---- check mode -------------------------------------------------------------
+
+function runCheck() {
+  const skills = discoverSkills();
+  const problems = [];
+
+  for (const skill of skills) {
+    for (const rel of bundledFiles(skill)) {
+      const srcPath = path.join(SOURCE_DIR, skill, rel);
+      const dstPath = path.join(PLUGIN_DIR, skill, rel);
+      const relReport = path.join(skill, rel).replace(/\\/g, "/");
+
+      if (!fs.existsSync(dstPath)) {
+        problems.push(`MISSING  ${relReport}`);
+        continue;
+      }
+      const src = fs.readFileSync(srcPath, "utf8");
+      const dst = fs.readFileSync(dstPath, "utf8");
+      if (src !== dst) {
+        problems.push(`DIFFERS  ${relReport}`);
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    console.error("[sync-skills] drift detected between packages/skills and");
+    console.error("[sync-skills] claude-code/neurodock/skills:");
+    for (const p of problems) console.error(`  ${p}`);
+    console.error("");
+    console.error("[sync-skills] run: node scripts/sync-skills.mjs");
+    process.exit(1);
+  }
+
+  console.log(
+    `[sync-skills] OK — ${skills.length} skill(s) in sync with the plugin.`,
+  );
+}
+
+// ---- write mode -------------------------------------------------------------
+
+function runSync() {
+  const skills = discoverSkills();
+  let copied = 0;
+  let unchanged = 0;
+
+  for (const skill of skills) {
+    for (const rel of bundledFiles(skill)) {
+      const srcPath = path.join(SOURCE_DIR, skill, rel);
+      const dstPath = path.join(PLUGIN_DIR, skill, rel);
+      const relReport = path.join(skill, rel).replace(/\\/g, "/");
+
+      const src = fs.readFileSync(srcPath, "utf8");
+      const current = fs.existsSync(dstPath)
+        ? fs.readFileSync(dstPath, "utf8")
+        : null;
+
+      if (current === src) {
+        unchanged++;
+        continue;
+      }
+
+      fs.mkdirSync(path.dirname(dstPath), { recursive: true });
+      fs.writeFileSync(dstPath, src);
+      copied++;
+      console.log(
+        `  ${current === null ? "+ added  " : "~ updated"} ${relReport}`,
+      );
+    }
+  }
+
+  console.log("");
+  console.log(
+    `[sync-skills] synced ${skills.length} skill(s): ${copied} written, ${unchanged} already current.`,
+  );
+}
+
+// ---- main -------------------------------------------------------------------
+
+// Fail loudly if the source tree is missing/mis-named, rather than reporting
+// "0 skill(s) in sync" and exiting 0 (a false green for the drift guard).
+if (!fs.existsSync(SOURCE_DIR)) {
+  console.error(`[sync-skills] source directory not found: ${SOURCE_DIR}`);
+  process.exit(1);
+}
+
+if (CHECK_MODE) {
+  runCheck();
+} else {
+  runSync();
+}

--- a/scripts/sync-skills.mjs
+++ b/scripts/sync-skills.mjs
@@ -50,14 +50,29 @@ function discoverSkills() {
   let entries;
   try {
     entries = fs.readdirSync(SOURCE_DIR, { withFileTypes: true });
-  } catch {
-    return [];
+  } catch (err) {
+    // Fail loudly if the source tree is missing/mis-named, rather than
+    // reporting "0 skill(s) in sync" and exiting 0 (a false green).
+    console.error(
+      `[sync-skills] cannot read source directory ${SOURCE_DIR}: ${err.message}`,
+    );
+    process.exit(1);
   }
   return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
     .filter((name) => fs.existsSync(path.join(SOURCE_DIR, name, "SKILL.md")))
     .sort();
+}
+
+/** Read a file's text, or null if absent — avoids a check-then-read race. */
+function readIfExists(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  }
 }
 
 /** Files to bundle for a given skill (relative to the skill dir). */
@@ -93,12 +108,12 @@ function runCheck() {
       const dstPath = path.join(PLUGIN_DIR, skill, rel);
       const relReport = path.join(skill, rel).replace(/\\/g, "/");
 
-      if (!fs.existsSync(dstPath)) {
+      const dst = readIfExists(dstPath);
+      if (dst === null) {
         problems.push(`MISSING  ${relReport}`);
         continue;
       }
       const src = fs.readFileSync(srcPath, "utf8");
-      const dst = fs.readFileSync(dstPath, "utf8");
       if (src !== dst) {
         problems.push(`DIFFERS  ${relReport}`);
       }
@@ -133,9 +148,7 @@ function runSync() {
       const relReport = path.join(skill, rel).replace(/\\/g, "/");
 
       const src = fs.readFileSync(srcPath, "utf8");
-      const current = fs.existsSync(dstPath)
-        ? fs.readFileSync(dstPath, "utf8")
-        : null;
+      const current = readIfExists(dstPath);
 
       if (current === src) {
         unchanged++;
@@ -158,13 +171,6 @@ function runSync() {
 }
 
 // ---- main -------------------------------------------------------------------
-
-// Fail loudly if the source tree is missing/mis-named, rather than reporting
-// "0 skill(s) in sync" and exiting 0 (a false green for the drift guard).
-if (!fs.existsSync(SOURCE_DIR)) {
-  console.error(`[sync-skills] source directory not found: ${SOURCE_DIR}`);
-  process.exit(1);
-}
 
 if (CHECK_MODE) {
   runCheck();


### PR DESCRIPTION
## What

The six per-neurotype skills in `packages/skills/` (adhd-daily-planner,
asd-meeting-translator, audhd-context-recovery, hyperfocus-formatter,
ocd-decision-finalizer, visual-organizer) were authored and CI-tested but reached
**no plugin/marketplace user** — `claude-code/neurodock/skills/` only shipped the six
substrate skills. This is R8 (skills delivery), part A: the plugin path.

- `scripts/sync-skills.mjs` copies each skill's `SKILL.md` verbatim into the plugin,
  excluding `tests/` and author docs; `--check` mode exits non-zero on drift.
- A drift-guard test in a new **private** `@neurodock/repo-tooling` package is wired into
  the existing `turbo run test` job, so the plugin bundle can never silently fall out of
  sync with the source again (byte-identity + completeness + frontmatter assertions).
- Plugin now ships **12** skills (6 substrate + 6 per-neurotype). Plugin README, skills
  README, and the write-a-skill contributor guide updated to document the sync step
  (the guide previously routed contributors into a CI failure).

The `@neurodock/cli install-skills` path (for non-plugin clients) and the hosted-remote
delivery docs are the separate part B follow-up.

## Review

Authored by `skill-author` (TDD, RED→GREEN shown). Reviewed by `code-reviewer` (APPROVE,
0 critical/high) and `docs-curator`. Fixed in response: `--check` now fails loudly if the
source tree is missing; `fileURLToPath` for path resolution; plugin README listed only
6/12 skills (fixed); contributor guide sync-step trap (fixed).

## Test plan

- [x] `node scripts/sync-skills.mjs --check` → OK, 6 in sync
- [x] `pnpm --filter @neurodock/repo-tooling test` → 14/14 (drift guard runs in CI)
- [x] `pnpm --filter @neurodock/docs build` → 54 pages, no MDX errors
- [x] full workspace `lint typecheck test build` green (24 tasks, per author)
- [x] `wrangler.jsonc` excluded