### PR TITLE
feat: neurodock install-skills + bundle skills into the cli (r8 part b)

### DIFF
--- a/.changeset/thin-snakes-deliver-skills.md
+++ b/.changeset/thin-snakes-deliver-skills.md
@@ -1,0 +1,16 @@
+---
+"@neurodock/cli": minor
+---
+
+add `neurodock install-skills` and bundle the per-neurotype skills into the cli
+
+the cli now ships the six per-neurotype skills (their `SKILL.md` files,
+generated into `dist/assets/skills/` at build time from `packages/skills/`).
+the new `neurodock install-skills` command copies them into the client's
+personal skills directory (`~/.claude/skills/neurodock-<name>/` for claude code
+and claude desktop; cursor is skipped). it supports `--client`, `--dry-run`,
+and `--yes`, and is idempotent.
+
+`install-all`, `setup`, and `update` now install the skills as part of the
+one-command happy path; opt out with `--no-skills` (mirrors `--no-native-host`).
+the skills step is best-effort — a failure warns but does not fail the command.

--- a/docs/src/content/docs/concepts/skills.mdx
+++ b/docs/src/content/docs/concepts/skills.mdx
@@ -23,6 +23,15 @@ A skill lives at `packages/skills/<name>/` and ships:
 
 That is the whole contract. There is no compilation step; there is no skill runtime. The client reads `SKILL.md` and follows it.
 
+## How skills reach you
+
+`packages/skills/` is the source of truth; users receive the skills through two delivery paths:
+
+- **Claude Code plugin / marketplace.** The plugin at `claude-code/neurodock/` ships each skill's `SKILL.md` in its own `skills/` directory, kept in sync by `scripts/sync-skills.mjs` and guarded against drift in CI. Installing the plugin makes the skills available automatically.
+- **`@neurodock/cli`.** Users who wire NeuroDock with the CLI run `neurodock install-skills` (also invoked automatically by `neurodock install-all`, `neurodock setup`, and `neurodock update` unless you pass `--no-skills`). It copies each skill into your client's personal skills directory — `~/.claude/skills/neurodock-<name>/SKILL.md` for Claude Code and Claude Desktop. Cursor has no skills system and is skipped.
+
+Either way the model reads the same markdown. Hosted/remote users get the skills via the marketplace plugin or `neurodock install-skills`, since the skills are content the client reads locally rather than something the remote server delivers.
+
 ## How triggers work
 
 A skill's `triggers` block in frontmatter declares the conditions under which the client activates it. Examples:

--- a/docs/src/content/docs/getting-started/first-skill.mdx
+++ b/docs/src/content/docs/getting-started/first-skill.mdx
@@ -28,6 +28,10 @@ sequenceDiagram
   What `/morning-brief` does under the hood. A short screen-capture demo is tracked in <a href="https://github.com/tlennon-ie/neurodock/issues/27">issue #27</a>.
 </figcaption>
 
+:::tip[Where the skill comes from]
+You do not install `adhd-daily-planner` by hand. The per-neurotype skills are copied into `~/.claude/skills` automatically by `neurodock install-all` or `neurodock setup`. To (re)install them on demand, run `neurodock install-skills`. If you use the Claude Code marketplace plugin, the skills ship bundled with it.
+:::
+
 ## Prerequisites
 
 - [Installation](/getting-started/installation/) is complete and `neurodock doctor` passes.

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -15,7 +15,7 @@ npx --yes @neurodock/cli@latest install-all
 
 That one command installs the five NeuroDock MCP servers from PyPI (via `uvx`), detects which MCP-aware clients you have (Claude Desktop, Claude Code, Cursor), and writes the server registration block into each of their config files. Then you restart your client and the tools appear.
 
-This is the developer preview (`@neurodock/cli v0.5.0`). The substrate is at `v0.2.1` and all five MCP servers are live on PyPI.
+This is an early release (`@neurodock/cli v0.8.2`); all five MCP servers are live on PyPI.
 
 :::caution[Quit fully — close-window is not enough]
 Claude only reads its MCP config **at startup**. Closing the window does not restart the process. You must fully quit:
@@ -270,7 +270,7 @@ npx neurodock init --dry-run
 `--dry-run` prints every file that *would* be created or modified without touching anything. Useful for review, useful for CI.
 
 :::note[CLI status]
-The `@neurodock/cli` package is shipped (`v0.6.2`) and exposes `init`, `doctor`, `validate`, `update`, `sync`, `uninstall`, `host install/uninstall`, `profile show/validate`, `install-hooks`, plus the `install-all` and `examples` ergonomics shortcuts and the `plugin add/remove/list/enable/disable/validate` subcommands. See the [CLI reference](/reference/cli/) for the full command surface.
+The `@neurodock/cli` package is shipped (`v0.8.2`) and exposes `init`, `setup`, `install-skills`, `doctor`, `validate`, `update`, `sync`, `uninstall`, `host install/uninstall`, `profile show/validate`, `guardrail status`, `install-hooks`, plus the `install-all` and `examples` ergonomics shortcuts and the `plugin add/remove/list/enable/disable/validate` subcommands. See the [CLI reference](/reference/cli/) for the full command surface.
 :::
 
 </details>

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -1,10 +1,10 @@
 ---
 title: CLI
-description: The neurodock command-line interface. Nineteen commands across seven groups, shipped in @neurodock/cli 0.6.2.
+description: The neurodock command-line interface. Twenty-two commands, shipped in @neurodock/cli 0.8.2.
 ---
 
 :::note[CLI status]
-`@neurodock/cli` `0.6.2` is shipped to npm. Nineteen commands across seven groups (`init`, `install-all`, `install-hooks`, `examples`, `doctor`, `validate`, `update`, `sync`, `uninstall`, `host install/uninstall`, `profile show/validate`, `plugin add/remove/list/enable/disable/validate`). The CLI is the lowest-friction onboarding path: `npx --yes @neurodock/cli@latest install-all` should take a fresh install from zero to a working substrate in under five minutes.
+`@neurodock/cli` `0.8.2` is shipped to npm. Twenty-two commands: top-level `init`, `install-all`, `setup`, `install-skills`, `examples`, `doctor`, `validate`, `update`, `sync`, `uninstall`, `install-hooks`, plus the `profile show/validate`, `guardrail status`, `host install/uninstall`, and `plugin add/remove/list/enable/disable/validate` groups. The CLI is the lowest-friction onboarding path: `npx --yes @neurodock/cli@latest install-all` should take a fresh install from zero to a working substrate in under five minutes.
 :::
 
 ## Commands
@@ -12,7 +12,9 @@ description: The neurodock command-line interface. Nineteen commands across seve
 | Command | Job |
 |---|---|
 | [`neurodock init`](#neurodock-init) | Detect installed MCP clients, scaffold the profile, register the five substrate servers. |
-| [`neurodock install-all`](#neurodock-install-all) | One-command install: detect `uv` or `pip`, install the six Python packages, then run `init`. |
+| [`neurodock install-all`](#neurodock-install-all) | One-command install: detect `uv` or `pip`, install the six Python packages, run `init`, register the native host, and install the skills. |
+| [`neurodock setup`](#neurodock-setup) | Full setup in one command: runs `install-all` then `install-hooks`. Standalone daemon is opt-in via `--daemon`. |
+| [`neurodock install-skills`](#neurodock-install-skills) | Copy the per-neurotype skills into your client's personal skills directory (`~/.claude/skills`). |
 | [`neurodock examples`](#neurodock-examples) | Print copy-pasteable prompts that exercise every wired NeuroDock MCP tool. |
 | [`neurodock doctor`](#neurodock-doctor) | Verify the install. Profile readable, all servers start, embedding backend reachable. |
 | [`neurodock validate`](#neurodock-validate) | Ajv-driven schema validation against the canonical profile schema. |
@@ -23,6 +25,7 @@ description: The neurodock command-line interface. Nineteen commands across seve
 | [`neurodock host uninstall`](#neurodock-host-uninstall) | Remove the native messaging host manifests / registry pointers. |
 | [`neurodock profile show`](#neurodock-profile-show) | Print the loaded profile with loader defaults applied. |
 | [`neurodock profile validate`](#neurodock-profile-validate) | Validate `~/.neurodock/profile.yaml` against the schema. |
+| [`neurodock guardrail status`](#neurodock-guardrail-status) | Report which proactive-guardrail pieces (hooks, daemon) are wired and which are missing. |
 | [`neurodock plugin add`](#neurodock-plugin-add) | Install a plugin from a local directory into `~/.neurodock/plugins/`. |
 | [`neurodock plugin remove`](#neurodock-plugin-remove) | Remove an installed plugin. |
 | [`neurodock plugin list`](#neurodock-plugin-list) | List installed plugins and their enabled state. |
@@ -60,7 +63,7 @@ npx neurodock init --client claude-desktop --profile minimal --dry-run
 npx neurodock install-all
 ```
 
-The one-command first-time install. Detects whether `uv` is on PATH (preferred) and falls back to `python -m pip`, installs the six Python MCP servers (`neurodock-mcp-chronometric`, `neurodock-mcp-cognitive-graph`, `neurodock-mcp-task-fractionator`, `neurodock-mcp-translation`, `neurodock-mcp-guardrail`, `neurodock-evals`), verifies each entrypoint with `<command> --help`, and then runs `neurodock init` to wire MCP clients. Collapses six `pip install` lines plus an `init` into one.
+The one-command first-time install. Detects whether `uv` is on PATH (preferred) and falls back to `python -m pip`, installs the six Python MCP servers (`neurodock-mcp-chronometric`, `neurodock-mcp-cognitive-graph`, `neurodock-mcp-task-fractionator`, `neurodock-mcp-translation`, `neurodock-mcp-guardrail`, `neurodock-evals`), verifies each entrypoint with `<command> --help`, runs `neurodock init` to wire MCP clients, registers the optional native-messaging host, and installs the per-neurotype skills into `~/.claude/skills`. Collapses six `pip install` lines plus `init`, host registration, and skill install into one.
 
 | Flag | Default | Meaning |
 |---|---|---|
@@ -70,6 +73,11 @@ The one-command first-time install. Detects whether `uv` is on PATH (preferred) 
 | `--skip-install` | `false` | Skip the Python install step; only run `init`. |
 | `--yes` | `false` | Answer yes to all prompts. |
 | `--dry-run` | `false` | Print what would happen without writing. |
+| `--no-native-host` | n/a | Skip registering the optional native-messaging host (browser extension ↔ `profile.yaml`). |
+| `--no-skills` | n/a | Skip copying the per-neurotype skills into `~/.claude/skills`. |
+| `--extension-id <id>` | — | Extra browser-extension id to allow on the native host (repeatable; published store ids are always included). |
+
+The native-host and skills steps are best-effort: a failure in either emits a warning but does not fail the command (the six MCP servers are the core).
 
 Exit codes: `0` on success; `1` if any entrypoint is missing from PATH; `2` if `init` fails.
 
@@ -78,6 +86,55 @@ Example:
 ```bash
 npx neurodock install-all --installer uv --yes
 ```
+
+### `neurodock setup`
+
+```bash
+npx neurodock setup
+```
+
+Full setup in one command. A thin orchestrator that runs two existing installers in order:
+
+1. [`neurodock install-all`](#neurodock-install-all) — install the six MCP servers, wire the clients, register the native-messaging host, and install the skills.
+2. [`neurodock install-hooks`](#neurodock-install-hooks) — wire the Claude Code proactive-guardrail hooks into `~/.claude/settings.json`.
+
+The standalone guardrail daemon stays opt-in: pass `--daemon` to also register it at user-login autostart. The hooks step runs even if `install-all` reported a problem, so a PATH hiccup with the MCP entrypoints does not leave you without proactive guardrails.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--client <id>` | `all` | `claude-desktop`, `claude-code`, `cursor`, or `all`. |
+| `--profile <id>` | `example` | `minimal` or `example`. |
+| `--installer <id>` | `auto` | `uv`, `pip`, or `auto`. |
+| `--skip-install` | `false` | Skip the Python install step (only wire clients + hooks). |
+| `--yes` | `false` | Answer yes to all prompts. |
+| `--dry-run` | `false` | Print what would happen without writing. |
+| `--no-native-host` | n/a | Skip registering the optional native-messaging host. |
+| `--no-skills` | n/a | Skip copying the per-neurotype skills into `~/.claude/skills`. |
+| `--daemon` | `false` | Also register the standalone guardrail daemon at user-login autostart. |
+| `--extension-id <id>` | — | Extra browser-extension id to allow on the native host (repeatable; published store ids are always included). |
+
+Exit codes: `install-all`'s exit code wins when non-zero; otherwise `1` if the hooks step failed, else `0`.
+
+### `neurodock install-skills`
+
+```bash
+npx neurodock install-skills
+```
+
+Copy the per-neurotype NeuroDock skills bundled in the CLI tarball into your client's personal skills directory so Claude Code / Claude Desktop discover them. Each skill installs as `~/.claude/skills/neurodock-<name>/SKILL.md` (namespaced so it is collision-free and recognisably NeuroDock's).
+
+- Claude Code and Claude Desktop share `~/.claude/skills`; the command de-duplicates so the files are written once.
+- Cursor has no skills system today and is skipped with a notice (never an error).
+- Idempotent: re-running refreshes each `SKILL.md` in place.
+- This step also runs automatically inside `install-all`, `setup`, and `update` unless you pass `--no-skills`.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--client <id>` | `all` | `claude-desktop`, `claude-code`, `cursor`, or `all`. |
+| `--dry-run` | `false` | Print the planned targets without writing anything. |
+| `--yes` | `false` | Answer yes to all prompts (idempotent re-runs refresh in place). |
+
+Exit codes: `0` on success; `1` if no bundled skills were found (a packaging bug).
 
 ### `neurodock examples`
 
@@ -140,7 +197,7 @@ Exit codes: `0` if valid; `1` if missing, unparseable, or invalid.
 neurodock update
 ```
 
-Upgrades NeuroDock to the latest version. Same code path as `install-all` — re-runs `pip install --upgrade` (or `uv tool install`) for every NeuroDock MCP server, re-wires the detected MCP clients, and re-registers the optional native-messaging host. This is the verb users look for when they want a version bump.
+Upgrades NeuroDock to the latest version. Same code path as `install-all` — re-runs `pip install --upgrade` (or `uv tool install`) for every NeuroDock MCP server, re-wires the detected MCP clients, re-registers the optional native-messaging host, and refreshes the per-neurotype skills in `~/.claude/skills`. This is the verb users look for when they want a version bump.
 
 | Flag | Default | Meaning |
 |---|---|---|
@@ -151,6 +208,7 @@ Upgrades NeuroDock to the latest version. Same code path as `install-all` — re
 | `--yes` | `false` | Answer yes to all prompts. |
 | `--dry-run` | `false` | Print what would happen without writing. |
 | `--no-native-host` | n/a | Skip re-registering the optional native-messaging host. |
+| `--no-skills` | n/a | Skip refreshing the per-neurotype skills in `~/.claude/skills`. |
 
 Exit codes: `0` ok; `1` an entrypoint is missing from PATH after install; `2` init failed.
 
@@ -231,6 +289,16 @@ neurodock profile validate
 Validate `~/.neurodock/profile.yaml` against the canonical schema. Returns the same checks as the top-level `validate` command but scoped to the resolved profile path with no file/strict flags.
 
 Exit codes: `0` if valid; `1` if missing or invalid.
+
+### `neurodock guardrail status`
+
+```bash
+neurodock guardrail status
+```
+
+Report which proactive-guardrail pieces are wired and which are missing — the Claude Code hooks in `~/.claude/settings.json` and the optional standalone daemon. Read-only diagnostic; writes nothing. No flags.
+
+Exit codes: `0` when the wiring is healthy; non-zero when a piece is missing.
 
 ### `neurodock plugin add`
 
@@ -315,7 +383,7 @@ Exit codes: `0` if valid; non-zero otherwise.
 
 | Flag | Meaning |
 |---|---|
-| `-v, --version` | Print the CLI version (`0.6.2`). |
+| `-v, --version` | Print the CLI version (`0.8.2`). |
 | `-h, --help` | Show help for the program or a subcommand. |
 
 ## Environment

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 The `neurodock` installer and diagnostic CLI for [NeuroDock](https://neurodock.org/) — a local-first cognitive substrate for neurodivergent professionals.
 
-Status: **v0.6.2**.
+Status: **v0.8.2**.
 
 ## Quickstart
 
@@ -34,8 +34,9 @@ install, `install-all` runs the `pip install` step automatically.
 
 | Command                      | What it does                                                                                                                                                    |
 | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `neurodock install-all`      | One-command first-time install: pip-install the six servers, wire every detected client, copy the starter profile.                                              |
+| `neurodock install-all`      | One-command first-time install: pip-install the six servers, wire every detected client, copy the starter profile, install the per-neurotype skills.            |
 | `neurodock init`             | Install MCP servers into Claude Desktop / Claude Code / Cursor (the wiring half of `install-all`).                                                              |
+| `neurodock install-skills`   | Copy the per-neurotype skills into your client's personal skills directory (`~/.claude/skills` for Claude Code / Claude Desktop). Cursor is skipped.            |
 | `neurodock doctor`           | Diagnose your install — profile validity, client wiring, tool availability.                                                                                     |
 | `neurodock validate`         | Schema-validate a profile file (`~/.neurodock/profile.yaml` by default).                                                                                        |
 | `neurodock update`           | Upgrade NeuroDock to the latest version — re-installs the six MCP servers via pip/uv and re-wires client configs.                                               |
@@ -60,16 +61,47 @@ install, `install-all` runs the `pip install` step automatically.
 neurodock install-all [--client=claude-desktop|claude-code|cursor|all] \
                       [--profile=minimal|example] \
                       [--installer=uv|pip|auto] \
-                      [--skip-install] [--yes] [--dry-run]
+                      [--skip-install] [--yes] [--dry-run] \
+                      [--no-native-host] [--no-skills]
 ```
 
 Single-command first-time install. Prefers `uv` if it is on PATH; falls
 back to `python -m pip`. After install, verifies each server entrypoint
-is on PATH with `<command> --help`, then delegates to `init` to wire
-clients.
+is on PATH with `<command> --help`, delegates to `init` to wire clients,
+registers the optional native-messaging host, and installs the
+per-neurotype skills into `~/.claude/skills`.
 
-Exit codes: `0` ok, `1` an entrypoint is missing from PATH after
-install, `2` init failed.
+- `--no-native-host` skips registering the native-messaging host.
+- `--no-skills` skips copying the per-neurotype skills.
+
+Both steps are best-effort: a failure in either emits a warning but does
+not fail the command (the six MCP servers are the core). Exit codes:
+`0` ok, `1` an entrypoint is missing from PATH after install, `2` init
+failed.
+
+### `neurodock install-skills`
+
+```
+neurodock install-skills [--client=claude-desktop|claude-code|cursor|all] \
+                         [--dry-run] [--yes]
+```
+
+Copies the six per-neurotype skills bundled in the CLI tarball into the
+client's personal skills directory so Claude Code / Claude Desktop
+discover them. Each skill installs as
+`~/.claude/skills/neurodock-<name>/SKILL.md` (namespaced so it is
+collision-free and recognisably NeuroDock's).
+
+- Claude Code and Claude Desktop share `~/.claude/skills`; the command
+  de-duplicates so the files are written once.
+- Cursor has no skills system today and is skipped with a notice (never
+  an error).
+- `--dry-run` prints the planned targets and exits 0 without writing.
+- Idempotent: re-running refreshes each `SKILL.md` in place.
+
+This is also run automatically by `install-all` / `setup` / `update`
+unless you pass `--no-skills`. Exit codes: `0` ok, `1` no bundled skills
+were found (a packaging bug).
 
 ### `neurodock init`
 
@@ -100,14 +132,16 @@ key are skipped unless `--yes` is supplied.
 neurodock update [--client=claude-desktop|claude-code|cursor|all] \
                  [--profile=minimal|example] \
                  [--installer=uv|pip|auto] \
-                 [--skip-install] [--yes] [--dry-run] [--no-native-host]
+                 [--skip-install] [--yes] [--dry-run] \
+                 [--no-native-host] [--no-skills]
 ```
 
 One-command upgrade. Same code path as `install-all` — re-runs
 `pip install --upgrade` (or `uv tool install`) for every NeuroDock MCP
-server, re-wires the detected MCP clients, and re-registers the
-optional native-messaging host. Exit codes match `install-all`:
-`0` ok, `1` an entrypoint is missing from PATH, `2` init failed.
+server, re-wires the detected MCP clients, re-registers the optional
+native-messaging host, and refreshes the per-neurotype skills (skip with
+`--no-skills`). Exit codes match `install-all`: `0` ok, `1` an
+entrypoint is missing from PATH, `2` init failed.
 
 ### `neurodock sync`
 

--- a/packages/cli/scripts/copy-assets.mjs
+++ b/packages/cli/scripts/copy-assets.mjs
@@ -4,20 +4,34 @@
  * Copyright (c) 2026 NeuroDock contributors.
  */
 /**
- * Copy non-TS assets from `src/assets/` and `packages/core/schemas/` into
- * `dist/assets/` after tsc.
+ * Copy non-TS assets from `src/assets/`, `packages/core/schemas/`, and the
+ * per-neurotype skills from `packages/skills/` into `dist/assets/` after tsc.
  *
  * tsc only emits the .ts -> .js transformation; the bundled Python hook
- * script, profile templates, and JSON schemas need to be copied separately
- * so the published npm package contains them. Without the schemas, `init`,
- * profile validation, and plugin validation all fail on a fresh `npx`
- * install because the resolver paths point at the workspace `core` package
- * which is not part of the cli tarball.
+ * script, profile templates, JSON schemas, and skill markdown need to be
+ * copied separately so the published npm package contains them. Without the
+ * schemas, `init`, profile validation, and plugin validation all fail on a
+ * fresh `npx` install because the resolver paths point at the workspace
+ * `core` package which is not part of the cli tarball. Likewise, without the
+ * skills, `neurodock install-skills` has nothing to copy.
+ *
+ * The skills copy is GENERATED here at build time (the destination lives
+ * under `dist/`, which is gitignored) so there is no committed third copy of
+ * the skill content to drift. `packages/skills/` stays the single source of
+ * truth, the Claude Code plugin copy is produced by `scripts/sync-skills.mjs`
+ * (+ its drift guard), and this build step produces the CLI tarball copy.
  *
  * Idempotent — runs after every build, overwrites destination.
  */
-import { cpSync, existsSync, mkdirSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -44,5 +58,49 @@ if (existsSync(coreSchemas)) {
 } else {
   process.stderr.write(
     `[copy-assets] no core schemas at ${coreSchemas}, skipping (init/validate will fail in a published tarball)\n`,
+  );
+}
+
+// --- skills (packages/skills/<name>/SKILL.md -> dist/assets/skills/) --------
+// Copy SKILL.md ONLY. Exclude tests/ (CI-only) and the author-facing
+// README.md / CHANGELOG.md, mirroring scripts/sync-skills.mjs so the CLI
+// tarball ships the same content the plugin does. Read-and-catch (no
+// existsSync-then-read) avoids a TOCTOU window.
+const skillsSource = resolve(cliRoot, "..", "skills");
+const distSkills = resolve(distAssets, "skills");
+
+function readSkillDirs(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return null;
+  }
+}
+
+const skillDirs = readSkillDirs(skillsSource);
+if (skillDirs === null) {
+  process.stderr.write(
+    `[copy-assets] no skills source at ${skillsSource}, skipping (install-skills will be empty in a published tarball)\n`,
+  );
+} else {
+  let copied = 0;
+  for (const name of skillDirs) {
+    const srcMd = join(skillsSource, name, "SKILL.md");
+    let content;
+    try {
+      content = readFileSync(srcMd, "utf8");
+    } catch {
+      // Not a skill (no SKILL.md) — skip silently.
+      continue;
+    }
+    const dstDir = join(distSkills, name);
+    mkdirSync(dstDir, { recursive: true });
+    writeFileSync(join(dstDir, "SKILL.md"), content);
+    copied += 1;
+  }
+  process.stdout.write(
+    `[copy-assets] bundled ${copied} skill(s) ${skillsSource} -> ${distSkills}\n`,
   );
 }

--- a/packages/cli/src/commands/install-all.ts
+++ b/packages/cli/src/commands/install-all.ts
@@ -9,6 +9,10 @@ import {
   runHostInstall as defaultRunHostInstall,
   type HostCommandResult,
 } from "./host.js";
+import {
+  runInstallSkills as defaultRunInstallSkills,
+  type InstallSkillsResult,
+} from "./install-skills.js";
 import type { ClientId } from "../types.js";
 
 export type InstallerKind = "uv" | "pip";
@@ -29,11 +33,25 @@ export interface InstallAllOptions {
    */
   readonly noNativeHost: boolean;
   /**
+   * When true, skip copying the per-neurotype skills into the client's
+   * personal-skills directory. Skills are installed by default so the
+   * happy path is one command; `--no-skills` opts out (mirrors
+   * `--no-native-host`).
+   */
+  readonly noSkills: boolean;
+  /**
    * Extra browser-extension ids to allow on the native host, on top of the
    * published store ids. Needed for a locally-loaded unpacked build, whose
    * id differs from the published one. Empty/omitted = published ids only.
    */
   readonly extensionIds?: ReadonlyArray<string>;
+}
+
+export interface SkillsOutcome {
+  /** "installed" = ran, "skipped" = --no-skills or dry-run, "failed" = error/exit!=0. */
+  readonly status: "installed" | "skipped" | "failed";
+  readonly result?: InstallSkillsResult;
+  readonly error?: string;
 }
 
 export interface NativeHostOutcome {
@@ -62,6 +80,7 @@ export interface InstallAllResult {
   readonly packages: ReadonlyArray<PackageOutcome>;
   readonly initResult: InitRunResult | null;
   readonly nativeHost: NativeHostOutcome;
+  readonly skills: SkillsOutcome;
   readonly messages: ReadonlyArray<string>;
   /** 0 = ok, 1 = install/path failure, 2 = init failure */
   readonly exitCode: 0 | 1 | 2;
@@ -84,6 +103,12 @@ export interface InstallAllDependencies {
    * touch the user's registry / config dirs.
    */
   readonly runHostInstall?: typeof defaultRunHostInstall;
+  /**
+   * Override the skills install step. Defaults to the real
+   * `runInstallSkills` from ./install-skills.js. Tests inject a stub so
+   * they don't touch the user's ~/.claude/skills dir.
+   */
+  readonly runInstallSkills?: typeof defaultRunInstallSkills;
 }
 
 export type SpawnFn = (
@@ -137,6 +162,7 @@ export async function runInstallAll(
   const spawn = deps.spawn ?? defaultSpawn;
   const init = deps.runInit ?? runInit;
   const hostInstall = deps.runHostInstall ?? defaultRunHostInstall;
+  const skillsInstall = deps.runInstallSkills ?? defaultRunInstallSkills;
   const messages: string[] = [];
 
   // Phase 1: pick installer.
@@ -168,11 +194,21 @@ export async function runInstallAll(
         "Would register the optional native-messaging host (browser extension <-> profile.yaml).",
       );
     }
+    if (options.noSkills) {
+      messages.push(
+        "Would skip the per-neurotype skills install (--no-skills).",
+      );
+    } else {
+      messages.push(
+        "Would install the per-neurotype skills into ~/.claude/skills (Claude Code / Claude Desktop).",
+      );
+    }
     return {
       installer: "dry-run",
       packages: [],
       initResult: null,
       nativeHost: { status: "skipped" },
+      skills: { status: "skipped" },
       messages,
       exitCode: 0,
     };
@@ -185,6 +221,7 @@ export async function runInstallAll(
       packages: [],
       initResult: null,
       nativeHost: { status: "skipped" },
+      skills: { status: "skipped" },
       messages,
       exitCode: 1,
     };
@@ -241,6 +278,7 @@ export async function runInstallAll(
       packages: outcomes,
       initResult: null,
       nativeHost: { status: "skipped" },
+      skills: { status: "skipped" },
       messages,
       exitCode: 2,
     };
@@ -251,6 +289,11 @@ export async function runInstallAll(
   // installs the browser extension, and surfacing a warning is friendlier
   // than failing the whole "first-time install" command.
   const nativeHost = installNativeHost(options, hostInstall, messages);
+
+  // Phase 3.6: install the per-neurotype skills (opt-out). Failure is
+  // non-fatal — the MCP servers are the core; skills are an enhancement —
+  // so a write hiccup in ~/.claude/skills should not fail the command.
+  const skills = await installSkills(options, skillsInstall, deps, messages);
 
   // Phase 4: summary + suggested prompts.
   const installedCount = outcomes.filter((o) => o.installed).length;
@@ -280,6 +323,7 @@ export async function runInstallAll(
     "  - Wired your MCP-aware clients (Claude Desktop / Claude Code / Cursor)",
   );
   messages.push(`  - ${describeNativeHostBullet(nativeHost)}`);
+  messages.push(`  - ${describeSkillsBullet(skills)}`);
   messages.push("");
   messages.push("Try one of these in your MCP client:");
   for (const p of SUGGESTED_PROMPTS) {
@@ -294,9 +338,58 @@ export async function runInstallAll(
     packages: outcomes,
     initResult,
     nativeHost,
+    skills,
     messages,
     exitCode,
   };
+}
+
+async function installSkills(
+  options: InstallAllOptions,
+  skillsInstall: typeof defaultRunInstallSkills,
+  deps: InstallAllDependencies,
+  messages: string[],
+): Promise<SkillsOutcome> {
+  messages.push("");
+  if (options.noSkills) {
+    messages.push("Skipping skills install (--no-skills).");
+    return { status: "skipped" };
+  }
+
+  messages.push(
+    "Installing per-neurotype skills (Claude Code / Claude Desktop)...",
+  );
+  try {
+    const result = await skillsInstall(
+      { client: options.client, dryRun: false, yes: options.yes },
+      deps.envOverrides ? { envOverrides: deps.envOverrides } : {},
+    );
+    for (const m of result.messages) messages.push(`  ${m}`);
+    return {
+      status: result.exitCode === 0 ? "installed" : "failed",
+      result,
+      ...(result.exitCode !== 0
+        ? { error: "skills install reported a non-zero exit" }
+        : {}),
+    };
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    messages.push(`  [warn] skills install failed: ${truncate(detail)}`);
+    messages.push(
+      "  This is optional — the MCP servers are wired regardless. Re-run 'neurodock install-skills' later.",
+    );
+    return { status: "failed", error: detail };
+  }
+}
+
+function describeSkillsBullet(outcome: SkillsOutcome): string {
+  if (outcome.status === "installed") {
+    return "Installed the per-neurotype skills into ~/.claude/skills (Claude Code / Claude Desktop)";
+  }
+  if (outcome.status === "failed") {
+    return "Skills install failed (optional — re-run 'neurodock install-skills' later)";
+  }
+  return "Skipped the per-neurotype skills (optional — run 'neurodock install-skills' to add them)";
 }
 
 function installNativeHost(

--- a/packages/cli/src/commands/install-skills.ts
+++ b/packages/cli/src/commands/install-skills.ts
@@ -1,0 +1,234 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * `neurodock install-skills` — copy the bundled per-neurotype skills into
+ * the user's client personal-skills directory so Claude Code / Claude
+ * Desktop discover them.
+ *
+ * Why this exists:
+ *
+ *   Marketplace/plugin users already get the skills bundled into the
+ *   Claude Code plugin (see `scripts/sync-skills.mjs`). Users who install
+ *   via `@neurodock/cli` only got the MCP servers wired — no skills. This
+ *   command closes that gap by copying the skills the CLI tarball ships
+ *   (under `dist/assets/skills/`) into `~/.claude/skills/neurodock-<name>/`.
+ *
+ * Target directories:
+ *
+ *   - Claude Code   -> ~/.claude/skills/   (personal skills)
+ *   - Claude Desktop -> ~/.claude/skills/  (same personal-skills dir)
+ *   - Cursor        -> skipped (no skills system today)
+ *
+ * Idempotent: re-running overwrites/refreshes each `SKILL.md` atomically.
+ */
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { atomicWriteOverwrite } from "../util/atomic-write.js";
+import { readEnv, type EnvSnapshot } from "../lib/env.js";
+import {
+  bundledSkillsCandidates,
+  clientSkillsDir,
+  discoverBundledSkills,
+  namespacedSkillDir,
+  readIfExists,
+  type BundledSkill,
+} from "../lib/skills.js";
+import type { ClientId } from "../types.js";
+
+export interface InstallSkillsOptions {
+  /** Which client's personal-skills dir to target, or `all`. */
+  readonly client: ClientId | "all";
+  readonly dryRun: boolean;
+  readonly yes: boolean;
+}
+
+export interface InstallSkillsDependencies {
+  /** Override the environment snapshot (for tests). */
+  readonly envOverrides?: Parameters<typeof readEnv>[0];
+  /**
+   * Override where the bundled skills live. Defaults to the first existing
+   * candidate from `bundledSkillsCandidates`. Tests inject a fake source.
+   */
+  readonly skillsSourceDir?: string;
+}
+
+export interface InstallSkillsResult {
+  readonly messages: ReadonlyArray<string>;
+  /** Number of (skill x client-target) copies written. */
+  readonly installed: number;
+  /** 0 = ok, 1 = no bundled skills found (packaging bug). */
+  readonly exitCode: 0 | 1;
+}
+
+/** Clients that have a personal-skills directory we can write to. */
+const SKILLS_CAPABLE: ReadonlyArray<ClientId> = [
+  "claude-code",
+  "claude-desktop",
+];
+
+const SKILLS_INCAPABLE: ReadonlyArray<ClientId> = ["cursor"];
+
+export async function runInstallSkills(
+  options: InstallSkillsOptions,
+  deps: InstallSkillsDependencies = {},
+): Promise<InstallSkillsResult> {
+  const env = readEnv(deps.envOverrides ?? {});
+  const messages: string[] = [];
+
+  // 1. Locate the bundled skills.
+  const sourceDir = resolveSkillsSource(deps, env);
+  const skills = discoverBundledSkills(sourceDir);
+  if (skills.length === 0) {
+    messages.push("[install-skills] could not find any bundled skills.");
+    messages.push(
+      "  This is a packaging bug — the skills should ship with @neurodock/cli " +
+        "(under dist/assets/skills/). Re-install the CLI or run a fresh build.",
+    );
+    return { messages, installed: 0, exitCode: 1 };
+  }
+
+  // 2. Resolve which client target dirs to write to. We do NOT gate on the
+  //    client config existing: skills live in ~/.claude/skills regardless of
+  //    whether the MCP config file is present, and the dir is shared anyway.
+  const targets = resolveTargets(options.client);
+
+  // 3. Skipped clients (e.g. Cursor) — clear notice, never an error.
+  const skipped = resolveSkipped(options.client);
+  for (const s of skipped) {
+    messages.push(
+      `Skipping ${s}: it has no skills system, so there is nowhere to install skills.`,
+    );
+  }
+
+  if (targets.length === 0) {
+    messages.push("No skills-capable client selected. Nothing to install.");
+    messages.push(
+      "Skills install into Claude Code / Claude Desktop's ~/.claude/skills directory.",
+    );
+    return { messages, installed: 0, exitCode: 0 };
+  }
+
+  // The personal-skills dir is shared between Claude Code and Claude Desktop,
+  // so de-duplicate the resolved paths to avoid copying the same files twice.
+  const skillsDirs = uniqueSkillsDirs(targets, env);
+
+  if (options.dryRun) {
+    messages.push("Dry run. No skills written.");
+    messages.push(
+      `Would install ${skills.length} skill(s) into ${skillsDirs.length} location(s):`,
+    );
+    for (const dir of skillsDirs) {
+      messages.push(`  ${dir}`);
+      for (const skill of skills) {
+        messages.push(`    + ${join(`neurodock-${skill.name}`, "SKILL.md")}`);
+      }
+    }
+    return { messages, installed: 0, exitCode: 0 };
+  }
+
+  // 4. Install.
+  let installed = 0;
+  messages.push(
+    `Installing ${skills.length} NeuroDock skill(s) into ${skillsDirs.length} location(s)...`,
+  );
+  for (const dir of skillsDirs) {
+    messages.push(`  ${dir}`);
+    for (const skill of skills) {
+      const line = installSkill(skill, dir);
+      messages.push(`    ${line.text}`);
+      if (line.ok) installed += 1;
+    }
+  }
+
+  messages.push("");
+  messages.push(
+    `Summary: installed ${installed} of ${
+      skills.length * skillsDirs.length
+    } skill copy(ies) across ${skillsDirs.length} location(s).`,
+  );
+  messages.push(
+    "Restart Claude Code / Claude Desktop so it discovers the new skills.",
+  );
+
+  return { messages, installed, exitCode: 0 };
+}
+
+interface InstallLine {
+  readonly ok: boolean;
+  readonly text: string;
+}
+
+function installSkill(skill: BundledSkill, skillsDir: string): InstallLine {
+  // Read-and-catch (no existsSync-then-read): the source SKILL.md was
+  // confirmed readable during discovery, but re-read defensively.
+  const content = readIfExists(skill.skillMd);
+  if (content === null) {
+    return {
+      ok: false,
+      text: `[skip] neurodock-${skill.name} — source SKILL.md disappeared`,
+    };
+  }
+  const destDir = namespacedSkillDir(skillsDir, skill.name);
+  const destFile = join(destDir, "SKILL.md");
+  try {
+    mkdirSync(destDir, { recursive: true });
+    atomicWriteOverwrite(destFile, content);
+    return { ok: true, text: `[ok]   neurodock-${skill.name}` };
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      text: `[fail] neurodock-${skill.name} — ${truncate(detail)}`,
+    };
+  }
+}
+
+function resolveSkillsSource(
+  deps: InstallSkillsDependencies,
+  env: EnvSnapshot,
+): string {
+  if (deps.skillsSourceDir !== undefined) return deps.skillsSourceDir;
+  // Pick the first candidate that actually contains a skill. We probe by
+  // discovery rather than existsSync to avoid a TOCTOU window.
+  for (const candidate of bundledSkillsCandidates(import.meta.url, env)) {
+    if (discoverBundledSkills(candidate).length > 0) return candidate;
+  }
+  // Fall back to the first candidate; discovery there will return [] and the
+  // caller reports the packaging-bug message.
+  return bundledSkillsCandidates(import.meta.url, env)[0] ?? "";
+}
+
+function resolveTargets(client: ClientId | "all"): ReadonlyArray<ClientId> {
+  if (client === "all") return SKILLS_CAPABLE;
+  if (SKILLS_CAPABLE.includes(client)) return [client];
+  return [];
+}
+
+function resolveSkipped(client: ClientId | "all"): ReadonlyArray<ClientId> {
+  if (client === "all") return SKILLS_INCAPABLE;
+  if (SKILLS_INCAPABLE.includes(client)) return [client];
+  return [];
+}
+
+function uniqueSkillsDirs(
+  clients: ReadonlyArray<ClientId>,
+  env: EnvSnapshot,
+): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  const dirs: string[] = [];
+  for (const client of clients) {
+    const dir = clientSkillsDir(client, env);
+    if (dir === null) continue;
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    dirs.push(dir);
+  }
+  return dirs;
+}
+
+function truncate(s: string, max = 120): string {
+  const first = s.split("\n")[0] ?? "";
+  return first.length > max ? `${first.slice(0, max - 1)}…` : first;
+}

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -43,6 +43,12 @@ export interface SetupOptions {
   readonly dryRun: boolean;
   readonly noNativeHost: boolean;
   /**
+   * Opt-out: skip copying the per-neurotype skills into the client's
+   * personal-skills directory. Off (skills installed) by default — see
+   * `install-all`'s `--no-skills`.
+   */
+  readonly noSkills: boolean;
+  /**
    * Opt-in: also register the standalone guardrail daemon at user-login
    * autostart. Off by default — see the module comment above.
    */
@@ -90,6 +96,7 @@ export async function runSetup(
     yes: options.yes,
     dryRun: options.dryRun,
     noNativeHost: options.noNativeHost,
+    noSkills: options.noSkills,
     ...(options.extensionIds ? { extensionIds: options.extensionIds } : {}),
   });
   messages.push(...installAllResult.messages);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import { runHostInstall, runHostUninstall } from "./commands/host.js";
 import { runInstallHooks } from "./commands/install-hooks.js";
 import { runGuardrailStatus } from "./commands/guardrail.js";
 import { runInstallAll, type InstallerChoice } from "./commands/install-all.js";
+import { runInstallSkills } from "./commands/install-skills.js";
 import { runSetup } from "./commands/setup.js";
 import { runExamples } from "./commands/examples.js";
 import {
@@ -130,6 +131,10 @@ export function buildProgram(): Command {
       "skip registering the optional native-messaging host (browser extension <-> profile.yaml)",
     )
     .option(
+      "--no-skills",
+      "skip copying the per-neurotype skills into ~/.claude/skills (Claude Code / Claude Desktop)",
+    )
+    .option(
       "--extension-id <id>",
       "extra browser-extension id to allow on the native host, e.g. a " +
         "locally-loaded unpacked build (repeatable; published store ids are " +
@@ -147,6 +152,8 @@ export function buildProgram(): Command {
         dryRun: boolean;
         // Commander inverts `--no-native-host`: presence of the flag sets this to false.
         nativeHost: boolean;
+        // Commander inverts `--no-skills`: presence of the flag sets this to false.
+        skills: boolean;
         extensionId: string[];
       }) => {
         const client = validateClient(opts.client);
@@ -160,6 +167,7 @@ export function buildProgram(): Command {
           yes: opts.yes === true,
           dryRun: opts.dryRun === true,
           noNativeHost: opts.nativeHost === false,
+          noSkills: opts.skills === false,
           ...(opts.extensionId.length > 0
             ? { extensionIds: opts.extensionId }
             : {}),
@@ -203,6 +211,10 @@ export function buildProgram(): Command {
       "skip registering the optional native-messaging host (browser extension <-> profile.yaml)",
     )
     .option(
+      "--no-skills",
+      "skip copying the per-neurotype skills into ~/.claude/skills (Claude Code / Claude Desktop)",
+    )
+    .option(
       "--daemon",
       "also register the optional standalone guardrail daemon at user-login " +
         "autostart (off by default — the Claude Code hook covers the common cases)",
@@ -226,6 +238,8 @@ export function buildProgram(): Command {
         dryRun: boolean;
         // Commander inverts `--no-native-host`: presence of the flag sets this to false.
         nativeHost: boolean;
+        // Commander inverts `--no-skills`: presence of the flag sets this to false.
+        skills: boolean;
         daemon: boolean;
         extensionId: string[];
       }) => {
@@ -240,6 +254,7 @@ export function buildProgram(): Command {
           yes: opts.yes === true,
           dryRun: opts.dryRun === true,
           noNativeHost: opts.nativeHost === false,
+          noSkills: opts.skills === false,
           daemon: opts.daemon === true,
           ...(opts.extensionId.length > 0
             ? { extensionIds: opts.extensionId }
@@ -249,6 +264,38 @@ export function buildProgram(): Command {
         process.exit(r.exitCode);
       },
     );
+
+  program
+    .command("install-skills")
+    .description(
+      "copy the per-neurotype NeuroDock skills into your client's personal " +
+        "skills directory (~/.claude/skills for Claude Code / Claude Desktop)",
+    )
+    .option(
+      "--client <id>",
+      "claude-desktop | claude-code | cursor | all",
+      "all",
+    )
+    .option(
+      "--dry-run",
+      "print what would be installed without writing anything",
+      false,
+    )
+    .option(
+      "--yes",
+      "answer yes to all prompts (idempotent re-runs refresh in place)",
+      false,
+    )
+    .action(async (opts: { client: string; dryRun: boolean; yes: boolean }) => {
+      const client = validateClient(opts.client);
+      const r = await runInstallSkills({
+        client,
+        dryRun: opts.dryRun === true,
+        yes: opts.yes === true,
+      });
+      for (const m of r.messages) print(m);
+      process.exit(r.exitCode);
+    });
 
   program
     .command("examples")
@@ -388,6 +435,10 @@ export function buildProgram(): Command {
       "--no-native-host",
       "skip re-registering the optional native-messaging host",
     )
+    .option(
+      "--no-skills",
+      "skip refreshing the per-neurotype skills in ~/.claude/skills (Claude Code / Claude Desktop)",
+    )
     .action(
       async (opts: {
         client: string;
@@ -397,6 +448,8 @@ export function buildProgram(): Command {
         yes: boolean;
         dryRun: boolean;
         nativeHost: boolean;
+        // Commander inverts `--no-skills`: presence of the flag sets this to false.
+        skills: boolean;
       }) => {
         const client = validateClient(opts.client);
         const profile = validateProfile(opts.profile);
@@ -409,6 +462,7 @@ export function buildProgram(): Command {
           yes: opts.yes === true,
           dryRun: opts.dryRun === true,
           noNativeHost: opts.nativeHost === false,
+          noSkills: opts.skills === false,
         });
         for (const m of r.messages) print(m);
         process.exit(r.exitCode);

--- a/packages/cli/src/lib/skills.ts
+++ b/packages/cli/src/lib/skills.ts
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * Skills-delivery helpers for `neurodock install-skills`.
+ *
+ * Two concerns live here, kept separate from the command body so they can
+ * be unit-tested and reused:
+ *
+ *   1. Locating the *bundled* skills inside the @neurodock/cli package
+ *      (shipped to `dist/assets/skills/<name>/SKILL.md` by
+ *      `scripts/copy-assets.mjs`, with dev/workspace fall-backs).
+ *   2. Resolving each MCP client's *personal skills directory* on disk.
+ *
+ * The personal-skills directory is the same for Claude Code and Claude
+ * Desktop — both read `~/.claude/skills/<name>/SKILL.md`. Cursor has no
+ * skills system, so it has no target (the caller skips it).
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ClientId } from "../types.js";
+import { type EnvSnapshot, readEnv } from "./env.js";
+
+/** A single bundled skill discovered in the CLI package. */
+export interface BundledSkill {
+  /** Source skill directory name, e.g. `adhd-daily-planner`. */
+  readonly name: string;
+  /** Absolute path to the skill's `SKILL.md`. */
+  readonly skillMd: string;
+}
+
+/**
+ * The personal-skills directory Claude Code AND Claude Desktop both read.
+ * Returns `null` for clients without a skills system (Cursor).
+ */
+export function clientSkillsDir(
+  client: ClientId,
+  env: EnvSnapshot = readEnv(),
+): string | null {
+  switch (client) {
+    case "claude-code":
+    case "claude-desktop":
+      // Both desktop and code discover *personal* skills from ~/.claude/skills.
+      return join(env.home, ".claude", "skills");
+    case "cursor":
+      // Cursor has no skills system today.
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Namespace an installed skill so it is collision-free and recognisably
+ * NeuroDock's: `<dir>/neurodock-<name>/`.
+ */
+export function namespacedSkillDir(skillsDir: string, name: string): string {
+  return join(skillsDir, `neurodock-${name}`);
+}
+
+/**
+ * Candidate locations for the bundled skills, in precedence order:
+ *
+ *   1. Published tarball: `dist/assets/skills/` (copy-assets.mjs target).
+ *      From `dist/commands/install-skills.js` that is `../assets/skills`.
+ *   2. Dev/workspace: the monorepo's `packages/skills/` source of truth,
+ *      so the command works under `tsx`/vitest without a prior build.
+ */
+export function bundledSkillsCandidates(
+  moduleUrl: string,
+  env: EnvSnapshot = readEnv(),
+): ReadonlyArray<string> {
+  // `here` is the calling module's dir: src/commands (tsx/vitest) or
+  // dist/commands (published). The candidates below cover both.
+  const here = dirname(fileURLToPath(moduleUrl));
+  return [
+    // Published tarball: dist/commands -> dist/assets/skills.
+    resolve(here, "..", "assets", "skills"),
+    // Monorepo dev: dist|src/commands -> packages/skills (up three levels).
+    resolve(here, "..", "..", "..", "skills"),
+    // Monorepo dev, one level deeper (defensive against nested build output).
+    resolve(here, "..", "..", "..", "..", "skills"),
+    join(env.cwd, "packages", "skills"),
+  ];
+}
+
+/** Names of files that must never ship as part of an installed skill. */
+const EXCLUDED_TOP_LEVEL_FILES = new Set(["README.md", "CHANGELOG.md"]);
+
+/**
+ * Enumerate bundled skills under `sourceDir`. A skill is any direct child
+ * directory that contains a readable `SKILL.md`. Returns an empty array if
+ * `sourceDir` is missing/unreadable (the caller treats that as a packaging
+ * bug).
+ *
+ * Read-and-catch throughout — no `existsSync`-then-read TOCTOU windows.
+ */
+export function discoverBundledSkills(
+  sourceDir: string,
+): ReadonlyArray<BundledSkill> {
+  let entries: ReadonlyArray<{ name: string; isDirectory: () => boolean }>;
+  try {
+    entries = readdirSync(sourceDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const skills: BundledSkill[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (EXCLUDED_TOP_LEVEL_FILES.has(entry.name)) continue;
+    const skillMd = join(sourceDir, entry.name, "SKILL.md");
+    if (readIfExists(skillMd) === null) continue;
+    skills.push({ name: entry.name, skillMd });
+  }
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Read a file's text, or null if absent — avoids a check-then-read race. */
+export function readIfExists(filePath: string): string | null {
+  try {
+    return readFileSync(filePath, "utf8");
+  } catch (err: unknown) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw err;
+  }
+}

--- a/packages/cli/tests/install-all.test.ts
+++ b/packages/cli/tests/install-all.test.ts
@@ -14,6 +14,27 @@ import {
   type SpawnFn,
   type SpawnResult,
 } from "../src/commands/install-all.js";
+import type { InstallSkillsResult } from "../src/commands/install-skills.js";
+
+function makeFakeInstallSkills(): {
+  fn: () => Promise<InstallSkillsResult>;
+  calls: number;
+} {
+  let calls = 0;
+  return {
+    get calls() {
+      return calls;
+    },
+    fn: () => {
+      calls += 1;
+      return Promise.resolve({
+        messages: ["  ~/.claude/skills", "    [ok]   neurodock-fake-skill"],
+        installed: 6,
+        exitCode: 0 as const,
+      });
+    },
+  };
+}
 
 function makeSandbox(): { home: string; cwd: string; cleanup: () => void } {
   const root = mkdtempSync(join(tmpdir(), "neurodock-installall-"));
@@ -131,6 +152,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: true,
         noNativeHost: true,
+        noSkills: true,
       },
       {
         spawn,
@@ -183,6 +205,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: true,
+        noSkills: true,
       },
       {
         spawn,
@@ -232,6 +255,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: true,
+        noSkills: true,
       },
       {
         spawn,
@@ -276,6 +300,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: true,
+        noSkills: true,
       },
       {
         spawn,
@@ -325,6 +350,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: true,
+        noSkills: true,
       },
       {
         spawn,
@@ -358,6 +384,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: true,
+        noSkills: true,
       },
       {
         spawn,
@@ -391,6 +418,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: true,
+        noSkills: true,
       },
       {
         spawn,
@@ -446,6 +474,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: false,
+        noSkills: true,
       },
       {
         spawn,
@@ -499,6 +528,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: false,
+        noSkills: true,
         extensionIds: ["devunpackedid"],
       },
       {
@@ -544,6 +574,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: true,
+        noSkills: true,
       },
       {
         spawn,
@@ -569,6 +600,123 @@ describe("neurodock install-all", () => {
     expect(joined).toContain("Skipped the native-messaging host");
   });
 
+  it("happy path: install-all also installs the per-neurotype skills", async () => {
+    const { spawn } = makeFakeSpawn({ uvAvailable: true });
+    const fakeSkills = makeFakeInstallSkills();
+    const fakeHostInstall = (): {
+      platform: string;
+      outcomes: ReadonlyArray<{
+        browser: string;
+        manifestPath: string;
+        action: "create" | "skip" | "update" | "remove";
+        detail?: string;
+      }>;
+    } => ({ platform: "linux", outcomes: [] });
+
+    const r = await runInstallAll(
+      {
+        client: "claude-code",
+        profile: "minimal",
+        installer: "auto",
+        skipInstall: false,
+        yes: true,
+        dryRun: false,
+        noNativeHost: true,
+        noSkills: false,
+      },
+      {
+        spawn,
+        runHostInstall: fakeHostInstall,
+        runInstallSkills: fakeSkills.fn,
+        envOverrides: {
+          platform: "linux",
+          home: sandbox.home,
+          cwd: sandbox.cwd,
+          user: "tester",
+          env: {
+            NEURODOCK_PROFILE_PATH: join(sandbox.home, "profile.yaml"),
+          } as NodeJS.ProcessEnv,
+        },
+      },
+    );
+
+    expect(fakeSkills.calls).toBe(1);
+    expect(r.exitCode).toBe(0);
+    const joined = r.messages.join("\n");
+    expect(joined).toContain("Installing per-neurotype skills");
+    expect(joined).toContain("neurodock-fake-skill");
+    expect(joined).toContain("Installed the per-neurotype skills");
+  });
+
+  it("--no-skills skips the skills install", async () => {
+    const { spawn } = makeFakeSpawn({ uvAvailable: true });
+    const fakeSkills = makeFakeInstallSkills();
+
+    const r = await runInstallAll(
+      {
+        client: "claude-code",
+        profile: "minimal",
+        installer: "auto",
+        skipInstall: false,
+        yes: true,
+        dryRun: false,
+        noNativeHost: true,
+        noSkills: true,
+      },
+      {
+        spawn,
+        runInstallSkills: fakeSkills.fn,
+        envOverrides: {
+          platform: "linux",
+          home: sandbox.home,
+          cwd: sandbox.cwd,
+          user: "tester",
+          env: {
+            NEURODOCK_PROFILE_PATH: join(sandbox.home, "profile.yaml"),
+          } as NodeJS.ProcessEnv,
+        },
+      },
+    );
+
+    expect(fakeSkills.calls).toBe(0);
+    expect(r.exitCode).toBe(0);
+    const joined = r.messages.join("\n");
+    expect(joined).toContain("Skipping skills install");
+    expect(joined).toContain("--no-skills");
+  });
+
+  it("--dry-run mentions the skills step", async () => {
+    const { spawn } = makeFakeSpawn({ uvAvailable: true });
+
+    const r = await runInstallAll(
+      {
+        client: "claude-code",
+        profile: "minimal",
+        installer: "auto",
+        skipInstall: false,
+        yes: true,
+        dryRun: true,
+        noNativeHost: true,
+        noSkills: false,
+      },
+      {
+        spawn,
+        envOverrides: {
+          platform: "linux",
+          home: sandbox.home,
+          cwd: sandbox.cwd,
+          user: "tester",
+          env: {
+            NEURODOCK_PROFILE_PATH: join(sandbox.home, "profile.yaml"),
+          } as NodeJS.ProcessEnv,
+        },
+      },
+    );
+
+    expect(r.exitCode).toBe(0);
+    expect(r.messages.join("\n").toLowerCase()).toContain("skill");
+  });
+
   it("native-host failure emits a warning but does not fail the whole command", async () => {
     const { spawn } = makeFakeSpawn({ uvAvailable: true });
     const fakeHostInstall = (): {
@@ -592,6 +740,7 @@ describe("neurodock install-all", () => {
         yes: true,
         dryRun: false,
         noNativeHost: false,
+        noSkills: true,
       },
       {
         spawn,
@@ -618,5 +767,47 @@ describe("neurodock install-all", () => {
     expect(joined).toContain("native-messaging host install failed");
     expect(joined).toContain("optional");
     expect(joined).toContain("Native-messaging host install failed");
+  });
+
+  it("skills-install failure emits a warning but does not fail the whole command", async () => {
+    const { spawn } = makeFakeSpawn({ uvAvailable: true });
+    const throwingSkills = (): Promise<InstallSkillsResult> => {
+      throw new Error("permission denied writing ~/.claude/skills");
+    };
+
+    const r = await runInstallAll(
+      {
+        client: "claude-code",
+        profile: "minimal",
+        installer: "auto",
+        skipInstall: false,
+        yes: true,
+        dryRun: false,
+        noNativeHost: true,
+        noSkills: false,
+      },
+      {
+        spawn,
+        runInstallSkills: throwingSkills,
+        envOverrides: {
+          platform: "linux",
+          home: sandbox.home,
+          cwd: sandbox.cwd,
+          user: "tester",
+          env: {
+            NEURODOCK_PROFILE_PATH: join(sandbox.home, "profile.yaml"),
+          } as NodeJS.ProcessEnv,
+        },
+      },
+    );
+
+    expect(r.skills.status).toBe("failed");
+    expect(r.skills.error).toContain("permission denied");
+    // Whole command stays exit 0 — the MCP servers are wired regardless; the
+    // per-neurotype skills are an optional convenience.
+    expect(r.exitCode).toBe(0);
+    const joined = r.messages.join("\n");
+    expect(joined).toContain("[warn] skills install failed");
+    expect(joined).toContain("optional");
   });
 });

--- a/packages/cli/tests/install-skills.test.ts
+++ b/packages/cli/tests/install-skills.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runInstallSkills } from "../src/commands/install-skills.js";
+
+interface Sandbox {
+  readonly root: string;
+  readonly home: string;
+  readonly cwd: string;
+  /** A fake "bundled skills" source dir under the sandbox. */
+  readonly skillsSource: string;
+  readonly cleanup: () => void;
+}
+
+const SKILL_NAMES = [
+  "adhd-daily-planner",
+  "asd-meeting-translator",
+  "audhd-context-recovery",
+  "hyperfocus-formatter",
+  "ocd-decision-finalizer",
+  "visual-organizer",
+];
+
+function makeSandbox(): Sandbox {
+  const root = mkdtempSync(join(tmpdir(), "neurodock-installskills-"));
+  const home = join(root, "home");
+  const cwd = join(root, "cwd");
+  const skillsSource = join(root, "bundled-skills");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(cwd, { recursive: true });
+  // Seed a fake bundled-skills source mirroring the published dist layout:
+  // one SKILL.md per skill, with author docs + tests that must NOT be copied.
+  for (const name of SKILL_NAMES) {
+    const dir = join(skillsSource, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "SKILL.md"),
+      `---\nname: ${name}\n---\nbody for ${name}\n`,
+    );
+  }
+  return {
+    root,
+    home,
+    cwd,
+    skillsSource,
+    cleanup: () => {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+function envFor(sandbox: Sandbox): {
+  platform: "linux";
+  home: string;
+  cwd: string;
+  user: string;
+  env: NodeJS.ProcessEnv;
+} {
+  return {
+    platform: "linux",
+    home: sandbox.home,
+    cwd: sandbox.cwd,
+    user: "tester",
+    env: {} as NodeJS.ProcessEnv,
+  };
+}
+
+describe("neurodock install-skills", () => {
+  let sandbox: Sandbox;
+
+  beforeEach(() => {
+    sandbox = makeSandbox();
+  });
+
+  afterEach(() => sandbox.cleanup());
+
+  it("copies every bundled SKILL.md into ~/.claude/skills/neurodock-<name>/", async () => {
+    const r = await runInstallSkills(
+      { client: "all", dryRun: false, yes: true },
+      { envOverrides: envFor(sandbox), skillsSourceDir: sandbox.skillsSource },
+    );
+
+    expect(r.exitCode).toBe(0);
+    for (const name of SKILL_NAMES) {
+      const dest = join(
+        sandbox.home,
+        ".claude",
+        "skills",
+        `neurodock-${name}`,
+        "SKILL.md",
+      );
+      expect(existsSync(dest)).toBe(true);
+      expect(readFileSync(dest, "utf8")).toContain(`body for ${name}`);
+    }
+  });
+
+  it("never copies tests/, README.md, or CHANGELOG.md from the source", async () => {
+    // Add author-facing junk to one skill source.
+    const dir = join(sandbox.skillsSource, "adhd-daily-planner");
+    writeFileSync(join(dir, "README.md"), "author readme\n");
+    writeFileSync(join(dir, "CHANGELOG.md"), "author changelog\n");
+    mkdirSync(join(dir, "tests"), { recursive: true });
+    writeFileSync(join(dir, "tests", "case1.md"), "test case\n");
+
+    await runInstallSkills(
+      { client: "all", dryRun: false, yes: true },
+      { envOverrides: envFor(sandbox), skillsSourceDir: sandbox.skillsSource },
+    );
+
+    const installed = join(
+      sandbox.home,
+      ".claude",
+      "skills",
+      "neurodock-adhd-daily-planner",
+    );
+    expect(existsSync(join(installed, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(installed, "README.md"))).toBe(false);
+    expect(existsSync(join(installed, "CHANGELOG.md"))).toBe(false);
+    expect(existsSync(join(installed, "tests"))).toBe(false);
+  });
+
+  it("--dry-run writes nothing and reports the planned targets", async () => {
+    const r = await runInstallSkills(
+      { client: "all", dryRun: true, yes: true },
+      { envOverrides: envFor(sandbox), skillsSourceDir: sandbox.skillsSource },
+    );
+
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(join(sandbox.home, ".claude", "skills"))).toBe(false);
+    const joined = r.messages.join("\n");
+    expect(joined).toContain("Dry run");
+    expect(joined).toContain("neurodock-adhd-daily-planner");
+  });
+
+  it("is idempotent — re-running refreshes content without error", async () => {
+    const opts = { client: "all", dryRun: false, yes: true } as const;
+    const deps = {
+      envOverrides: envFor(sandbox),
+      skillsSourceDir: sandbox.skillsSource,
+    };
+    const first = await runInstallSkills(opts, deps);
+    expect(first.exitCode).toBe(0);
+
+    // Mutate the source so we can assert the refresh actually overwrote.
+    writeFileSync(
+      join(sandbox.skillsSource, "visual-organizer", "SKILL.md"),
+      "---\nname: visual-organizer\n---\nUPDATED body\n",
+    );
+    const second = await runInstallSkills(opts, deps);
+    expect(second.exitCode).toBe(0);
+
+    const dest = join(
+      sandbox.home,
+      ".claude",
+      "skills",
+      "neurodock-visual-organizer",
+      "SKILL.md",
+    );
+    expect(readFileSync(dest, "utf8")).toContain("UPDATED body");
+  });
+
+  it("skips Cursor with a clear notice (no skills system) and does not error", async () => {
+    const r = await runInstallSkills(
+      { client: "cursor", dryRun: false, yes: true },
+      { envOverrides: envFor(sandbox), skillsSourceDir: sandbox.skillsSource },
+    );
+
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(join(sandbox.home, ".claude", "skills"))).toBe(false);
+    const joined = r.messages.join("\n");
+    expect(joined.toLowerCase()).toContain("cursor");
+    expect(joined.toLowerCase()).toContain("skip");
+  });
+
+  it("installs into the shared ~/.claude/skills for claude-desktop too", async () => {
+    const r = await runInstallSkills(
+      { client: "claude-desktop", dryRun: false, yes: true },
+      { envOverrides: envFor(sandbox), skillsSourceDir: sandbox.skillsSource },
+    );
+
+    expect(r.exitCode).toBe(0);
+    const dest = join(
+      sandbox.home,
+      ".claude",
+      "skills",
+      "neurodock-adhd-daily-planner",
+      "SKILL.md",
+    );
+    expect(existsSync(dest)).toBe(true);
+  });
+
+  it("returns exit 1 with a packaging-bug message when no bundled skills are found", async () => {
+    const r = await runInstallSkills(
+      { client: "all", dryRun: false, yes: true },
+      {
+        envOverrides: envFor(sandbox),
+        skillsSourceDir: join(sandbox.root, "does-not-exist"),
+      },
+    );
+
+    expect(r.exitCode).toBe(1);
+    expect(r.messages.join("\n").toLowerCase()).toContain("packaging");
+  });
+
+  it("prints a per-skill installed summary line", async () => {
+    const r = await runInstallSkills(
+      { client: "all", dryRun: false, yes: true },
+      { envOverrides: envFor(sandbox), skillsSourceDir: sandbox.skillsSource },
+    );
+
+    const joined = r.messages.join("\n");
+    expect(joined).toMatch(/6 skill/);
+    expect(joined).toContain(".claude");
+  });
+});

--- a/packages/cli/tests/setup.test.ts
+++ b/packages/cli/tests/setup.test.ts
@@ -17,6 +17,7 @@ function makeInstallAllResult(
     packages: [],
     initResult: null,
     nativeHost: { status: "installed" },
+    skills: { status: "installed" },
     messages: ["[install-all] fake message"],
     exitCode: 0,
     ...overrides,
@@ -78,6 +79,7 @@ function makeOptions(overrides: Partial<SetupOptions> = {}): SetupOptions {
     yes: false,
     dryRun: false,
     noNativeHost: false,
+    noSkills: false,
     daemon: false,
     ...overrides,
   };
@@ -106,6 +108,7 @@ describe("neurodock setup", () => {
         skipInstall: true,
         yes: true,
         noNativeHost: true,
+        noSkills: true,
       }),
       stubs.deps,
     );
@@ -118,7 +121,18 @@ describe("neurodock setup", () => {
       yes: true,
       dryRun: false,
       noNativeHost: true,
+      noSkills: true,
     });
+  });
+
+  it("threads noSkills through to install-all (default installs skills)", async () => {
+    const on = makeStubs();
+    await runSetup(makeOptions(), on.deps);
+    expect(on.installAllCalls[0]?.noSkills).toBe(false);
+
+    const off = makeStubs();
+    await runSetup(makeOptions({ noSkills: true }), off.deps);
+    expect(off.installAllCalls[0]?.noSkills).toBe(true);
   });
 
   it("--dry-run propagates to both underlying runners", async () => {

--- a/packages/remote/README.md
+++ b/packages/remote/README.md
@@ -57,6 +57,16 @@ enforced in code and pinned by tests against `REMOTE_TOOL_NAMES`.
 > PyPI (the local install path via `@neurodock/cli` is unchanged). Local-only
 > tools remain available exactly as before through the stdio servers.
 
+### Skills delivery (hosted/remote users)
+
+The remote server exposes **tools**, not skills. Skills are markdown the
+client reads locally, so the remote endpoint never delivers them. Hosted/remote
+users get the per-neurotype skills the same way local users do: install the
+**Claude Code marketplace plugin** (which bundles them) or run
+`neurodock install-skills` from `@neurodock/cli`, which copies each skill into
+`~/.claude/skills/neurodock-<name>/SKILL.md` for Claude Code / Claude Desktop.
+See [packages/skills/README.md](../skills/README.md) for the delivery paths.
+
 ## Run locally
 
 ```bash

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -19,9 +19,18 @@ The sync copies every `packages/skills/<name>/` that contains a `SKILL.md`, **ex
 
 A **drift guard** in `@neurodock/repo-tooling` (`packages/repo-tooling/tests/skills-bundle-drift.test.ts`) runs in the CI `TypeScript (lint, typecheck, test, build)` job. It fails the build if any source skill is missing from the plugin or differs from its bundled copy, so the bundle can never silently fall out of sync. The same invariant is enforced locally by `scripts/sync-skills.mjs --check`.
 
-### CLI install (coming in a follow-up)
+### CLI install (implemented)
 
-A `@neurodock/cli` install path that bundles these skills into the local substrate is planned as a separate change. Until it lands, the Claude Code plugin is the user-facing delivery path.
+Users who install via `@neurodock/cli` (rather than the marketplace plugin) get the skills too. Each source skill's `SKILL.md` is bundled into the published CLI tarball (generated at build time into `dist/assets/skills/<name>/SKILL.md` by `packages/cli/scripts/copy-assets.mjs` — the destination is under `dist/`, which is gitignored, so there is no committed third copy to drift). The command that delivers them:
+
+```bash
+neurodock install-skills            # copy skills into ~/.claude/skills/neurodock-<name>/
+neurodock install-skills --dry-run  # print the planned targets, write nothing
+```
+
+`install-skills` copies each skill into the client's personal skills directory — `~/.claude/skills/` for both Claude Code and Claude Desktop — namespaced as `neurodock-<name>/SKILL.md`. Cursor has no skills system and is skipped with a notice. It is idempotent (re-running refreshes in place) and runs automatically as part of `neurodock install-all` / `neurodock setup` / `neurodock update` unless you pass `--no-skills`.
+
+`packages/skills/` remains the single source of truth: the plugin copy is produced by `scripts/sync-skills.mjs` (with its drift guard), and the CLI tarball copy is produced by the CLI build step — both copy `SKILL.md` only and exclude `tests/`, `README.md`, and `CHANGELOG.md`.
 
 ## Launch skills
 


### PR DESCRIPTION
## What

Completes R8 (skills delivery). Part A bundled the per-neurotype skills into the Claude
Code marketplace plugin; this part closes the gap for users who install via **`@neurodock/cli`**.

- The CLI build copies `packages/skills/*/SKILL.md` into the package at
  `dist/assets/skills/` (gitignored — generated, no committed third copy).
- New `neurodock install-skills` copies them into the client personal skills dir
  (`~/.claude/skills/neurodock-<name>/`) for Claude Code / Claude Desktop; **Cursor is
  skipped with a notice**, never an error.
- Wired into `install-all` / `setup` / `update` with an opt-out **`--no-skills`** flag,
  mirroring `--no-native-host`. Best-effort: a skills failure warns and keeps the overall
  install at exit 0 (the MCP servers are wired regardless).
- Docs: cli/skills/remote READMEs, the canonical CLI reference (recounted to **22**
  commands, added `install-skills` + the previously-undocumented `setup` and
  `guardrail status`, `--no-skills` flags), and onboarding (`first-skill`/`installation`).

After A (merged) + this, **all per-neurotype skills reach users on every install path**:
marketplace plugin, CLI, and documented for hosted-remote users.

## Review

`cli-expert` (TDD, RED→GREEN), reviewed by `code-reviewer` (APPROVE, 0 critical/high) and
`docs-curator` (twice — implementation docs + a final accuracy pass on the reference,
independently recounting the 22 commands and verifying every flag against `src/index.ts`).
Fixes applied: summary now reports the true installed count; corrected path comments; added
a non-fatal skills-failure test; fixed a stale in-file version contradiction.

## Test plan

- [x] `pnpm --filter @neurodock/cli typecheck` clean
- [x] `pnpm --filter @neurodock/cli test` → 132/132 (incl. new install-skills + non-fatal-failure tests)
- [x] `pnpm --filter @neurodock/cli build` bundles 6 skills into `dist/assets/skills/`
- [x] `pnpm --filter @neurodock/docs build` → 54 pages, no MDX errors
- [x] `install-skills --dry-run` / `install-all --dry-run` show skills; Cursor skipped
- [x] `wrangler.jsonc` excluded