### PR TITLE
feat: add eight optional per-neurotype profile fields (r5 schema)

### DIFF
--- a/.changeset/spotty-rivers-tailor.md
+++ b/.changeset/spotty-rivers-tailor.md
@@ -1,0 +1,45 @@
+---
+"@neurodock/core": minor
+---
+
+add eight optional per-neurotype tailoring fields to the profile schema (adr 0011)
+
+promotes the eight fields previously tracked as "candidate fields for a future
+schema bump" in `profiles/README.md` from documented intent to real, optional,
+additive schema fields. per adr 0011 (and the additive-only contract of adr
+0004 / adr 0005), every field is optional, never required, and never
+type-narrowing, so an existing v0.1.0 profile that carries none of them keeps
+validating unchanged.
+
+under `preferences`:
+
+- `line_height_hint` — `"compact" | "default" | "relaxed"` categorical
+  line-height hint for rich-text clients, alongside `reading_font_hint`.
+- `voice_input_preferred` — boolean; when true, skills keep examples
+  copy-pasteable as a single block (dictation-first users).
+
+under `chronometric`:
+
+- `calendar_phase` — `"teaching" | "marking" | "exam" | "deadlines" | "break"`.
+- `weekday_overrides` — per-weekday overrides for `end_of_day_local` and
+  `hyperfocus_break_minutes` (weekday-keyed object; override objects reject
+  unknown keys).
+- `protected_windows` — list of `{ start, end, label? }` local-time ranges
+  where the hyperfocus monitor should hard-surface rather than nudge.
+- `deadline_cluster_awareness` — boolean.
+- `time_buffer_multiplier` — number 1.0–3.0, neutral default 1.0.
+- `motor_fatigue_aware` — boolean, neutral default false.
+
+the schema stays at `$id` `.../profile/v0.1.0/...`: per adr 0004 the `$id`
+only changes on a major bump, and additive optional fields are backward-
+compatible within the v0.1.x line. no `$id` references elsewhere in the repo
+needed changing.
+
+also exports hand-written `Profile` typescript types (with the new optional
+fields) from `@neurodock/core`, linked to the schema by a runtime-assertion
+test so the two cannot drift. no runtime dependency added — ajv / ajv-formats /
+yaml are dev-only test dependencies.
+
+note for the release commit: this changeset bumps `package.json` to `0.1.0`;
+the `version` constant in `src/index.ts` must be bumped to match in the same
+commit (the two are joined).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,9 @@
     "clean": "rm -rf dist .turbo"
   },
   "devDependencies": {
-    "vitest": "^3.2.6"
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "vitest": "^3.2.6",
+    "yaml": "^2.8.3"
   }
 }

--- a/packages/core/schemas/profile.example.yaml
+++ b/packages/core/schemas/profile.example.yaml
@@ -62,6 +62,15 @@ preferences:
   #   system_default          — your OS choice
   reading_font_hint: "atkinson_hyperlegible"
 
+  # How much space do you want between lines of text?
+  # This is a hint for apps that show NeuroDock's output as styled text.
+  # Options:
+  #   compact  — lines sit closer together (more text fits on screen)
+  #   default  — the app's own everyday spacing
+  #   relaxed  — extra space between lines; pairs with atkinson_hyperlegible
+  # Leave it out and the app just uses its own spacing.
+  line_height_hint: "relaxed"
+
   # Do you want visual animations turned on?
   # Options:
   #   reduced  — no animations (default; safest for vestibular sensitivity)

--- a/packages/core/schemas/profile.schema.json
+++ b/packages/core/schemas/profile.schema.json
@@ -90,6 +90,17 @@
           "enum": ["reduced", "system", "full"],
           "default": "reduced",
           "description": "Animation policy hint. 'reduced' = no animation, no transitions, no auto-scroll (default). 'system' = follow the OS prefers-reduced-motion setting. 'full' = animations allowed."
+        },
+        "line_height_hint": {
+          "type": "string",
+          "enum": ["compact", "default", "relaxed"],
+          "description": "Optional (added v0.1.x per ADR 0011). Line-height hint for any client that renders NeuroDock output as HTML or rich text, sitting alongside 'reading_font_hint'. A categorical band rather than a raw multiplier so each client maps it to its own CSS line-height. CONFORMANCE FLOOR: clients MUST NOT render body-paragraph line spacing below 1.5 regardless of band (WCAG 1.4.8 Visual Presentation / 1.4.12 Text Spacing). The bands are advisory line-height ratios relative to font size for body paragraphs; headings and other non-body text MAY be tighter. Per-band anchors: 'compact' ≈ 1.5 — the floor itself, a power-user opt-in for more text per viewport that still respects the 1.5 minimum (for readers who find generous spacing scatters their eye-line and prefer denser text, the dual of why 'relaxed' exists); 'default' ≈ 1.5–1.6 — the client's own comfortable default within the conformant range; 'relaxed' ≈ 1.65–1.8 — generous line spacing (~1.65 is the project body line-height) and the evidence-based pairing with 'atkinson_hyperlegible' for dyslexia, which is why dyslexia-aware presets set it. Read-when-present, neutral-when-absent: an untailored client ignores it; absence is NOT an error. The loader applies no value when absent. Self-ID never gates this (ADR 0004/0011).",
+          "examples": ["relaxed", "default"]
+        },
+        "voice_input_preferred": {
+          "type": "boolean",
+          "description": "Optional (added v0.1.x per ADR 0011). When true, the user predominantly dictates rather than types for sustained work (common for dyspraxic users). Downstream skills that emit code or structured text MUST NOT assume the user can hand-edit fiddly punctuation cheaply: keep examples copy-pasteable as a single block rather than scattered across inline edits. Read by the shaping layer; absence means 'no preference' and is the same as today's behaviour. Consumer pending; schema-only in this release.",
+          "examples": [true]
         }
       }
     },
@@ -121,6 +132,62 @@
           "enum": ["auto_close", "error"],
           "default": "auto_close",
           "description": "Behaviour of mark_session_start when a prior session is still open. 'auto_close' (default, charitable) closes the prior session and returns its metadata so the skill can surface it. 'error' refuses to start a new session until the prior one is explicitly closed. See ADR 0001, open question 3."
+        },
+        "calendar_phase": {
+          "type": "string",
+          "enum": ["teaching", "marking", "exam", "deadlines", "break"],
+          "description": "Optional (added v0.1.x per ADR 0011). Self-declared phase of the user's term/semester so skills can shift defaults across the calendar: tighter break cadence during 'marking' / 'exam', deadline-cluster awareness during 'deadlines' (e.g. week 12), looser during 'break'. Surfaced by the educator-semester and student-university presets. The neurotype is never a branch point (ADR 0004/0011); this is a user input the shaping layer reads, neutral-when-absent. Consumer pending (mcp-chronometric); schema-only in this release.",
+          "examples": ["teaching", "marking"]
+        },
+        "weekday_overrides": {
+          "type": "object",
+          "description": "Optional (added v0.1.x per ADR 0011). Per-weekday overrides for 'end_of_day_local' and 'hyperfocus_break_minutes', covering late-office-hours, Wednesday-afternoon-class, and library-day-vs-lecture-day patterns without forcing a whole-profile swap. Keys are lowercase English weekday names; only the seven weekdays are accepted (a misspelt key is a silent no-op, so unknown keys are rejected here rather than preserved). Each value is an override object reusing the same patterns/ranges as the top-level chronometric fields; an empty override object is valid. A weekday absent from the map inherits the top-level chronometric values. Consumer pending (mcp-chronometric); schema-only in this release.",
+          "additionalProperties": false,
+          "properties": {
+            "monday": { "$ref": "#/$defs/weekdayOverride" },
+            "tuesday": { "$ref": "#/$defs/weekdayOverride" },
+            "wednesday": { "$ref": "#/$defs/weekdayOverride" },
+            "thursday": { "$ref": "#/$defs/weekdayOverride" },
+            "friday": { "$ref": "#/$defs/weekdayOverride" },
+            "saturday": { "$ref": "#/$defs/weekdayOverride" },
+            "sunday": { "$ref": "#/$defs/weekdayOverride" }
+          },
+          "examples": [
+            {
+              "wednesday": { "end_of_day_local": "18:30" },
+              "saturday": { "hyperfocus_break_minutes": 120 }
+            }
+          ]
+        },
+        "protected_windows": {
+          "type": "array",
+          "description": "Optional (added v0.1.x per ADR 0011). Local-time ranges (lunch, post-EOD evening, scheduled lectures, lab times) where the hyperfocus monitor should HARD-SURFACE rather than nudge — the strict rung of the escalation ladder, applied because the window itself is protected, not because a session has run long. Each entry is a 'HH:MM'-'HH:MM' range with an optional human label; ranges are interpreted in the user's local timezone and a range whose 'end' is earlier than its 'start' is treated as wrapping past midnight by the consumer. An empty list is valid. Consumer pending (mcp-chronometric); schema-only in this release.",
+          "items": { "$ref": "#/$defs/protectedWindow" },
+          "examples": [
+            [
+              { "start": "12:00", "end": "12:30", "label": "lunch" },
+              { "start": "17:00", "end": "23:59", "label": "evening" }
+            ]
+          ]
+        },
+        "deadline_cluster_awareness": {
+          "type": "boolean",
+          "description": "Optional (added v0.1.x per ADR 0011). When true, planning skills surface deadline proximity and shift the break-cadence math when work clusters (e.g. three assignments due in a single week). Set by the student-university preset. Read by planning skills; absence means today's behaviour (no clustering adjustment). Consumer pending (task-fractionator); schema-only in this release.",
+          "examples": [true]
+        },
+        "time_buffer_multiplier": {
+          "type": "number",
+          "minimum": 1.0,
+          "maximum": 3.0,
+          "default": 1.0,
+          "description": "Optional (added v0.1.x per ADR 0011). Multiplier that pads presented time estimates because real-world execution time for motor-heavy tasks is systematically underestimated (e.g. 1.3 = +30%, the value the dyspraxia preset sets). Range 1.0..3.0; the neutral default 1.0 reproduces today's unpadded behaviour so an untouched profile is unchanged. Read by planning skills to scale the estimates they present; the underlying estimate is not altered. Consumer pending (task-fractionator); schema-only in this release.",
+          "examples": [1.0, 1.3]
+        },
+        "motor_fatigue_aware": {
+          "type": "boolean",
+          "default": false,
+          "description": "Optional (added v0.1.x per ADR 0011). When true, the hyperfocus monitor weights motor activity (click / keystroke / window-switch volume) into the fatigue signal rather than relying on continuous-session length alone — cognitive sharpness and motor exhaustion can coexist (set by the dyspraxia preset). The neutral default false reproduces today's session-length-only behaviour. Reading motor activity is still gated by 'privacy.os_idle_consent' and the relevant OS-input consents; this flag only declares the preference. Consumer pending (mcp-chronometric); schema-only in this release.",
+          "examples": [true]
         }
       }
     },
@@ -172,6 +239,55 @@
           "type": "boolean",
           "default": false,
           "description": "Consent for mcp-chronometric.idle_status to read OS idle time. False (default) means idle_status returns 'consent_granted: false' and 'hyperfocus_signal: unknown' without error, per ADR 0001 cross-cutting decision 5."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "weekdayOverride": {
+      "type": "object",
+      "description": "Per-weekday override for the chronometric fields that vary by day. Both members are optional and reuse the same validation as their top-level counterparts; an empty object means 'this weekday is named but inherits the top-level values'. additionalProperties is false because an unknown key here is almost always a typo that would silently do nothing.",
+      "additionalProperties": false,
+      "properties": {
+        "end_of_day_local": {
+          "type": "string",
+          "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$",
+          "description": "Override of 'chronometric.end_of_day_local' for this weekday, as 'HH:MM' (24h) in the user's local timezone. Same pattern as the top-level field.",
+          "examples": ["17:00", "18:30"]
+        },
+        "hyperfocus_break_minutes": {
+          "type": "integer",
+          "minimum": 15,
+          "maximum": 240,
+          "description": "Override of 'chronometric.hyperfocus_break_minutes' for this weekday. Same 15..240 range as the top-level field; re-anchors the 'nudge' rung for this day only.",
+          "examples": [60, 120]
+        }
+      }
+    },
+    "protectedWindow": {
+      "type": "object",
+      "description": "A single local-time range where the hyperfocus monitor hard-surfaces. 'start' and 'end' are required 'HH:MM' (24h) strings; 'label' is an optional human-readable name. additionalProperties is false to catch typos in this small, fixed shape.",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": {
+          "type": "string",
+          "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$",
+          "description": "Window start, 'HH:MM' (24h), local timezone.",
+          "examples": ["12:00", "17:00"]
+        },
+        "end": {
+          "type": "string",
+          "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$",
+          "description": "Window end, 'HH:MM' (24h), local timezone. An 'end' earlier than 'start' is treated by the consumer as wrapping past midnight.",
+          "examples": ["12:30", "23:59"]
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80,
+          "description": "Optional human-readable label for the window, surfaced in any notice the monitor emits.",
+          "examples": ["lunch", "evening", "lecture"]
         }
       }
     }

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -2,11 +2,31 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  * Copyright (c) 2026 NeuroDock contributors.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 import { version } from "./index";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function readPackageVersion(): string {
+  const raw = readFileSync(resolve(here, "..", "package.json"), "utf8");
+  return (JSON.parse(raw) as { version: string }).version;
+}
 
 describe("@neurodock/core", () => {
   test("exports a version constant", () => {
     expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  // Version-drift guard: `changeset version` bumps package.json but cannot touch
+  // the hand-written `version` constant in src/index.ts. This asserts the two
+  // stay joined, so a release that forgets to bump the constant fails CI here
+  // instead of shipping a mismatch. (We assert against package.json read at
+  // runtime rather than deriving the constant from it, to keep src/index.ts a
+  // plain `tsc` build with no JSON import escaping rootDir.)
+  test("exported version matches package.json", () => {
+    expect(version).toBe(readPackageVersion());
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,25 @@
  * Copyright (c) 2026 NeuroDock contributors.
  */
 export const version = "0.0.1";
+
+export type {
+  Profile,
+  ProfileIdentity,
+  ProfilePreferences,
+  ProfileChronometric,
+  ProfileGuardrails,
+  ProfilePrivacy,
+  WeekdayOverride,
+  ProtectedWindow,
+  Neurotype,
+  OutputFormat,
+  ReadingFontHint,
+  Motion,
+  LineHeightHint,
+  SessionOverlapPolicy,
+  CalendarPhase,
+  SycophancyCheck,
+  Embeddings,
+  Telemetry,
+  Weekday,
+} from "./profile.js";

--- a/packages/core/src/profile.presets.test.ts
+++ b/packages/core/src/profile.presets.test.ts
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * profile.presets.test.ts — every curated preset under the repo-root
+ * `profiles/` directory MUST validate against the canonical profile schema.
+ * Presets are part of the public contract (ADR 0004): a preset that drifts
+ * out of conformance is a user-facing breakage. This walks the directory so
+ * a newly added preset is covered automatically.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { beforeAll, describe, expect, test } from "vitest";
+import type { ValidateFunction } from "ajv";
+import { buildAjv } from "./test-helpers/ajv.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..", "..");
+const presetsDir = resolve(repoRoot, "profiles");
+
+function readSchema(): object {
+  const raw = readFileSync(
+    resolve(here, "..", "schemas", "profile.schema.json"),
+    "utf8",
+  );
+  return JSON.parse(raw) as object;
+}
+
+let validate: ValidateFunction;
+
+beforeAll(() => {
+  validate = buildAjv().compile(readSchema());
+});
+
+const presetFiles = readdirSync(presetsDir).filter((f) => f.endsWith(".yaml"));
+
+describe("curated presets validate against the profile schema", () => {
+  test("the profiles directory contains presets to check", () => {
+    expect(presetFiles.length).toBeGreaterThan(0);
+  });
+
+  test.each(presetFiles)("%s is a valid profile", (file) => {
+    const parsed = parseYaml(readFileSync(resolve(presetsDir, file), "utf8"));
+    const ok = validate(parsed);
+    if (!ok) {
+      throw new Error(
+        `${file} failed schema validation: ${JSON.stringify(
+          validate.errors,
+          null,
+          2,
+        )}`,
+      );
+    }
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/core/src/profile.schema.test.ts
+++ b/packages/core/src/profile.schema.test.ts
@@ -1,0 +1,378 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * profile.schema.test.ts — schema-conformance gate for the NeuroDock profile.
+ *
+ * Compiles the canonical schema (the exact file shipped in the package and
+ * consumed at runtime by @neurodock/cli, the extension, and the native host)
+ * with Ajv 2020 and asserts:
+ *   - the worked example + minimal templates validate clean (they are part of
+ *     the contract per ADR 0004);
+ *   - every R5 optional field (ADR 0011) validates when present, is valid when
+ *     omitted, and is rejected on a malformed value;
+ *   - a v0.1.0 profile carrying NONE of the new fields still validates
+ *     (backward-compat — the central correctness property of ADR 0004).
+ *
+ * Ajv + ajv-formats + yaml are dev-only test dependencies. The package keeps
+ * its zero-runtime-dependencies invariant.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { beforeAll, describe, expect, test } from "vitest";
+import type { ValidateFunction } from "ajv";
+import { buildAjv } from "./test-helpers/ajv.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const schemasDir = resolve(here, "..", "schemas");
+
+function readSchema(): object {
+  const raw = readFileSync(resolve(schemasDir, "profile.schema.json"), "utf8");
+  return JSON.parse(raw) as object;
+}
+
+function readYaml(name: string): unknown {
+  return parseYaml(readFileSync(resolve(schemasDir, name), "utf8"));
+}
+
+let validate: ValidateFunction;
+
+beforeAll(() => {
+  validate = buildAjv().compile(readSchema());
+});
+
+const BASE_IDENTITY = {
+  identity: { display_name: "T", neurotypes: ["adhd"] },
+} as const;
+
+describe("profile schema — shipped templates", () => {
+  test("the worked example validates clean", () => {
+    expect(validate(readYaml("profile.example.yaml"))).toBe(true);
+  });
+
+  test("the minimal template validates clean", () => {
+    expect(validate(readYaml("profile.minimal.yaml"))).toBe(true);
+  });
+});
+
+describe("profile schema — backward compatibility (ADR 0004)", () => {
+  test("a v0.1.0 profile carrying NONE of the R5 fields still validates", () => {
+    const legacy = {
+      schema_version: "0.1.0",
+      identity: { display_name: "T", neurotypes: ["adhd", "asd"] },
+      preferences: {
+        output_format: "answer_first",
+        max_chunk_size: 5,
+        reading_font_hint: "atkinson_hyperlegible",
+        motion: "reduced",
+      },
+      chronometric: {
+        hyperfocus_break_minutes: 90,
+        end_of_day_local: "18:30",
+        session_overlap_policy: "auto_close",
+      },
+      guardrails: {
+        rumination_threshold: 3,
+        rumination_window_minutes: 90,
+        sycophancy_check: "warn",
+      },
+      privacy: {
+        embeddings: "local",
+        telemetry: "off",
+        os_idle_consent: false,
+      },
+    };
+    expect(validate(legacy)).toBe(true);
+  });
+
+  test("the bare minimal profile (identity only) is still valid", () => {
+    expect(validate({ ...BASE_IDENTITY })).toBe(true);
+  });
+});
+
+describe("preferences.line_height_hint (R5)", () => {
+  test.each(["compact", "default", "relaxed"])(
+    "accepts the enum value %s",
+    (value) => {
+      expect(
+        validate({
+          ...BASE_IDENTITY,
+          preferences: { line_height_hint: value },
+        }),
+      ).toBe(true);
+    },
+  );
+
+  test("is valid when omitted", () => {
+    expect(validate({ ...BASE_IDENTITY, preferences: {} })).toBe(true);
+  });
+
+  test("rejects a value outside the enum", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        preferences: { line_height_hint: "double" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("preferences.voice_input_preferred (R5)", () => {
+  test("accepts true", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        preferences: { voice_input_preferred: true },
+      }),
+    ).toBe(true);
+  });
+
+  test("is valid when omitted", () => {
+    expect(validate({ ...BASE_IDENTITY, preferences: {} })).toBe(true);
+  });
+
+  test("rejects a non-boolean", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        preferences: { voice_input_preferred: "yes" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("chronometric.calendar_phase (R5)", () => {
+  test.each(["teaching", "marking", "exam", "deadlines", "break"])(
+    "accepts the enum value %s",
+    (value) => {
+      expect(
+        validate({ ...BASE_IDENTITY, chronometric: { calendar_phase: value } }),
+      ).toBe(true);
+    },
+  );
+
+  test("is valid when omitted", () => {
+    expect(validate({ ...BASE_IDENTITY, chronometric: {} })).toBe(true);
+  });
+
+  test("rejects a value outside the enum", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { calendar_phase: "summer" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("chronometric.weekday_overrides (R5)", () => {
+  test("accepts per-weekday overrides reusing the existing patterns/ranges", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: {
+          weekday_overrides: {
+            wednesday: { end_of_day_local: "18:30" },
+            saturday: { hyperfocus_break_minutes: 120 },
+            monday: {
+              end_of_day_local: "17:00",
+              hyperfocus_break_minutes: 60,
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("accepts an empty override object for a weekday", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { weekday_overrides: { friday: {} } },
+      }),
+    ).toBe(true);
+  });
+
+  test("is valid when omitted", () => {
+    expect(validate({ ...BASE_IDENTITY, chronometric: {} })).toBe(true);
+  });
+
+  test("rejects an unknown weekday key", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { weekday_overrides: { funday: {} } },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects a malformed end_of_day_local inside an override", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: {
+          weekday_overrides: { monday: { end_of_day_local: "25:00" } },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects an out-of-range hyperfocus_break_minutes inside an override", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: {
+          weekday_overrides: { monday: { hyperfocus_break_minutes: 5 } },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects an unknown key inside an override object", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { weekday_overrides: { monday: { lunch: "12:00" } } },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("chronometric.protected_windows (R5)", () => {
+  test("accepts a list of local-time ranges with optional labels", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: {
+          protected_windows: [
+            { start: "12:00", end: "12:30", label: "lunch" },
+            { start: "17:00", end: "23:59" },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("accepts an empty list", () => {
+    expect(
+      validate({ ...BASE_IDENTITY, chronometric: { protected_windows: [] } }),
+    ).toBe(true);
+  });
+
+  test("is valid when omitted", () => {
+    expect(validate({ ...BASE_IDENTITY, chronometric: {} })).toBe(true);
+  });
+
+  test("rejects a window missing the required end", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { protected_windows: [{ start: "12:00" }] },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects a malformed time string", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { protected_windows: [{ start: "9am", end: "10am" }] },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects an unknown key inside a window object", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: {
+          protected_windows: [{ start: "12:00", end: "12:30", color: "red" }],
+        },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("chronometric.deadline_cluster_awareness (R5)", () => {
+  test("accepts true", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { deadline_cluster_awareness: true },
+      }),
+    ).toBe(true);
+  });
+
+  test("is valid when omitted", () => {
+    expect(validate({ ...BASE_IDENTITY, chronometric: {} })).toBe(true);
+  });
+
+  test("rejects a non-boolean", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { deadline_cluster_awareness: "yes" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("chronometric.time_buffer_multiplier (R5)", () => {
+  test.each([1.0, 1.3, 3.0])("accepts the multiplier %s", (value) => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { time_buffer_multiplier: value },
+      }),
+    ).toBe(true);
+  });
+
+  test("is valid when omitted", () => {
+    expect(validate({ ...BASE_IDENTITY, chronometric: {} })).toBe(true);
+  });
+
+  test("rejects a multiplier below the minimum", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { time_buffer_multiplier: 0.5 },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects a multiplier above the maximum", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { time_buffer_multiplier: 4 },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("chronometric.motor_fatigue_aware (R5)", () => {
+  test("accepts true", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { motor_fatigue_aware: true },
+      }),
+    ).toBe(true);
+  });
+
+  test("is valid when omitted", () => {
+    expect(validate({ ...BASE_IDENTITY, chronometric: {} })).toBe(true);
+  });
+
+  test("rejects a non-boolean", () => {
+    expect(
+      validate({
+        ...BASE_IDENTITY,
+        chronometric: { motor_fatigue_aware: 1 },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/profile.test.ts
+++ b/packages/core/src/profile.test.ts
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * profile.test.ts — links the hand-written `Profile` type to the canonical
+ * JSON Schema. A typed fixture that exercises every R5 field is validated
+ * against the Ajv-compiled schema; if the type permits a shape the schema
+ * rejects (or vice versa) this test fails, preventing the two from drifting.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { beforeAll, describe, expect, test } from "vitest";
+import type { ValidateFunction } from "ajv";
+import { buildAjv } from "./test-helpers/ajv.js";
+import type { Profile } from "./profile.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function readSchema(): object {
+  const raw = readFileSync(
+    resolve(here, "..", "schemas", "profile.schema.json"),
+    "utf8",
+  );
+  return JSON.parse(raw) as object;
+}
+
+let validate: ValidateFunction;
+
+beforeAll(() => {
+  validate = buildAjv().compile(readSchema());
+});
+
+describe("Profile type ↔ schema", () => {
+  test("a minimal typed Profile validates against the schema", () => {
+    const profile: Profile = {
+      identity: { display_name: "T", neurotypes: ["adhd"] },
+    };
+    expect(validate(profile)).toBe(true);
+  });
+
+  test("a typed Profile exercising every R5 field validates", () => {
+    const profile: Profile = {
+      schema_version: "0.1.0",
+      identity: { display_name: "T", neurotypes: ["dyspraxia"] },
+      preferences: {
+        output_format: "answer_first",
+        line_height_hint: "relaxed",
+        voice_input_preferred: true,
+      },
+      chronometric: {
+        hyperfocus_break_minutes: 60,
+        calendar_phase: "marking",
+        weekday_overrides: {
+          wednesday: { end_of_day_local: "18:30" },
+          saturday: { hyperfocus_break_minutes: 120 },
+        },
+        protected_windows: [
+          { start: "12:00", end: "12:30", label: "lunch" },
+          { start: "17:00", end: "23:59" },
+        ],
+        deadline_cluster_awareness: true,
+        time_buffer_multiplier: 1.3,
+        motor_fatigue_aware: true,
+      },
+    };
+    expect(validate(profile)).toBe(true);
+  });
+});

--- a/packages/core/src/profile.ts
+++ b/packages/core/src/profile.ts
@@ -1,0 +1,169 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * profile.ts — the canonical TypeScript shape of a NeuroDock profile.
+ *
+ * Derived by hand from `schemas/profile.schema.json` and linked to it by the
+ * runtime-assertion test in `profile.test.ts`, which validates representative
+ * typed fixtures against the Ajv-compiled schema so the two cannot drift.
+ *
+ * ADR 0004 says shared types SHOULD be derived from the schema. We deliberately
+ * hand-write this type and close the drift loop with the runtime schema-assertion
+ * test above, rather than running a codegen step: it keeps `@neurodock/core`'s
+ * build a plain `tsc` with zero codegen tooling and zero runtime deps, and the
+ * surface is small enough that the assertion test is a cheaper, equally reliable
+ * guard. This is an intentional choice, not an oversight.
+ *
+ * Forward-compat (ADR 0004): unknown keys are allowed at every object level,
+ * so each interface carries an index signature. Every field below `identity`
+ * is optional; defaults are loader-applied, never written into the file.
+ *
+ * Additive-only (ADR 0005 / ADR 0011): the R5 tailoring fields are OPTIONAL
+ * and additive. They are never required and never narrow an existing type.
+ */
+
+/** Self-identified neurotype tags. Self-ID is sufficient; never a diagnosis. */
+export type Neurotype =
+  | "adhd"
+  | "asd"
+  | "audhd"
+  | "ocd"
+  | "dyslexia"
+  | "dyspraxia"
+  | "tourette"
+  | "other";
+
+export type OutputFormat = "answer_first" | "conventional" | "bullet_first";
+export type ReadingFontHint =
+  | "atkinson_hyperlegible"
+  | "lexend"
+  | "system_default";
+export type Motion = "reduced" | "system" | "full";
+
+/** R5 (ADR 0011): categorical line-height band for rich-text clients. */
+export type LineHeightHint = "compact" | "default" | "relaxed";
+
+export type SessionOverlapPolicy = "auto_close" | "error";
+
+/** R5 (ADR 0011): self-declared term/semester phase. */
+export type CalendarPhase =
+  | "teaching"
+  | "marking"
+  | "exam"
+  | "deadlines"
+  | "break";
+
+export type SycophancyCheck = "off" | "warn" | "refuse";
+export type Embeddings = "local" | "cloud_voyage" | "cloud_openai";
+export type Telemetry = "off" | "local_otel_only" | "full";
+
+/** Lowercase English weekday names — the keys of `weekday_overrides`. */
+export type Weekday =
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday"
+  | "sunday";
+
+export interface ProfileIdentity {
+  display_name: string;
+  neurotypes: Neurotype[];
+  additional_notes?: string;
+  [key: string]: unknown;
+}
+
+export interface ProfilePreferences {
+  output_format?: OutputFormat;
+  max_chunk_size?: number;
+  reading_font_hint?: ReadingFontHint;
+  motion?: Motion;
+  /** R5 (ADR 0011): optional rich-text line-height hint. */
+  line_height_hint?: LineHeightHint;
+  /** R5 (ADR 0011): true when the user predominantly dictates input. */
+  voice_input_preferred?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * R5 (ADR 0011): per-weekday override of the day-varying chronometric fields.
+ *
+ * Intentionally NO `[key: string]: unknown` index signature, unlike the other
+ * interfaces in this file. This corresponds to the `weekdayOverride` `$def`,
+ * which sets `additionalProperties: false` as a deliberate typo-guard (a
+ * misspelt key here is almost always a mistake that would silently do nothing).
+ * Omitting the index signature mirrors that closed shape in the type; do NOT
+ * "fix" it by adding one — the schema would then reject what the type permits.
+ */
+export interface WeekdayOverride {
+  end_of_day_local?: string;
+  hyperfocus_break_minutes?: number;
+}
+
+/**
+ * R5 (ADR 0011): a local-time range the hyperfocus monitor hard-surfaces in.
+ *
+ * Intentionally NO `[key: string]: unknown` index signature, unlike the other
+ * interfaces in this file. This corresponds to the `protectedWindow` `$def`,
+ * which sets `additionalProperties: false` as a deliberate typo-guard for its
+ * small, fixed shape. Omitting the index signature mirrors that closed shape;
+ * do NOT "fix" it by adding one — the schema would then reject what the type
+ * permits.
+ */
+export interface ProtectedWindow {
+  start: string;
+  end: string;
+  label?: string;
+}
+
+export interface ProfileChronometric {
+  hyperfocus_break_minutes?: number;
+  end_of_day_local?: string;
+  zones?: Record<string, unknown>;
+  session_overlap_policy?: SessionOverlapPolicy;
+  /** R5 (ADR 0011): self-declared term/semester phase. */
+  calendar_phase?: CalendarPhase;
+  /** R5 (ADR 0011): per-weekday overrides; absent weekdays inherit top-level. */
+  weekday_overrides?: Partial<Record<Weekday, WeekdayOverride>>;
+  /** R5 (ADR 0011): windows where the monitor hard-surfaces rather than nudges. */
+  protected_windows?: ProtectedWindow[];
+  /** R5 (ADR 0011): surface deadline proximity in planning skills. */
+  deadline_cluster_awareness?: boolean;
+  /** R5 (ADR 0011): pad presented time estimates (1.0..3.0; neutral 1.0). */
+  time_buffer_multiplier?: number;
+  /** R5 (ADR 0011): weight motor activity into the fatigue signal. */
+  motor_fatigue_aware?: boolean;
+  [key: string]: unknown;
+}
+
+export interface ProfileGuardrails {
+  rumination_threshold?: number;
+  rumination_window_minutes?: number;
+  sycophancy_check?: SycophancyCheck;
+  [key: string]: unknown;
+}
+
+export interface ProfilePrivacy {
+  embeddings?: Embeddings;
+  telemetry?: Telemetry;
+  os_idle_consent?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * A NeuroDock profile. `identity` is the only required block; every other
+ * block is optional and defaulted by the loader at read time (ADR 0004).
+ */
+export interface Profile {
+  schema_version?: string;
+  extends?: string;
+  identity: ProfileIdentity;
+  preferences?: ProfilePreferences;
+  chronometric?: ProfileChronometric;
+  guardrails?: ProfileGuardrails;
+  privacy?: ProfilePrivacy;
+  [key: string]: unknown;
+}

--- a/packages/core/src/test-helpers/ajv.ts
+++ b/packages/core/src/test-helpers/ajv.ts
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * ajv.ts — shared Ajv 2020 builder for the core schema tests.
+ *
+ * The three core schema tests (profile.test.ts, profile.schema.test.ts,
+ * profile.presets.test.ts) all need an identically-configured Ajv2020 instance
+ * with ajv-formats applied. This helper is the single source of that config so
+ * the `addFormats` interop cast lives in one place rather than being duplicated
+ * (and drifting) across three files.
+ *
+ * Test-only: Ajv + ajv-formats are dev dependencies. Importing this from
+ * production code would break the zero-runtime-dependencies invariant, so it
+ * lives under `test-helpers/` and is only ever imported by `*.test.ts` files.
+ */
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+// ajv-formats ships a CommonJS default export whose call signature is not
+// visible through the ESM interop wrapper, so we narrow it once here.
+const applyFormats = addFormats as unknown as (ajv: Ajv2020) => Ajv2020;
+
+/**
+ * Build a fresh Ajv 2020 instance configured exactly as the core schema tests
+ * require: lenient strict mode (the schema uses draft-2020 features Ajv's strict
+ * mode flags as warnings), union types allowed, all errors collected, and
+ * ajv-formats applied so `pattern`/format keywords resolve.
+ */
+export function buildAjv(): Ajv2020 {
+  const ajv = new Ajv2020({
+    allErrors: true,
+    strict: false,
+    allowUnionTypes: true,
+  });
+  applyFormats(ajv);
+  return ajv;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,9 +133,18 @@ importers:
 
   packages/core:
     devDependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@25.9.3)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.9.0
 
   packages/extension-browser:
     dependencies:

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -12,17 +12,17 @@ serve you.
 
 ## Available presets
 
-| Preset                                               | Distinctive tuning                                                                                                                                                                                                                                                                                                                                                                                                      |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`adhd.yaml`](adhd.yaml)                             | `max_chunk_size: 5`, `hyperfocus_break_minutes: 75`, `reading_font_hint: lexend`. Activates `adhd-daily-planner`, `hyperfocus-formatter`, `audhd-context-recovery`, `visual-organizer`.                                                                                                                                                                                                                                 |
-| [`audhd.yaml`](audhd.yaml)                           | `neurotypes: ["audhd"]` (first-class, not a sum). 75-minute break cadence + `end_of_day_local` pre-set. Activates `audhd-context-recovery` (primary), plus ADHD- and ASD-tagged skills including `asd-meeting-translator`.                                                                                                                                                                                              |
-| [`ocd.yaml`](ocd.yaml)                               | Strictest guardrail config: `rumination_threshold: 2` over a 60-minute window, `sycophancy_check: refuse`. Activates `ocd-decision-finalizer`.                                                                                                                                                                                                                                                                          |
-| [`dyslexic.yaml`](dyslexic.yaml)                     | `reading_font_hint: atkinson_hyperlegible`, `max_chunk_size: 4`, `output_format: answer_first` for fast scanning.                                                                                                                                                                                                                                                                                                       |
-| [`low-stimulation.yaml`](low-stimulation.yaml)       | Temporary-override shape. `neurotypes: []` (no identity claim), `max_chunk_size: 3`, `hyperfocus_break_minutes: 60`, all guardrails at most-protective values.                                                                                                                                                                                                                                                          |
-| [`educator-semester.yaml`](educator-semester.yaml)   | Profession-shaped, not neurotype-shaped. `neurotypes: []` (overlay a neurotype preset), `output_format: answer_first` for triage, `hyperfocus_break_minutes: 75` (lecture/marking blocks), `end_of_day_local: "17:00"` (firmer EOD to defend non-work hours). Drop break cadence to 60 during marking weeks.                                                                                                            |
-| [`dyspraxia.yaml`](dyspraxia.yaml)                   | For self-identified dyspraxic users. `neurotypes: ["dyspraxia"]`, `max_chunk_size: 4`, `hyperfocus_break_minutes: 60` (motor-fatigue compounds faster than cognitive-only), `motion: reduced` hard-pinned for vestibular sensitivity (bodily-safety, not aesthetic). Header documents voice-input and 30% time-buffer expectations.                                                                                     |
-| [`burnout-recovery.yaml`](burnout-recovery.yaml)     | **Temporary state preset.** `neurotypes: []` (overlay a neurotype preset). `max_chunk_size: 3` for success-stacking, `hyperfocus_break_minutes: 45` (firm — don't grind through recovery), `end_of_day_local: "16:30"` (firm-early), `sycophancy_check: refuse` (substrate MUST refuse to validate "push through"), `rumination_threshold: 2`. Revisit in 4-6 weeks. **Not a clinical tool** — pair with human support. |
-| [`student-university.yaml`](student-university.yaml) | Student-life-shaped, not neurotype-shaped. `neurotypes: []` (overlay a neurotype preset). `max_chunk_size: 5`, `hyperfocus_break_minutes: 90` (library-session blocks), `end_of_day_local: "22:00"` (honest about real student schedules — interrupts the 2am-essay spiral). Drop break cadence to 60 during exam weeks.                                                                                                |
+| Preset                                               | Distinctive tuning                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`adhd.yaml`](adhd.yaml)                             | `max_chunk_size: 5`, `hyperfocus_break_minutes: 75`, `reading_font_hint: lexend`. Activates `adhd-daily-planner`, `hyperfocus-formatter`, `audhd-context-recovery`, `visual-organizer`.                                                                                                                                                                                                                                                                                         |
+| [`audhd.yaml`](audhd.yaml)                           | `neurotypes: ["audhd"]` (first-class, not a sum). 75-minute break cadence + `end_of_day_local` pre-set. Activates `audhd-context-recovery` (primary), plus ADHD- and ASD-tagged skills including `asd-meeting-translator`.                                                                                                                                                                                                                                                      |
+| [`ocd.yaml`](ocd.yaml)                               | Strictest guardrail config: `rumination_threshold: 2` over a 60-minute window, `sycophancy_check: refuse`. Activates `ocd-decision-finalizer`.                                                                                                                                                                                                                                                                                                                                  |
+| [`dyslexic.yaml`](dyslexic.yaml)                     | `reading_font_hint: atkinson_hyperlegible`, `line_height_hint: relaxed`, `max_chunk_size: 4`, `output_format: answer_first` for fast scanning.                                                                                                                                                                                                                                                                                                                                  |
+| [`low-stimulation.yaml`](low-stimulation.yaml)       | Temporary-override shape. `neurotypes: []` (no identity claim), `max_chunk_size: 3`, `hyperfocus_break_minutes: 60`, all guardrails at most-protective values.                                                                                                                                                                                                                                                                                                                  |
+| [`educator-semester.yaml`](educator-semester.yaml)   | Profession-shaped, not neurotype-shaped. `neurotypes: []` (overlay a neurotype preset), `output_format: answer_first` for triage, `hyperfocus_break_minutes: 75` (lecture/marking blocks), `end_of_day_local: "17:00"` (firmer EOD to defend non-work hours). `calendar_phase: teaching`, a Wednesday `weekday_overrides` EOD bump to 18:30, and lunch/evening `protected_windows`. Drop break cadence to 60 during marking weeks.                                              |
+| [`dyspraxia.yaml`](dyspraxia.yaml)                   | For self-identified dyspraxic users. `neurotypes: ["dyspraxia"]`, `max_chunk_size: 4`, `hyperfocus_break_minutes: 60` (motor-fatigue compounds faster than cognitive-only), `motion: reduced` hard-pinned for vestibular sensitivity (bodily-safety, not aesthetic). `voice_input_preferred: true`, `time_buffer_multiplier: 1.3` (+30%), `motor_fatigue_aware: true`.                                                                                                          |
+| [`burnout-recovery.yaml`](burnout-recovery.yaml)     | **Temporary state preset.** `neurotypes: []` (overlay a neurotype preset). `max_chunk_size: 3` for success-stacking, `hyperfocus_break_minutes: 45` (firm — don't grind through recovery), `end_of_day_local: "16:30"` (firm-early), `sycophancy_check: refuse` (substrate MUST refuse to validate "push through"), `rumination_threshold: 2`. Revisit in 4-6 weeks. **Not a clinical tool** — pair with human support.                                                         |
+| [`student-university.yaml`](student-university.yaml) | Student-life-shaped, not neurotype-shaped. `neurotypes: []` (overlay a neurotype preset). `max_chunk_size: 5`, `hyperfocus_break_minutes: 90` (library-session blocks), `end_of_day_local: "22:00"` (honest about real student schedules — interrupts the 2am-essay spiral). `calendar_phase: teaching`, `deadline_cluster_awareness: true`, a Saturday `weekday_overrides` break bump to 120, lunch/wind-down `protected_windows`. Drop break cadence to 60 during exam weeks. |
 
 ## How to use a preset
 
@@ -48,15 +48,43 @@ them implies a diagnosis, and NeuroDock never asks for one. The schema
 treats `identity.neurotypes` as a self-identification list and never
 gates features on it — see ETHICS §"On self-identification".
 
+## Per-neurotype tailoring fields (added v0.1.x, ADR 0011)
+
+These eight optional fields were promoted from "candidate" to real schema
+fields under [ADR 0011](../docs/decisions/0011-neurotype-schema-strategy.md).
+Every one is **optional and additive**: a profile that omits them validates
+exactly as before, and the loader applies a neutral default at read time. They
+express per-neurotype tailoring through populated values and presentation hints
+— never by changing the required shape. The "consumer" column tracks which
+package reads each field; "pending" means the schema field has landed but the
+consuming code ships in a later PR.
+
+| Field                                     | Type / values                                                                                                                                                | Set by preset(s)                          | Consumer / status                       |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- | --------------------------------------- |
+| `preferences.line_height_hint`            | `"compact" \| "default" \| "relaxed"` — advisory body-paragraph line-height bands; clients MUST keep body spacing ≥ 1.5 in every band (WCAG 1.4.8 / 1.4.12). | `dyslexic`                                | clients rendering rich text (pending)   |
+| `preferences.voice_input_preferred`       | boolean                                                                                                                                                      | `dyspraxia`                               | skill shaping layer (pending)           |
+| `chronometric.calendar_phase`             | `"teaching" \| "marking" \| "exam" \| "deadlines" \| "break"`                                                                                                | `educator-semester`, `student-university` | consumed by mcp-chronometric (pending)  |
+| `chronometric.weekday_overrides`          | map of weekday → `{ end_of_day_local?, hyperfocus_break_minutes? }`                                                                                          | `educator-semester`, `student-university` | consumed by mcp-chronometric (pending)  |
+| `chronometric.protected_windows`          | list of `{ start, end, label? }` local-time ranges                                                                                                           | `educator-semester`, `student-university` | consumed by mcp-chronometric (pending)  |
+| `chronometric.deadline_cluster_awareness` | boolean                                                                                                                                                      | `student-university`                      | consumed by task-fractionator (pending) |
+| `chronometric.time_buffer_multiplier`     | number 1.0–3.0 (neutral default 1.0)                                                                                                                         | `dyspraxia` (1.3)                         | consumed by task-fractionator (pending) |
+| `chronometric.motor_fatigue_aware`        | boolean                                                                                                                                                      | `dyspraxia`                               | consumed by mcp-chronometric (pending)  |
+
+Notes:
+
+- `motor_fatigue_aware` only declares the preference; actually reading motor
+  activity is still gated by `privacy.os_idle_consent` and the relevant
+  OS-input consents.
+- `weekday_overrides` and the objects inside `protected_windows` reject unknown
+  keys (a misspelt weekday or window field is almost always a typo that would
+  silently do nothing); every other block stays forward-compatible
+  (`additionalProperties: true`) per ADR 0004.
+
 ## Candidate fields for a future schema bump
 
-Notes the presets surfaced during authoring; tracked here for a future
+Notes the presets surfaced during authoring; still tracked for a future
 profile schema version:
 
-- **Preferred line-height hint.** `dyslexic.yaml` would benefit from an
-  explicit `preferences.line_height_hint` (or similar) so clients that
-  render NeuroDock output as rich text can honour it alongside
-  `reading_font_hint`. v0.1.0 has no such field.
 - **Escalation-ladder shape override.** Today
   `chronometric.hyperfocus_break_minutes` re-anchors only the "nudge"
   rung; the 60/+30/+60 ladder shape is fixed. An ADHD or low-stimulation
@@ -67,37 +95,3 @@ profile schema version:
   no schema-level way to declare "always show the override path
   prominently in finality-mode output" — the skill copy carries that
   contract instead.
-- **Semester / calendar-phase awareness.** `educator-semester.yaml`
-  and `student-university.yaml` both surfaced semester-cadence knobs
-  that v0.1.0 cannot model:
-  - `chronometric.calendar_phase` — `"teaching" | "marking" | "exam" |
-"deadlines" | "break"` so skills can shift defaults across the term
-    (tighter break cadence during marking / exam weeks, looser during
-    break, deadline-cluster awareness during week 12).
-  - `chronometric.weekday_overrides` — per-weekday overrides for
-    `end_of_day_local` and `hyperfocus_break_minutes` to cover the
-    late-office-hours, Wednesday-afternoon-class, library-day vs
-    lecture-day patterns without forcing a whole-profile swap.
-  - `chronometric.protected_windows` — list of local-time ranges
-    (lunch, post-EOD evening, scheduled lectures, lab times) where
-    the hyperfocus monitor should hard-surface rather than nudge.
-  - `chronometric.deadline_cluster_awareness` — hint to surface
-    deadline proximity in planning skills; when three assignments are
-    due in a single week, the break-cadence math should shift.
-    The educator and student presets encode the intent in header
-    comments and user-tunable notes until these land in a schema bump.
-- **Dyspraxia-specific fields.** `dyspraxia.yaml` surfaced three
-  motor-planning knobs that v0.1.0 cannot model:
-  - `preferences.voice_input_preferred` — boolean. When true,
-    downstream skills should not assume the user can hand-edit fiddly
-    punctuation cheaply; keep examples copy-pasteable as a single
-    block. Many dyspraxic users dictate rather than type for sustained
-    work.
-  - `chronometric.time_buffer_multiplier` — float. Pads time estimates
-    (e.g. 1.3 for ~30%) because real-world execution time for motor-
-    heavy tasks is systematically underestimated. Used by planning
-    skills to scale presented estimates.
-  - `chronometric.motor_fatigue_aware` — boolean. When true, the
-    hyperfocus monitor weights click / keystroke / window-switch
-    volume into the fatigue signal, not just continuous-session
-    length. Cognitive sharpness and motor exhaustion can coexist.

--- a/profiles/dyslexic.yaml
+++ b/profiles/dyslexic.yaml
@@ -27,12 +27,12 @@
 #     - chronometric.hyperfocus_break_minutes = 90   the schema default;
 #       no dyslexia-specific reason to move it.
 #     - guardrails.sycophancy_check = warn   manifesto default.
-#   NOTE on line-height:
-#     v0.1.0 of the schema does not yet carry a preferred-line-height
-#     field. Clients tend to pair atkinson_hyperlegible with a generous
-#     line-height by default; an explicit profile field is a candidate
-#     for a future schema version. See the README in this directory
-#     for the running list.
+#     - preferences.line_height_hint = relaxed   atkinson_hyperlegible
+#       pairs best with generous line spacing for dyslexic readers. This
+#       categorical hint lets clients that render NeuroDock output as
+#       rich text honour it without each one re-deriving the pairing.
+#       (Schema field since v0.1.x per ADR 0011; consumed by clients
+#       rendering rich text — pending.)
 #   USER-TUNABLE:
 #     - identity.display_name       set to your preferred handle.
 #     - identity.neurotypes   add more tags if you also identify with
@@ -59,6 +59,11 @@ preferences:
   max_chunk_size: 4
   reading_font_hint: "atkinson_hyperlegible"
   motion: "reduced"
+  # Generous line spacing pairs with atkinson_hyperlegible for dyslexic
+  # readers; clients rendering rich text honour this where they can.
+  # "relaxed" anchors around 1.65; every band stays at or above the 1.5
+  # body line-height floor required by WCAG 1.4.8 / 1.4.12.
+  line_height_hint: "relaxed"
 
 chronometric:
   hyperfocus_break_minutes: 90

--- a/profiles/dyspraxia.yaml
+++ b/profiles/dyspraxia.yaml
@@ -37,32 +37,25 @@
 #       break before the motor system locks up.
 #     - guardrails.sycophancy_check = warn   manifesto default.
 #
-# Voice-input preference:
-#   Many dyspraxic users dictate rather than type for sustained work.
-#   v0.1.0 has no schema field for `voice_input_preferred`; until that
-#   lands, downstream skills that emit code or structured text should
-#   not assume the user can hand-edit fiddly punctuation cheaply. Keep
-#   examples copy-pasteable as a single block. Tracked as a candidate
-#   schema field in profiles/README.md.
-#
-# Time-buffer expansion:
-#   Real-world time estimates are systematically unreliable for
-#   dyspraxic users — the motor execution of a "five minute task" often
-#   takes 30-50% longer than the cognitive estimate predicts. Until the
-#   schema carries a `time_buffer_multiplier` field, downstream
-#   planning skills should pad estimates by ~30% when this preset is
-#   active. The behaviour is encoded here in the comment rather than in
-#   the data because v0.1.0 has nowhere to put it. Candidate field
-#   tracked in profiles/README.md.
-#
-# Motor-fatigue awareness:
-#   Distinct from cognitive fatigue. A dyspraxic user can be
-#   cognitively sharp and motorically wrecked at the same time; the
-#   hyperfocus monitor's existing nudge fires on continuous-session
-#   length and is the right hook to reuse, but a future
-#   `motor_fatigue_aware` field would let the monitor weight clicks /
-#   keystrokes / window-switches into the signal. Candidate schema
-#   field tracked in profiles/README.md.
+#     - preferences.voice_input_preferred = true   many dyspraxic users
+#       dictate rather than type for sustained work. Downstream skills
+#       that emit code or structured text should keep examples copy-
+#       pasteable as a single block and not assume the user can hand-
+#       edit fiddly punctuation cheaply. (Consumer pending; schema field
+#       since v0.1.x per ADR 0011.)
+#     - chronometric.time_buffer_multiplier = 1.3   real-world time
+#       estimates are systematically unreliable for dyspraxic users —
+#       the motor execution of a "five minute task" often takes 30-50%
+#       longer than the cognitive estimate predicts. Planning skills
+#       scale presented estimates by this factor (~+30%). (Consumer
+#       pending: task-fractionator.)
+#     - chronometric.motor_fatigue_aware = true   distinct from
+#       cognitive fatigue: a dyspraxic user can be cognitively sharp and
+#       motorically wrecked at once. When true the hyperfocus monitor
+#       weights clicks / keystrokes / window-switches into the fatigue
+#       signal, not just continuous-session length. (Consumer pending:
+#       mcp-chronometric. Reading motor activity still requires
+#       privacy.os_idle_consent and the relevant OS-input consents.)
 #
 #   USER-TUNABLE (edit freely after copying):
 #     - identity.display_name       set to your preferred handle.
@@ -98,6 +91,9 @@ preferences:
   # Hard-pinned, not deferred to OS. See header comment — vestibular
   # sensitivity makes this a bodily-safety setting, not a preference.
   motion: "reduced"
+  # Many dyspraxic users dictate rather than type for sustained work.
+  # Downstream skills keep examples copy-pasteable as a single block.
+  voice_input_preferred: true
 
 chronometric:
   # 60-minute "gentle" rung. Motor-fatigue accumulates faster than
@@ -106,6 +102,12 @@ chronometric:
   hyperfocus_break_minutes: 60
   # end_of_day_local: "18:30"   # uncomment to enable the after-hours nudge
   session_overlap_policy: "auto_close"
+  # Pad presented time estimates by ~30%: motor execution of a task
+  # routinely runs longer than the cognitive estimate predicts.
+  time_buffer_multiplier: 1.3
+  # Weight clicks / keystrokes / window-switches into the fatigue
+  # signal, not just continuous-session length.
+  motor_fatigue_aware: true
 
 guardrails:
   rumination_threshold: 3

--- a/profiles/educator-semester.yaml
+++ b/profiles/educator-semester.yaml
@@ -48,17 +48,14 @@
 #       to prevent grade-fatigue spirals. The accuracy of rubric
 #       application drops measurably after ~60 min of continuous marking;
 #       surfacing the nudge earlier protects both the cohort and you.
-#     - chronometric.end_of_day_local
+#     - chronometric.end_of_day_local / chronometric.weekday_overrides
 #       OFFICE HOURS: if you hold late office hours one day a week (a
-#       common pattern), bump this to "18:30" on that day only by
-#       swapping in a day-specific override profile, or accept the early
-#       nudge as a reminder to wrap. The schema does not currently model
-#       per-weekday EOD — see the candidate-fields note in
-#       profiles/README.md.
-#       WEDNESDAY-AFTERNOON-CLASS PATTERN: a Wednesday afternoon teaching
-#       block that runs past 17:00 will trigger the EOD nudge mid-class.
-#       That's working as intended — the nudge is a signal to protect
-#       Wednesday evening from spillover admin, not to leave the room.
+#       common pattern), bump that day only via `weekday_overrides`
+#       (this preset overrides Wednesday to 18:30) rather than relaxing
+#       the whole-week EOD.
+#       WEDNESDAY-AFTERNOON-CLASS PATTERN: the Wednesday override keeps
+#       the nudge from firing mid-class while still protecting Wednesday
+#       evening from spillover admin.
 #     - guardrails.rumination_threshold / rumination_window_minutes
 #       schema defaults (3 queries / 90 min). Marking and feedback work
 #       involves legitimate iteration on phrasing; raise the threshold
@@ -68,23 +65,20 @@
 #       want chronometric.idle_status to read OS idle time (useful for
 #       distinguishing "in a lecture" from "stuck on a sentence").
 #
-# Semester cadence — fields the schema does NOT yet model:
-#   This preset would benefit from explicit semester-aware fields. They
-#   are NOT in profile.schema.json v0.1.0 and are tracked as candidate
-#   schema-bump fields in profiles/README.md:
+# Semester cadence — schema fields this preset sets (since v0.1.x, ADR 0011):
 #     - chronometric.calendar_phase
-#         enum-ish: "teaching" | "marking" | "exam" | "break"
-#         lets skills shift defaults (e.g. tighter break cadence during
-#         marking, looser during break).
+#         "teaching" | "marking" | "exam" | "deadlines" | "break".
+#         Lets skills shift defaults (e.g. tighter break cadence during
+#         marking, looser during break). This preset ships "teaching" as
+#         the neutral starting point — change it as the term moves.
+#         (Consumer pending: mcp-chronometric.)
 #     - chronometric.weekday_overrides
-#         map of weekday -> { end_of_day_local, hyperfocus_break_minutes }
-#         covers the Wednesday-afternoon-class and late-office-hours
-#         patterns without forcing a profile swap.
+#         map of weekday -> { end_of_day_local, hyperfocus_break_minutes }.
+#         This preset overrides Wednesday (late office hours / afternoon
+#         class -> 18:30) so the EOD nudge does not fire mid-class.
 #     - chronometric.protected_windows
-#         list of local-time ranges where the hyperfocus monitor should
-#         hard-surface (e.g. 12:00-12:30 lunch, post-17:00 evening).
-#   Until those land in a schema bump, encode the intent in this
-#   comment block and in the user-tunable notes above.
+#         local-time ranges where the hyperfocus monitor hard-surfaces
+#         rather than nudges: a lunch window and the post-EOD evening.
 #
 # Install (as your default educator profile):
 #   cp profiles/educator-semester.yaml ~/.neurodock/profile.yaml
@@ -128,6 +122,23 @@ chronometric:
   # interruption that protects the boundary.
   end_of_day_local: "17:00"
   session_overlap_policy: "auto_close"
+  # Neutral starting point for the term. Move to "marking" / "exam"
+  # during those weeks for tighter break cadence; "break" loosens it.
+  calendar_phase: "teaching"
+  # Wednesday holds late office hours / an afternoon class — push EOD
+  # to 18:30 that day only so the nudge does not fire mid-class.
+  weekday_overrides:
+    wednesday:
+      end_of_day_local: "18:30"
+  # Hard-surface (not just nudge) in these windows: defend lunch and
+  # the post-EOD evening from spillover admin.
+  protected_windows:
+    - start: "12:00"
+      end: "12:30"
+      label: "lunch"
+    - start: "17:00"
+      end: "23:59"
+      label: "evening"
 
 guardrails:
   rumination_threshold: 3

--- a/profiles/student-university.yaml
+++ b/profiles/student-university.yaml
@@ -51,49 +51,44 @@
 #       arguments — students benefit from challenge as well as
 #       affirmation.
 #
-# Semester cadence — fields the schema does NOT yet model:
-#   This preset shares the semester-awareness problem with
-#   educator-semester.yaml. The same candidate schema fields apply
-#   (tracked in profiles/README.md):
+# Semester cadence — schema fields this preset sets (since v0.1.x, ADR 0011):
 #     - chronometric.calendar_phase
-#         "teaching" | "deadlines" | "exam" | "break"
-#         lets skills shift defaults across the term. Week 1 of
-#         semester (light load, social calibration) has a very
-#         different demand profile from week 12 (deadline cluster,
-#         everything due at once) and from exam week (single-task
-#         focus, revision blocks).
-#     - chronometric.deadline_cluster_awareness
-#         hint to surface deadline proximity in planning skills;
-#         when three assignments are due in a single week, the
-#         break-cadence math should shift.
+#         "teaching" | "marking" | "exam" | "deadlines" | "break".
+#         Lets skills shift defaults across the term. Week 1 (light
+#         load, social calibration) has a very different demand profile
+#         from week 12 (deadline cluster) and from exam week (single-
+#         task focus, revision blocks). Ships "teaching" as the neutral
+#         starting point — move it as the term progresses. (Consumer
+#         pending: mcp-chronometric.)
+#     - chronometric.deadline_cluster_awareness = true
+#         surface deadline proximity in planning skills; when three
+#         assignments are due in a single week, the break-cadence math
+#         should shift. (Consumer pending: task-fractionator.)
 #     - chronometric.weekday_overrides
 #         per-weekday overrides for end_of_day_local and
-#         hyperfocus_break_minutes — a Tuesday with a 09:00 lecture
-#         and a Saturday with a 14:00 study session are different
-#         shapes of day.
+#         hyperfocus_break_minutes — a Saturday study day genuinely
+#         supports a longer block than a lecture-heavy weekday. This
+#         preset bumps Saturday's break cadence to 120.
 #     - chronometric.protected_windows
-#         list of local-time ranges where the hyperfocus monitor
-#         should hard-surface (lecture blocks, lab times, scheduled
-#         study group meetings).
-#   Until those land in a schema bump, encode the intent in this
-#   comment block and in the user-tunable notes below.
+#         local-time ranges where the hyperfocus monitor hard-surfaces
+#         rather than nudges: a lunch window and the post-22:00 night.
 #
 # Exam-week override hint:
-#   During exam revision, drop hyperfocus_break_minutes to 60 (the
-#   schema-floor "gentle" rung) and consider swapping to the
-#   low-stimulation preset for the worst week. Sleep matters more
-#   than one extra revision hour; the firm break cadence is part of
-#   that.
+#   During exam revision, set calendar_phase to "exam", drop
+#   hyperfocus_break_minutes to 60 (the schema-floor "gentle" rung),
+#   and consider swapping to the low-stimulation preset for the worst
+#   week. Sleep matters more than one extra revision hour; the firm
+#   break cadence is part of that.
 #
 # Library-block vs lecture-day pattern:
 #   A "library day" (single 90-minute block per nudge cadence, EOD at
 #   22:00, motion reduced) and a "lecture day" (multiple short
-#   teaching blocks interleaved with travel/transitions, lower
-#   typing volume but higher cognitive switching cost) are different
-#   shapes of day. v0.1.0 cannot model this; until weekday_overrides
-#   exists, accept that the lecture-day will fire the structured
-#   nudge between lectures and treat that as a "have you eaten /
-#   drunk water" reminder rather than a working-session interruption.
+#   teaching blocks interleaved with travel/transitions, lower typing
+#   volume but higher cognitive switching cost) are different shapes of
+#   day. Use weekday_overrides to model the days that genuinely differ;
+#   on a lecture-day the structured nudge between lectures is best read
+#   as a "have you eaten / drunk water" reminder rather than a working-
+#   session interruption.
 #
 #   USER-TUNABLE (edit freely after copying):
 #     - identity.display_name       set to your preferred handle.
@@ -158,6 +153,26 @@ chronometric:
   # be winding down to protect tomorrow's 09:00.
   end_of_day_local: "22:00"
   session_overlap_policy: "auto_close"
+  # Neutral starting point for the term. Move to "deadlines" in week 12
+  # and "exam" during revision for tighter cadence; "break" loosens it.
+  calendar_phase: "teaching"
+  # When assignments cluster, planning skills should surface deadline
+  # proximity and shift the break-cadence math.
+  deadline_cluster_awareness: true
+  # A Saturday study day supports a longer focused block than a lecture-
+  # heavy weekday — bump that day's break cadence only.
+  weekday_overrides:
+    saturday:
+      hyperfocus_break_minutes: 120
+  # Hard-surface (not just nudge) in these windows: defend lunch and the
+  # post-22:00 night that protects tomorrow's 09:00.
+  protected_windows:
+    - start: "12:00"
+      end: "12:30"
+      label: "lunch"
+    - start: "22:00"
+      end: "23:59"
+      label: "wind-down"
 
 guardrails:
   rumination_threshold: 3


### PR DESCRIPTION
## What

R5 (schema part). Promotes the eight documented "candidate fields" in `profiles/README.md`
to real **optional, additive** profile fields, per ADR-0011 (one schema, additive-only):

- `preferences.line_height_hint` (enum compact|default|relaxed), `preferences.voice_input_preferred`
- `chronometric.calendar_phase`, `weekday_overrides`, `protected_windows`,
  `deadline_cluster_awareness`, `time_buffer_multiplier`, `motor_fatigue_aware`

All optional and backward-compatible — an existing v0.1.0 profile with none of them still
validates (asserted). **No `$id` bump** (additive minor per ADR-0004).

`line_height_hint` documents a **WCAG 1.4.8/1.4.12 conformance floor** (clients MUST NOT
render body line spacing below 1.5) with per-band numeric anchors — added after two reviewers
flagged the bands could otherwise license a sub-1.5 render.

Adds hand-written `@neurodock/core` `Profile` types with a runtime schema-assertion test (so
type↔schema can't drift), a version-drift guard test, sensible per-neurotype values in the
dyspraxia/dyslexic/educator/student presets, and updated README/example docs.

Consumers land separately: chronometric fields → mcp-chronometric (next PR); motor knobs →
task-fractionator (B1/R2); UI hints → extension (A3).

## Review

`core-expert` (TDD, RED→GREEN), reviewed by `code-reviewer` (WARN→fixed), `dyslexia-advocate`,
and `accessibility-auditor`. Fixes applied: WCAG line-height floor + per-band anchors;
documented intentional TS deviation on the closed `$defs` interfaces; version-drift guard
test; extracted shared Ajv test helper; onboarding example block.
(Note: `dyspraxia-advocate` doesn't exist yet — it's created in the R3 PR — so the dyspraxia
fields were reviewed by code-reviewer + accessibility-auditor.)

## Test plan

- [x] `pnpm --filter @neurodock/core lint typecheck test build` → 58/58
- [x] `pnpm --filter @neurodock/cli test` → 132/132 (runtime schema consumers unaffected)
- [x] backward-compat: identity-only + full-v0.1.0 profiles still validate
- [x] `wrangler.jsonc` excluded