### PR TITLE
feat(mcp-chronometric): consume the r5 chronometric profile fields

### DIFF
--- a/.changeset/chronometric-r5-profile-fields.md
+++ b/.changeset/chronometric-r5-profile-fields.md
@@ -1,0 +1,37 @@
+---
+"@neurodock/core": minor
+---
+
+feat(mcp-chronometric): consume the r5 chronometric profile fields
+
+`neurodock-mcp-chronometric` (Python, PyPI) now reads and honours the optional
+`chronometric` profile fields added in r5 part a, alongside the existing
+`privacy.os_idle_consent`. Every change is additive and optional per adr 0011:
+new output fields only, never a change to an existing field, and never a
+neurotype branch. a profile that declares none of the new fields produces the
+exact pre-r5 wire shape on every tool (covered by a backward-compat test).
+
+read from `profile.chronometric`:
+
+- `weekday_overrides` — today's entry re-anchors the effective `end_of_day_local`
+  and `hyperfocus_break_minutes` on top of the base values; an absent or empty
+  override inherits the base.
+- `protected_windows` — local-time ranges (midnight-wrap supported when
+  `end` < `start`) where the break logic hard-surfaces.
+- `calendar_phase`, `deadline_cluster_awareness`, `motor_fatigue_aware` — surfaced.
+
+tool output changes (all additive optional, omitted when unset):
+
+- `get_time_context` — `effective_end_of_day_local`, `past_end_of_day`,
+  `calendar_phase`, `deadline_cluster_awareness`, `motor_fatigue_aware`.
+- `request_break_if_needed` — `escalation` (`nudge` | `hard_surface`) and
+  `protected_window_label`; hard-surfaces when the current local time is inside
+  a protected window, even below the threshold.
+- `idle_status` — `motor_fatigue_aware` (a declared preference, surfaced
+  regardless of consent; the server has no keystroke/click stream so reading
+  actual motor activity stays gated by `os_idle_consent`).
+
+`time_buffer_multiplier` is intentionally not consumed here — it belongs to the
+task-fractionator. json schemas under `packages/mcp-chronometric/schemas/` and
+the pydantic models are updated together and validated by the protocol
+conformance test.

--- a/packages/mcp-chronometric/CHANGELOG.md
+++ b/packages/mcp-chronometric/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to `neurodock-mcp-chronometric` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This package follows semantic versioning.
 
+## [0.1.0] - 2026-06-18
+
+### Added
+
+- Consume the optional `chronometric` profile fields added in R5 (ADR 0011).
+  All output changes are additive and optional: a profile that declares none of
+  these fields produces the exact pre-R5 wire shape on every tool.
+  - `get_time_context` now surfaces `effective_end_of_day_local` (today's
+    weekday-resolved end-of-day), `past_end_of_day`, and echoes
+    `calendar_phase`, `deadline_cluster_awareness`, and `motor_fatigue_aware`.
+  - `request_break_if_needed` now surfaces `escalation` (`nudge` |
+    `hard_surface`) and `protected_window_label`. When the current local time
+    falls inside a `protected_windows` entry it HARD-SURFACES — even below the
+    threshold — because the window itself is protected. Midnight-wrapping
+    windows (`end` < `start`) are handled.
+  - `idle_status` now surfaces `motor_fatigue_aware`. It is a declared
+    preference (not OS data) so it is surfaced regardless of the consent gate;
+    the server has no keystroke/click stream, so reading actual motor activity
+    remains gated by `privacy.os_idle_consent` and must be done by an
+    activity-aware client.
+  - `weekday_overrides` re-anchor the effective `end_of_day_local` and
+    `hyperfocus_break_minutes` for the current weekday; unknown weekday keys and
+    malformed protected windows are dropped silently rather than failing.
+- `chronometric.time_buffer_multiplier` is intentionally NOT read here — it is
+  consumed by the task-fractionator in a later release.
+
+### Notes
+
+- JSON Schemas under `packages/mcp-chronometric/schemas/` and the Pydantic
+  models in `schemas.py` are updated together and validated by the protocol
+  conformance test.
+- The protected-window matcher and the end-of-day cutoff normalise `now` to the
+  system-local wall clock (`.astimezone()`) before comparing against the user's
+  declared local `HH:MM`, so the result is independent of which timezone offset
+  the caller's `datetime` carries (e.g. a `TZ=UTC` container).
+- `CalendarPhase` is defined once in `schemas.py`; the loader derives its
+  membership set from the type via `typing.get_args` so the two cannot drift.
+
 ## [0.0.3] - 2026-05-31
 
 - Republish the PyPI README carrying the `mcp-name:` marker so the MCP Registry can verify io.github.tlennon-ie ownership.

--- a/packages/mcp-chronometric/pyproject.toml
+++ b/packages/mcp-chronometric/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-chronometric"
-version = "0.0.3"
+version = "0.1.0"
 description = "NeuroDock chronometric MCP server — time, idle, and break management."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,6 +25,14 @@ test = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.24.0",
     "jsonschema>=4.21.0",
+]
+# Lint/type-check tooling. ``types-PyYAML`` is required for ``mypy --strict`` to
+# resolve ``import yaml`` in profile.py without an ``ignore_missing_imports``
+# override, keeping the package self-contained for type-checking.
+dev = [
+    "ruff>=0.8.0",
+    "mypy>=1.13.0",
+    "types-PyYAML>=6.0",
 ]
 
 [project.scripts]

--- a/packages/mcp-chronometric/schemas/get_time_context.schema.json
+++ b/packages/mcp-chronometric/schemas/get_time_context.schema.json
@@ -67,6 +67,29 @@
             "night_owl_caution",
             "unknown"
           ]
+        },
+        "effective_end_of_day_local": {
+          "type": "string",
+          "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$",
+          "description": "Optional (added v0.1.x per ADR 0011). Today's effective end-of-day cutoff, 'HH:MM' (24h) local. Resolved from profile.chronometric.end_of_day_local with the current weekday's profile.chronometric.weekday_overrides entry applied on top. Present only when the profile declares an end-of-day for today; absent otherwise.",
+          "examples": ["16:00", "18:30"]
+        },
+        "past_end_of_day": {
+          "type": "boolean",
+          "description": "Optional (added v0.1.x per ADR 0011). True when the local clock has reached 'effective_end_of_day_local' (inclusive). Present only when an effective end-of-day exists for today. Reports the fact; the downstream skill decides whether to surface anything."
+        },
+        "calendar_phase": {
+          "type": "string",
+          "enum": ["teaching", "marking", "exam", "deadlines", "break"],
+          "description": "Optional (added v0.1.x per ADR 0011). Echo of the user's self-declared profile.chronometric.calendar_phase so planning skills can shift defaults across the term. Surfaced verbatim; the chronometric server applies no phase-specific heuristic in this release. Absent when the profile does not declare it."
+        },
+        "deadline_cluster_awareness": {
+          "type": "boolean",
+          "description": "Optional (added v0.1.x per ADR 0011). Echo of profile.chronometric.deadline_cluster_awareness; present (true) only when the user opted in, so planning skills know to weight deadline proximity. Absent otherwise."
+        },
+        "motor_fatigue_aware": {
+          "type": "boolean",
+          "description": "Optional (added v0.1.x per ADR 0011). Echo of profile.chronometric.motor_fatigue_aware; present (true) only when the user opted in. The chronometric server has no keystroke/click stream so it cannot weight motor fatigue itself; this flag tells an activity-aware client to do so. Absent otherwise."
         }
       }
     }

--- a/packages/mcp-chronometric/schemas/idle_status.schema.json
+++ b/packages/mcp-chronometric/schemas/idle_status.schema.json
@@ -36,6 +36,10 @@
           "type": "string",
           "format": "date-time",
           "description": "ISO 8601 timestamp at which the idle reading was taken. Optional; included when a real OS sample was performed."
+        },
+        "motor_fatigue_aware": {
+          "type": "boolean",
+          "description": "Optional (added v0.1.x per ADR 0011). Echo of profile.chronometric.motor_fatigue_aware; present (true) only when the user opted in. A declared preference, NOT OS data, so it is surfaced regardless of consent. The chronometric server has no keystroke/click stream, so it cannot compute activity-weighted fatigue itself; this flag tells a client that DOES have an activity stream to weight motor fatigue alongside continuous-session length. Reading actual motor activity remains gated by privacy.os_idle_consent. Absent otherwise."
         }
       }
     }

--- a/packages/mcp-chronometric/schemas/request_break_if_needed.schema.json
+++ b/packages/mcp-chronometric/schemas/request_break_if_needed.schema.json
@@ -56,6 +56,15 @@
               "type": "integer",
               "minimum": 1,
               "description": "Echo of the threshold that triggered this response, for debugging."
+            },
+            "escalation": {
+              "type": "string",
+              "enum": ["nudge", "hard_surface"],
+              "description": "Optional (added v0.1.x per ADR 0011). Coarse escalation rung. 'nudge' (default, today's behaviour) when the session crossed the threshold outside any protected window. 'hard_surface' when the current local time falls inside a profile.chronometric.protected_windows entry — the firm rung, applied because the window itself is protected, so it can fire even below the threshold. Surfaced so skills can quote the user back to themselves (e.g. the protected window they set) rather than scolding them. Absent when the profile declares no protected windows and the legacy threshold path produced the suggestion without an escalation rung."
+            },
+            "protected_window_label": {
+              "type": "string",
+              "description": "Optional (added v0.1.x per ADR 0011). The optional human label of the matched protected window, surfaced when 'escalation' is 'hard_surface' and the window carried a label. Absent otherwise."
             }
           }
         }

--- a/packages/mcp-chronometric/src/neurodock_mcp_chronometric/profile.py
+++ b/packages/mcp-chronometric/src/neurodock_mcp_chronometric/profile.py
@@ -2,11 +2,28 @@
 # Copyright (c) 2026 NeuroDock contributors.
 """Thin loader for ``~/.neurodock/profile.yaml``.
 
-Only the fields the chronometric server needs are read in v0.0.1:
+Fields the chronometric server reads:
 
 * ``privacy.os_idle_consent`` — gates the OS idle probe.
 * ``chronometric.zones`` — optional override of the energy-zone bands
   (forward-compat hook; loader exposes it but server may ignore in v0.0.1).
+* ``chronometric.hyperfocus_break_minutes`` / ``chronometric.end_of_day_local``
+  — base thresholds, optionally re-anchored per weekday by
+  ``chronometric.weekday_overrides`` (R5).
+* ``chronometric.weekday_overrides`` — per-weekday overrides of the two base
+  thresholds above; keyed by lowercase English weekday name (R5).
+* ``chronometric.protected_windows`` — local-time ranges where the hyperfocus
+  monitor hard-surfaces rather than nudges; a range whose ``end`` precedes its
+  ``start`` wraps past midnight (R5).
+* ``chronometric.calendar_phase`` — term/semester phase hint (R5).
+* ``chronometric.deadline_cluster_awareness`` — boolean planning hint (R5).
+* ``chronometric.motor_fatigue_aware`` — boolean; surfaced so an
+  activity-aware client can weight motor fatigue. The chronometric server has
+  no keystroke/click stream, so it only *surfaces* this preference; reading
+  motor activity stays gated by ``privacy.os_idle_consent`` (R5).
+
+``chronometric.time_buffer_multiplier`` is intentionally NOT read here — it is
+consumed by the task-fractionator, not by chronometric.
 
 A ``NEURODOCK_PROFILE_PATH`` environment variable overrides the default path,
 which keeps tests fully isolated from the user's filesystem.
@@ -16,16 +33,69 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import yaml
+
+from neurodock_mcp_chronometric.schemas import CalendarPhase
 
 _LOG = logging.getLogger("neurodock_mcp_chronometric.profile")
 
 DEFAULT_PROFILE_PATH = Path.home() / ".neurodock" / "profile.yaml"
 PROFILE_PATH_ENV_VAR = "NEURODOCK_PROFILE_PATH"
+
+# Mirrors the profile schema's HH:MM (24h) pattern.
+_HHMM_RE = re.compile(r"^([01][0-9]|2[0-3]):[0-5][0-9]$")
+
+# The seven lowercase weekday keys the schema accepts for weekday_overrides.
+# Ordered Monday..Sunday to match ``datetime.weekday()`` (Monday == 0).
+WEEKDAY_KEYS: tuple[str, ...] = (
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+)
+
+# ``CalendarPhase`` is defined once in ``schemas.py`` (it owns the output
+# contract); the membership set is derived from the Literal's members so it can
+# never drift from the type.
+_CALENDAR_PHASES: frozenset[str] = frozenset(get_args(CalendarPhase))
+
+# Break-threshold bounds, mirroring the profile schema (hyperfocus_break_minutes
+# and the weekday-override counterpart both use 15..240).
+_BREAK_MIN = 15
+_BREAK_MAX = 240
+
+
+@dataclass(frozen=True)
+class WeekdayOverride:
+    """Per-weekday override of the two chronometric thresholds that vary by day.
+
+    Both members are optional; an all-``None`` override means "this weekday is
+    named but inherits the top-level values".
+    """
+
+    end_of_day_local: str | None = None
+    hyperfocus_break_minutes: int | None = None
+
+
+@dataclass(frozen=True)
+class ProtectedWindow:
+    """A single local-time range where the hyperfocus monitor hard-surfaces.
+
+    ``start`` and ``end`` are ``HH:MM`` (24h) strings; an ``end`` earlier than
+    ``start`` wraps past midnight (handled by the matcher in :mod:`windows`).
+    """
+
+    start: str
+    end: str
+    label: str | None = None
 
 
 @dataclass(frozen=True)
@@ -36,6 +106,15 @@ class ChronometricProfile:
     raw_zones: dict[str, Any] | None
     """Reserved for v0.1.x profile-declared zone overrides — unused in v0.0.1."""
 
+    # R5 additive fields. All optional; absent == today's behaviour.
+    hyperfocus_break_minutes: int | None = None
+    end_of_day_local: str | None = None
+    weekday_overrides: dict[str, WeekdayOverride] = field(default_factory=dict)
+    protected_windows: tuple[ProtectedWindow, ...] = ()
+    calendar_phase: CalendarPhase | None = None
+    deadline_cluster_awareness: bool = False
+    motor_fatigue_aware: bool = False
+
 
 def profile_path() -> Path:
     override = os.environ.get(PROFILE_PATH_ENV_VAR)
@@ -44,17 +123,111 @@ def profile_path() -> Path:
     return DEFAULT_PROFILE_PATH
 
 
+def _safe_default() -> ChronometricProfile:
+    return ChronometricProfile(os_idle_consent=False, raw_zones=None)
+
+
+def _parse_hhmm(value: Any) -> str | None:
+    """Return ``value`` if it is a well-formed HH:MM string, else ``None``."""
+
+    if isinstance(value, str) and _HHMM_RE.match(value):
+        return value
+    return None
+
+
+def _parse_break_minutes(value: Any) -> int | None:
+    """Return ``value`` if it is an int within the schema's 15..240 range."""
+
+    # bool is a subclass of int; reject it explicitly so True/False never leak.
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and _BREAK_MIN <= value <= _BREAK_MAX:
+        return value
+    return None
+
+
+def _parse_weekday_override(raw: Any) -> WeekdayOverride | None:
+    """Parse one weekday-override object; ``None`` if it is not a mapping."""
+
+    if not isinstance(raw, dict):
+        return None
+    return WeekdayOverride(
+        end_of_day_local=_parse_hhmm(raw.get("end_of_day_local")),
+        hyperfocus_break_minutes=_parse_break_minutes(raw.get("hyperfocus_break_minutes")),
+    )
+
+
+def _parse_weekday_overrides(raw: Any) -> dict[str, WeekdayOverride]:
+    """Parse the weekday_overrides map, dropping unknown/misspelt weekday keys."""
+
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, WeekdayOverride] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or key.lower() not in WEEKDAY_KEYS:
+            # A misspelt key would be a silent no-op anyway; drop it explicitly.
+            continue
+        override = _parse_weekday_override(value)
+        if override is not None:
+            result[key.lower()] = override
+    return result
+
+
+def _parse_protected_window(raw: Any) -> ProtectedWindow | None:
+    """Parse one protected-window object; ``None`` when malformed (dropped)."""
+
+    if not isinstance(raw, dict):
+        return None
+    start = _parse_hhmm(raw.get("start"))
+    end = _parse_hhmm(raw.get("end"))
+    if start is None or end is None:
+        return None
+    label_raw = raw.get("label")
+    label = label_raw if isinstance(label_raw, str) and label_raw else None
+    return ProtectedWindow(start=start, end=end, label=label)
+
+
+def _parse_protected_windows(raw: Any) -> tuple[ProtectedWindow, ...]:
+    """Parse the protected_windows list in declaration order, dropping bad items."""
+
+    if not isinstance(raw, list):
+        return ()
+    windows: list[ProtectedWindow] = []
+    for item in raw:
+        window = _parse_protected_window(item)
+        if window is not None:
+            windows.append(window)
+    return tuple(windows)
+
+
+def _parse_calendar_phase(value: Any) -> CalendarPhase | None:
+    """Return ``value`` if it is a recognised calendar-phase enum member."""
+
+    if isinstance(value, str) and value in _CALENDAR_PHASES:
+        # value is one of the literal members by the membership check above.
+        return value  # type: ignore[return-value]
+    return None
+
+
+def _parse_bool(value: Any) -> bool:
+    """Coerce a YAML bool to ``bool``; anything non-bool is ``False``."""
+
+    return value if isinstance(value, bool) else False
+
+
 def load_profile() -> ChronometricProfile:
     """Load the chronometric subset of the user profile.
 
-    Returns a safe-default profile (consent=False, no zones) when the file is
-    missing or unparseable. A structured warning is logged in the unparseable
-    case so the omission is visible — never silent.
+    Returns a safe-default profile (consent=False, no zones, neutral R5 fields)
+    when the file is missing or unparseable. A structured warning is logged in
+    the unparseable case so the omission is visible — never silent. All R5
+    fields default to today's behaviour when absent, so an existing profile that
+    carries none of them is unchanged.
     """
 
     path = profile_path()
     if not path.exists():
-        return ChronometricProfile(os_idle_consent=False, raw_zones=None)
+        return _safe_default()
 
     try:
         with path.open("r", encoding="utf-8") as fp:
@@ -64,10 +237,10 @@ def load_profile() -> ChronometricProfile:
             "profile_unreadable",
             extra={"event": "profile_unreadable", "error_type": type(exc).__name__},
         )
-        return ChronometricProfile(os_idle_consent=False, raw_zones=None)
+        return _safe_default()
 
     if not isinstance(data, dict):
-        return ChronometricProfile(os_idle_consent=False, raw_zones=None)
+        return _safe_default()
 
     privacy = data.get("privacy")
     consent = False
@@ -77,10 +250,20 @@ def load_profile() -> ChronometricProfile:
             consent = consent_raw
 
     chronometric = data.get("chronometric")
-    raw_zones: dict[str, Any] | None = None
-    if isinstance(chronometric, dict):
-        zones = chronometric.get("zones")
-        if isinstance(zones, dict):
-            raw_zones = zones
+    if not isinstance(chronometric, dict):
+        return ChronometricProfile(os_idle_consent=consent, raw_zones=None)
 
-    return ChronometricProfile(os_idle_consent=consent, raw_zones=raw_zones)
+    zones = chronometric.get("zones")
+    raw_zones: dict[str, Any] | None = zones if isinstance(zones, dict) else None
+
+    return ChronometricProfile(
+        os_idle_consent=consent,
+        raw_zones=raw_zones,
+        hyperfocus_break_minutes=_parse_break_minutes(chronometric.get("hyperfocus_break_minutes")),
+        end_of_day_local=_parse_hhmm(chronometric.get("end_of_day_local")),
+        weekday_overrides=_parse_weekday_overrides(chronometric.get("weekday_overrides")),
+        protected_windows=_parse_protected_windows(chronometric.get("protected_windows")),
+        calendar_phase=_parse_calendar_phase(chronometric.get("calendar_phase")),
+        deadline_cluster_awareness=_parse_bool(chronometric.get("deadline_cluster_awareness")),
+        motor_fatigue_aware=_parse_bool(chronometric.get("motor_fatigue_aware")),
+    )

--- a/packages/mcp-chronometric/src/neurodock_mcp_chronometric/schemas.py
+++ b/packages/mcp-chronometric/src/neurodock_mcp_chronometric/schemas.py
@@ -38,6 +38,20 @@ SuggestedAction = Literal[
 
 HyperfocusSignal = Literal["active", "switched_away", "unknown"]
 
+# Calendar/semester phase the user self-declares (profile.chronometric.calendar_phase).
+# Surfaced additively so planning skills can shift defaults across the term.
+CalendarPhase = Literal["teaching", "marking", "exam", "deadlines", "break"]
+
+# Coarse escalation rung for a break suggestion. ``nudge`` is the default rung
+# (today's behaviour); ``hard_surface`` is the firm rung, fired when the current
+# local time falls inside a profile-declared protected window (R5). The rung is
+# surfaced so skills can quote the user's own protected window back to them
+# rather than scolding them; the enum value name is NOT user-facing copy.
+BreakEscalation = Literal["nudge", "hard_surface"]
+
+# HH:MM (24h) local-time pattern, mirroring the profile schema.
+_HHMM_PATTERN = r"^([01][0-9]|2[0-3]):[0-5][0-9]$"
+
 # ISO 8601 duration pattern, mirroring the JSON Schemas. Pydantic v2 uses Rust
 # regex which does not support look-ahead, so we validate via a Python re check
 # in a field validator rather than as a Field(pattern=...) constraint.
@@ -67,6 +81,21 @@ class TimeContextOutput(_Base):
     time_since_last_prompt: str
     current_session_length: str
     energy_zone: EnergyZone
+
+    # R5 additive optional fields. Present only when the profile declares the
+    # corresponding input; absent (None) reproduces today's wire shape.
+    effective_end_of_day_local: str | None = Field(default=None, pattern=_HHMM_PATTERN)
+    past_end_of_day: bool | None = Field(
+        default=None,
+        description=(
+            "True when the local clock has reached 'effective_end_of_day_local' "
+            "(inclusive). Reports the fact; the downstream skill decides whether "
+            "to surface anything."
+        ),
+    )
+    calendar_phase: CalendarPhase | None = None
+    deadline_cluster_awareness: bool | None = None
+    motor_fatigue_aware: bool | None = None
 
     @field_validator("time_since_last_prompt", "current_session_length")
     @classmethod
@@ -130,6 +159,22 @@ class BreakSuggestion(_Base):
     suggested_action: SuggestedAction
     threshold_minutes: int = Field(ge=1)
 
+    # R5 additive optional fields. ``escalation`` defaults to ``nudge`` (today's
+    # behaviour) and rises to ``hard_surface`` (the firm rung) inside a protected
+    # window; ``protected_window_label`` carries the matched window's optional
+    # label.
+    escalation: BreakEscalation | None = Field(
+        default=None,
+        description=(
+            "Coarse escalation rung. 'nudge' (default) when the session crossed "
+            "the threshold outside any protected window; 'hard_surface' (the firm "
+            "rung) inside a profile-declared protected window. Surfaced so skills "
+            "can quote the user's own protected window back to them rather than "
+            "scolding them."
+        ),
+    )
+    protected_window_label: str | None = None
+
     @field_validator("elapsed")
     @classmethod
     def _validate_duration(cls, value: str) -> str:
@@ -145,3 +190,10 @@ class IdleStatusOutput(_Base):
     hyperfocus_signal: HyperfocusSignal
     consent_granted: bool
     sampled_at: str | None = None
+
+    # R5 additive optional field. The chronometric server has no keystroke/click
+    # stream, so it cannot compute activity-weighted fatigue itself; it surfaces
+    # the user's declared preference so a client that DOES have an activity
+    # stream knows to weight motor fatigue. Reading motor activity remains gated
+    # by ``profile.privacy.os_idle_consent``.
+    motor_fatigue_aware: bool | None = None

--- a/packages/mcp-chronometric/src/neurodock_mcp_chronometric/server.py
+++ b/packages/mcp-chronometric/src/neurodock_mcp_chronometric/server.py
@@ -16,7 +16,7 @@ from typing import Any
 from fastmcp import FastMCP
 
 from neurodock_mcp_chronometric.clock import Clock, SystemClock
-from neurodock_mcp_chronometric.profile import ChronometricProfile
+from neurodock_mcp_chronometric.profile import ChronometricProfile, load_profile
 from neurodock_mcp_chronometric.state import SessionState
 from neurodock_mcp_chronometric.tools.break_request import (
     ThresholdOutOfRangeError,
@@ -34,7 +34,7 @@ from neurodock_mcp_chronometric.tools.session import (
 from neurodock_mcp_chronometric.tools.time_context import get_time_context
 
 SERVER_NAME = "neurodock-mcp-chronometric"
-SERVER_VERSION = "0.0.2"
+SERVER_VERSION = "0.1.0"
 
 _LOG = logging.getLogger("neurodock_mcp_chronometric.server")
 
@@ -62,6 +62,10 @@ def build_server(
 
     effective_state = state if state is not None else SessionState()
     effective_clock: Clock = clock if clock is not None else SystemClock()
+    # Load the profile once at construction time so every tool reads a single,
+    # consistent snapshot of the chronometric thresholds and consent flag. Tests
+    # inject a deterministic profile; production callers pass nothing.
+    effective_profile = profile if profile is not None else load_profile()
 
     mcp: FastMCP[Any] = FastMCP(name=SERVER_NAME, version=SERVER_VERSION)
 
@@ -74,9 +78,9 @@ def build_server(
     )
     def _get_time_context() -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "get_time_context"})
-        return get_time_context(clock=effective_clock, state=effective_state).model_dump(
-            exclude_none=True
-        )
+        return get_time_context(
+            clock=effective_clock, state=effective_state, profile=effective_profile
+        ).model_dump(exclude_none=True)
 
     @mcp.tool(
         name="mark_session_start",
@@ -126,12 +130,16 @@ def build_server(
                 threshold_minutes=threshold_minutes,
                 clock=effective_clock,
                 state=effective_state,
+                profile=effective_profile,
             )
         except ThresholdOutOfRangeError as exc:
             raise _ToolError("THRESHOLD_OUT_OF_RANGE", str(exc)) from exc
         if result is None:
             return None
-        return result.model_dump(exclude_none=False)
+        # exclude_none drops the additive optional fields (escalation,
+        # protected_window_label) when unset; the four legacy fields are always
+        # populated so the wire shape is unchanged when no profile windows match.
+        return result.model_dump(exclude_none=True)
 
     @mcp.tool(
         name="idle_status",
@@ -142,12 +150,15 @@ def build_server(
     )
     def _idle_status() -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "idle_status"})
-        result = idle_status(clock=effective_clock, profile=profile)
-        # os_idle_seconds is required by the schema (nullable). sampled_at is
-        # optional and only included when a real sample was taken.
+        result = idle_status(clock=effective_clock, profile=effective_profile)
+        # os_idle_seconds is required by the schema (nullable), so we dump with
+        # exclude_none=False to keep it, then drop the genuinely-optional fields
+        # (sampled_at, motor_fatigue_aware) when they are unset.
         payload = result.model_dump(exclude_none=False)
         if result.sampled_at is None:
             payload.pop("sampled_at", None)
+        if result.motor_fatigue_aware is None:
+            payload.pop("motor_fatigue_aware", None)
         return payload
 
     return mcp

--- a/packages/mcp-chronometric/src/neurodock_mcp_chronometric/tools/break_request.py
+++ b/packages/mcp-chronometric/src/neurodock_mcp_chronometric/tools/break_request.py
@@ -8,8 +8,14 @@ from datetime import timedelta
 
 from neurodock_mcp_chronometric.clock import Clock
 from neurodock_mcp_chronometric.duration import format_duration
-from neurodock_mcp_chronometric.schemas import BreakSuggestion, SuggestedAction
+from neurodock_mcp_chronometric.profile import ChronometricProfile
+from neurodock_mcp_chronometric.schemas import (
+    BreakEscalation,
+    BreakSuggestion,
+    SuggestedAction,
+)
 from neurodock_mcp_chronometric.state import SessionState
+from neurodock_mcp_chronometric.windows import matched_protected_window
 
 
 class ThresholdOutOfRangeError(ValueError):
@@ -17,12 +23,27 @@ class ThresholdOutOfRangeError(ValueError):
 
 
 def request_break_if_needed(
-    *, threshold_minutes: int, clock: Clock, state: SessionState
+    *,
+    threshold_minutes: int,
+    clock: Clock,
+    state: SessionState,
+    profile: ChronometricProfile | None = None,
 ) -> BreakSuggestion | None:
-    """Return a break suggestion when the open session has exceeded the threshold.
+    """Return a break suggestion when a break is warranted.
 
-    Returns ``None`` when no session is open or the session has not yet reached
-    the threshold. ``null`` is a first-class return value here (per ADR 0001).
+    Returns ``None`` when no session is open, the session has not yet reached the
+    threshold, and the current local time is not inside a protected window.
+    ``null`` is a first-class return value here (per ADR 0001).
+
+    When ``profile`` declares ``protected_windows`` and the current local time
+    falls inside one, the suggestion HARD-SURFACES (``escalation="hard_surface"``)
+    regardless of the threshold — the window itself is protected, not because the
+    session ran long — and the matched window's optional ``label`` is surfaced.
+    Inside the protected-window regime but outside any window, the legacy
+    threshold behaviour applies with ``escalation="nudge"`` so the two rungs are
+    distinguishable. When the profile declares NO protected windows (or is
+    ``None``), the ``escalation`` field is left unset, reproducing the exact
+    pre-R5 wire shape.
     """
 
     if not isinstance(threshold_minutes, int) or isinstance(threshold_minutes, bool):
@@ -36,14 +57,36 @@ def request_break_if_needed(
 
     now = clock.now()
     elapsed = now - open_session.started_at
-    if elapsed < timedelta(minutes=threshold_minutes):
+
+    window = matched_protected_window(profile, now) if profile is not None else None
+    over_threshold = elapsed >= timedelta(minutes=threshold_minutes)
+
+    # A protected window hard-surfaces on its own; otherwise we only suggest a
+    # break once the session has crossed the threshold.
+    if window is None and not over_threshold:
         return None
 
+    if window is not None:
+        return BreakSuggestion(
+            elapsed=format_duration(elapsed),
+            prior_intent=open_session.intent,
+            suggested_action=_suggested_action_for(elapsed),
+            threshold_minutes=threshold_minutes,
+            escalation="hard_surface",
+            protected_window_label=window.label,
+        )
+
+    # Only annotate the rung once a protected-window regime is in play; with no
+    # windows configured the escalation field stays unset so the wire shape is
+    # byte-identical to the pre-R5 nudge.
+    has_windows = profile is not None and bool(profile.protected_windows)
+    escalation: BreakEscalation | None = "nudge" if has_windows else None
     return BreakSuggestion(
         elapsed=format_duration(elapsed),
         prior_intent=open_session.intent,
         suggested_action=_suggested_action_for(elapsed),
         threshold_minutes=threshold_minutes,
+        escalation=escalation,
     )
 
 

--- a/packages/mcp-chronometric/src/neurodock_mcp_chronometric/tools/idle.py
+++ b/packages/mcp-chronometric/src/neurodock_mcp_chronometric/tools/idle.py
@@ -28,12 +28,21 @@ def idle_status(
 
     effective_profile = profile if profile is not None else load_profile()
 
+    # ``motor_fatigue_aware`` is a declared user preference, not OS data, so it
+    # is surfaced regardless of the consent gate. It is set only when True so an
+    # untouched profile keeps the field absent under exclude_none. The server has
+    # no keystroke/click stream of its own, so this only TELLS an activity-aware
+    # client to weight motor fatigue; reading actual motor activity stays gated
+    # by ``os_idle_consent``.
+    motor_fatigue_aware: bool | None = True if effective_profile.motor_fatigue_aware else None
+
     if not effective_profile.os_idle_consent:
         log_consent_missing()
         return IdleStatusOutput(
             os_idle_seconds=None,
             hyperfocus_signal="unknown",
             consent_granted=False,
+            motor_fatigue_aware=motor_fatigue_aware,
         )
 
     sampled_at = clock.now()
@@ -47,6 +56,7 @@ def idle_status(
             hyperfocus_signal="unknown",
             consent_granted=True,
             sampled_at=sampled_at.isoformat(),
+            motor_fatigue_aware=motor_fatigue_aware,
         )
 
     signal: HyperfocusSignal = "active" if probe.os_idle_seconds < 30 else "switched_away"
@@ -55,4 +65,5 @@ def idle_status(
         hyperfocus_signal=signal,
         consent_granted=True,
         sampled_at=sampled_at.isoformat(),
+        motor_fatigue_aware=motor_fatigue_aware,
     )

--- a/packages/mcp-chronometric/src/neurodock_mcp_chronometric/tools/time_context.py
+++ b/packages/mcp-chronometric/src/neurodock_mcp_chronometric/tools/time_context.py
@@ -4,13 +4,15 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from neurodock_mcp_chronometric.clock import Clock
 from neurodock_mcp_chronometric.duration import format_duration
 from neurodock_mcp_chronometric.energy_zone import compute_energy_zone
+from neurodock_mcp_chronometric.profile import ChronometricProfile
 from neurodock_mcp_chronometric.schemas import DayOfWeek, TimeContextOutput
 from neurodock_mcp_chronometric.state import SessionState
+from neurodock_mcp_chronometric.windows import resolve_end_of_day_local
 
 _DAY_NAMES: tuple[DayOfWeek, ...] = (
     "Monday",
@@ -23,11 +25,23 @@ _DAY_NAMES: tuple[DayOfWeek, ...] = (
 )
 
 
-def get_time_context(*, clock: Clock, state: SessionState) -> TimeContextOutput:
+def get_time_context(
+    *,
+    clock: Clock,
+    state: SessionState,
+    profile: ChronometricProfile | None = None,
+) -> TimeContextOutput:
     """Return the current time context (see schema for full description).
 
     Side effects: updates the server's ``last_prompt_at`` marker so the next
     call computes ``time_since_last_prompt`` relative to this call.
+
+    When ``profile`` is provided, the R5 additive fields are populated from it:
+    ``effective_end_of_day_local`` (today's weekday-resolved end-of-day),
+    ``past_end_of_day`` (whether the local clock has reached that cutoff), and
+    the surfaced ``calendar_phase`` / ``deadline_cluster_awareness`` /
+    ``motor_fatigue_aware`` hints. When ``profile`` is ``None`` (or declares none
+    of these), every R5 field stays ``None`` so the wire shape is unchanged.
     """
 
     now = clock.now()
@@ -37,10 +51,53 @@ def get_time_context(*, clock: Clock, state: SessionState) -> TimeContextOutput:
     open_session = state.current_open()
     session_length = (now - open_session.started_at) if open_session else timedelta(0)
 
+    effective_end_of_day: str | None = None
+    past_end_of_day: bool | None = None
+    calendar_phase = None
+    deadline_cluster_awareness: bool | None = None
+    motor_fatigue_aware: bool | None = None
+
+    if profile is not None:
+        effective_end_of_day = resolve_end_of_day_local(profile, now)
+        if effective_end_of_day is not None:
+            past_end_of_day = _is_past_cutoff(now, effective_end_of_day)
+        calendar_phase = profile.calendar_phase
+        # Surface the boolean hints only when set so an untouched profile keeps
+        # the field absent under exclude_none. The False->None collapse is
+        # intentional: a hint the user did not opt into must not appear on the
+        # wire at all (per ADR 0011 additivity), so we never emit ``false`` —
+        # only ``true`` when opted in, or omit the field entirely.
+        if profile.deadline_cluster_awareness:
+            deadline_cluster_awareness = True
+        if profile.motor_fatigue_aware:
+            motor_fatigue_aware = True
+
     return TimeContextOutput(
         now=now.isoformat(),
         day_of_week=_DAY_NAMES[now.weekday()],
         time_since_last_prompt=format_duration(time_since_last),
         current_session_length=format_duration(session_length),
         energy_zone=compute_energy_zone(now),
+        effective_end_of_day_local=effective_end_of_day,
+        past_end_of_day=past_end_of_day,
+        calendar_phase=calendar_phase,
+        deadline_cluster_awareness=deadline_cluster_awareness,
+        motor_fatigue_aware=motor_fatigue_aware,
     )
+
+
+def _is_past_cutoff(now: datetime, hhmm: str) -> bool:
+    """Whether ``now``'s local clock has reached the ``HH:MM`` cutoff (inclusive).
+
+    Local-wall-clock contract: ``hhmm`` is the user's declared LOCAL end-of-day,
+    so ``now`` is normalised with ``.astimezone()`` before its minute-of-day is
+    read. The result is independent of which tz offset the caller's ``datetime``
+    carries (e.g. a UTC-tz clock compares the user's local time, not raw UTC
+    hours). ``hhmm`` is pre-validated HH:MM, so the split + int parse cannot
+    raise here.
+    """
+
+    hour_str, minute_str = hhmm.split(":")
+    cutoff_minute = int(hour_str) * 60 + int(minute_str)
+    local = now.astimezone()
+    return (local.hour * 60 + local.minute) >= cutoff_minute

--- a/packages/mcp-chronometric/src/neurodock_mcp_chronometric/windows.py
+++ b/packages/mcp-chronometric/src/neurodock_mcp_chronometric/windows.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Pure resolution helpers for the R5 chronometric profile fields.
+
+These functions are deliberately small and side-effect-free so the heuristics
+are auditable and unit-testable without a clock dependency beyond the tz-aware
+``datetime`` passed in. They map the declarative profile fields onto the
+"effective for today / right now" values the tools need:
+
+* :func:`resolve_end_of_day_local` and :func:`resolve_hyperfocus_break_minutes`
+  apply today's ``weekday_overrides`` entry (if any) on top of the base value.
+* :func:`matched_protected_window` returns the first ``protected_windows`` entry
+  that contains the current local time, handling the midnight-wrap case where a
+  window's ``end`` precedes its ``start``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from neurodock_mcp_chronometric.profile import (
+    WEEKDAY_KEYS,
+    ChronometricProfile,
+    ProtectedWindow,
+)
+
+
+def _today_override_key(now: datetime) -> str:
+    """Return the lowercase weekday key for ``now`` (Monday == index 0)."""
+
+    return WEEKDAY_KEYS[now.weekday()]
+
+
+def resolve_end_of_day_local(profile: ChronometricProfile, now: datetime) -> str | None:
+    """Return today's effective ``end_of_day_local`` (HH:MM), or ``None``.
+
+    Today's ``weekday_overrides`` entry, when it sets ``end_of_day_local``,
+    re-anchors the base value. An absent override (or an override that does not
+    set this field) inherits the top-level ``end_of_day_local``.
+    """
+
+    override = profile.weekday_overrides.get(_today_override_key(now))
+    if override is not None and override.end_of_day_local is not None:
+        return override.end_of_day_local
+    return profile.end_of_day_local
+
+
+def resolve_hyperfocus_break_minutes(profile: ChronometricProfile, now: datetime) -> int | None:
+    """Return today's effective ``hyperfocus_break_minutes``, or ``None``.
+
+    Today's ``weekday_overrides`` entry, when it sets ``hyperfocus_break_minutes``,
+    re-anchors the base value. An absent override inherits the top-level value;
+    ``None`` means the profile declared nothing and the caller should apply its
+    own default.
+    """
+
+    override = profile.weekday_overrides.get(_today_override_key(now))
+    if override is not None and override.hyperfocus_break_minutes is not None:
+        return override.hyperfocus_break_minutes
+    return profile.hyperfocus_break_minutes
+
+
+def _minute_of_day(hhmm: str) -> int:
+    # Precondition: ``hhmm`` is pre-validated by the profile loader's HH:MM regex
+    # (``_HHMM_RE``), so the split + int parse below can never raise here.
+    hour_str, minute_str = hhmm.split(":")
+    return int(hour_str) * 60 + int(minute_str)
+
+
+def _window_contains(window: ProtectedWindow, minute_of_day: int) -> bool:
+    """Return whether ``minute_of_day`` falls inside ``window``.
+
+    The window is half-open: ``start`` is inclusive, ``end`` is exclusive, so
+    adjacent windows never double-match. When ``end`` < ``start`` the window
+    wraps past midnight, so the inside test becomes the union of
+    ``[start, 1440)`` and ``[0, end)``.
+    """
+
+    start = _minute_of_day(window.start)
+    end = _minute_of_day(window.end)
+
+    if start == end:
+        # Degenerate zero-length window: matches nothing.
+        return False
+    if start < end:
+        return start <= minute_of_day < end
+    # Wrap past midnight.
+    return minute_of_day >= start or minute_of_day < end
+
+
+def matched_protected_window(profile: ChronometricProfile, now: datetime) -> ProtectedWindow | None:
+    """Return the first protected window containing ``now``'s local time, or ``None``.
+
+    Windows are evaluated in declaration order, so an earlier window in the
+    profile wins when ranges overlap.
+
+    Local-wall-clock contract: protected-window ``start``/``end`` are the user's
+    declared LOCAL HH:MM, so ``now`` is normalised with ``.astimezone()`` before
+    its minute-of-day is read. The result is therefore independent of which tz
+    offset the caller's ``datetime`` happens to carry (e.g. a UTC-tz clock in a
+    container compares the user's local time, not raw UTC hours).
+    """
+
+    local = now.astimezone()
+    minute_of_day = local.hour * 60 + local.minute
+    for window in profile.protected_windows:
+        if _window_contains(window, minute_of_day):
+            return window
+    return None

--- a/packages/mcp-chronometric/tests/test_chronometric_resolution.py
+++ b/packages/mcp-chronometric/tests/test_chronometric_resolution.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Unit tests for the pure R5 resolution helpers.
+
+These cover the weekday-override resolution (today's effective end-of-day and
+hyperfocus break threshold) and protected-window matching, including the
+midnight-wrap case where ``end`` < ``start``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from neurodock_mcp_chronometric.profile import ChronometricProfile, ProtectedWindow, WeekdayOverride
+from neurodock_mcp_chronometric.windows import (
+    matched_protected_window,
+    resolve_end_of_day_local,
+    resolve_hyperfocus_break_minutes,
+)
+
+
+def _profile(**kwargs: object) -> ChronometricProfile:
+    base: dict[str, object] = {
+        "os_idle_consent": False,
+        "raw_zones": None,
+        "hyperfocus_break_minutes": None,
+        "end_of_day_local": None,
+        "weekday_overrides": {},
+        "protected_windows": (),
+        "calendar_phase": None,
+        "deadline_cluster_awareness": False,
+        "motor_fatigue_aware": False,
+    }
+    base.update(kwargs)
+    return ChronometricProfile(**base)  # type: ignore[arg-type]
+
+
+def _local(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    """Build a tz-aware datetime in the SYSTEM-LOCAL zone with these wall-clock
+    components.
+
+    Protected windows and end-of-day are declared in the user's LOCAL HH:MM, and
+    the matcher/cutoff normalise ``now`` with ``.astimezone()`` (system-local).
+    Constructing the test ``now`` in the local frame keeps the asserted
+    wall-clock stable on any machine, regardless of its system timezone.
+    """
+
+    return datetime(year, month, day, hour, minute).astimezone()
+
+
+# --------------------------------------------------------------- weekday overrides
+
+
+def test_end_of_day_uses_base_when_no_override_for_today() -> None:
+    """A weekday with no override inherits the top-level end_of_day_local."""
+
+    # 2026-05-15 is a Friday.
+    now = datetime(2026, 5, 15, 9, 0, tzinfo=UTC)
+    profile = _profile(end_of_day_local="18:30")
+
+    assert resolve_end_of_day_local(profile, now) == "18:30"
+
+
+def test_end_of_day_applies_todays_override() -> None:
+    """A weekday override for today re-anchors end_of_day_local."""
+
+    # Friday.
+    now = datetime(2026, 5, 15, 9, 0, tzinfo=UTC)
+    profile = _profile(
+        end_of_day_local="18:30",
+        weekday_overrides={"friday": WeekdayOverride(end_of_day_local="16:00")},
+    )
+
+    assert resolve_end_of_day_local(profile, now) == "16:00"
+
+
+def test_end_of_day_override_for_other_day_does_not_apply() -> None:
+    """An override keyed to a different weekday leaves today on the base value."""
+
+    # Friday; override is for Wednesday.
+    now = datetime(2026, 5, 15, 9, 0, tzinfo=UTC)
+    profile = _profile(
+        end_of_day_local="18:30",
+        weekday_overrides={"wednesday": WeekdayOverride(end_of_day_local="16:00")},
+    )
+
+    assert resolve_end_of_day_local(profile, now) == "18:30"
+
+
+def test_end_of_day_empty_override_inherits_base() -> None:
+    """An empty override object for today inherits the top-level value."""
+
+    now = datetime(2026, 5, 15, 9, 0, tzinfo=UTC)
+    profile = _profile(
+        end_of_day_local="18:30",
+        weekday_overrides={"friday": WeekdayOverride()},
+    )
+
+    assert resolve_end_of_day_local(profile, now) == "18:30"
+
+
+def test_break_minutes_applies_todays_override() -> None:
+    """A weekday override for today re-anchors hyperfocus_break_minutes."""
+
+    # Saturday.
+    now = datetime(2026, 5, 16, 9, 0, tzinfo=UTC)
+    profile = _profile(
+        hyperfocus_break_minutes=90,
+        weekday_overrides={"saturday": WeekdayOverride(hyperfocus_break_minutes=120)},
+    )
+
+    assert resolve_hyperfocus_break_minutes(profile, now) == 120
+
+
+def test_break_minutes_inherits_base_off_day() -> None:
+    """No override for today -> base hyperfocus_break_minutes."""
+
+    now = datetime(2026, 5, 16, 9, 0, tzinfo=UTC)  # Saturday
+    profile = _profile(
+        hyperfocus_break_minutes=90,
+        weekday_overrides={"monday": WeekdayOverride(hyperfocus_break_minutes=45)},
+    )
+
+    assert resolve_hyperfocus_break_minutes(profile, now) == 90
+
+
+def test_break_minutes_none_when_unset() -> None:
+    """When nothing is configured, the resolved value is None (caller defaults)."""
+
+    now = datetime(2026, 5, 16, 9, 0, tzinfo=UTC)
+    profile = _profile()
+
+    assert resolve_hyperfocus_break_minutes(profile, now) is None
+
+
+# ------------------------------------------------------------- protected windows
+
+
+def test_no_protected_windows_matches_nothing() -> None:
+    now = _local(2026, 5, 15, 12, 15)
+    profile = _profile()
+
+    assert matched_protected_window(profile, now) is None
+
+
+def test_time_inside_window_matches_and_returns_window() -> None:
+    """A time inside a normal (non-wrapping) window matches and is returned."""
+
+    now = _local(2026, 5, 15, 12, 15)
+    window = ProtectedWindow(start="12:00", end="12:30", label="lunch")
+    profile = _profile(protected_windows=(window,))
+
+    assert matched_protected_window(profile, now) == window
+
+
+def test_time_outside_window_does_not_match() -> None:
+    now = _local(2026, 5, 15, 13, 0)
+    window = ProtectedWindow(start="12:00", end="12:30", label="lunch")
+    profile = _profile(protected_windows=(window,))
+
+    assert matched_protected_window(profile, now) is None
+
+
+def test_window_start_is_inclusive() -> None:
+    now = _local(2026, 5, 15, 12, 0)
+    window = ProtectedWindow(start="12:00", end="12:30", label="lunch")
+    profile = _profile(protected_windows=(window,))
+
+    assert matched_protected_window(profile, now) == window
+
+
+def test_window_end_is_exclusive() -> None:
+    """The end minute is exclusive so adjacent windows do not double-match."""
+
+    now = _local(2026, 5, 15, 12, 30)
+    window = ProtectedWindow(start="12:00", end="12:30", label="lunch")
+    profile = _profile(protected_windows=(window,))
+
+    assert matched_protected_window(profile, now) is None
+
+
+def test_midnight_wrap_window_matches_late_evening() -> None:
+    """A window with end < start wraps past midnight (evening side)."""
+
+    # 23:30 is inside 22:00 -> 06:00.
+    now = _local(2026, 5, 15, 23, 30)
+    window = ProtectedWindow(start="22:00", end="06:00", label="sleep")
+    profile = _profile(protected_windows=(window,))
+
+    assert matched_protected_window(profile, now) == window
+
+
+def test_midnight_wrap_window_matches_early_morning() -> None:
+    """A wrapping window also matches on the early-morning side."""
+
+    # 03:00 is inside 22:00 -> 06:00.
+    now = _local(2026, 5, 15, 3, 0)
+    window = ProtectedWindow(start="22:00", end="06:00", label="sleep")
+    profile = _profile(protected_windows=(window,))
+
+    assert matched_protected_window(profile, now) == window
+
+
+def test_midnight_wrap_window_excludes_daytime() -> None:
+    """A wrapping window does NOT match a time in the open daytime gap."""
+
+    now = _local(2026, 5, 15, 12, 0)
+    window = ProtectedWindow(start="22:00", end="06:00", label="sleep")
+    profile = _profile(protected_windows=(window,))
+
+    assert matched_protected_window(profile, now) is None
+
+
+def test_first_matching_window_wins() -> None:
+    """When two windows overlap, the first in declaration order is returned."""
+
+    now = _local(2026, 5, 15, 12, 15)
+    first = ProtectedWindow(start="12:00", end="13:00", label="lunch")
+    second = ProtectedWindow(start="12:10", end="12:20", label="standup")
+    profile = _profile(protected_windows=(first, second))
+
+    assert matched_protected_window(profile, now) == first
+
+
+# ------------------------------------------------------- timezone hardening
+
+
+def test_window_match_independent_of_carried_offset() -> None:
+    """The match is identical for the SAME INSTANT carried in two different tz
+    offsets, proving the matcher normalises to a single local frame instead of
+    comparing whichever raw wall-clock fields the caller's offset happens to
+    carry.
+
+    ``local_dt`` and ``same_instant_utc`` are the same point in time, but their
+    naive ``.hour``/``.minute`` fields differ by the +05:30 offset: one reads
+    inside a 12:00-12:30 window, the other (the UTC form) reads 06:45 — outside
+    it. A correct, offset-independent matcher must return the SAME answer for
+    both, since they denote the same instant. This holds on any test machine
+    regardless of its system timezone.
+    """
+
+    window = ProtectedWindow(start="12:00", end="12:30", label="lunch")
+    profile = _profile(protected_windows=(window,))
+
+    plus_530 = timezone(timedelta(hours=5, minutes=30))
+    local_dt = datetime(2026, 5, 15, 12, 15, tzinfo=plus_530)
+    same_instant_utc = local_dt.astimezone(UTC)
+
+    # Sanity: same instant, divergent naive wall-clock fields (the bug surface).
+    assert local_dt == same_instant_utc
+    naive_local = local_dt.hour * 60 + local_dt.minute
+    naive_utc = same_instant_utc.hour * 60 + same_instant_utc.minute
+    assert naive_local != naive_utc
+    assert 12 * 60 <= naive_local < 12 * 60 + 30
+    assert not (12 * 60 <= naive_utc < 12 * 60 + 30)
+
+    # Offset-independence: both forms of the same instant resolve identically.
+    assert matched_protected_window(profile, local_dt) == matched_protected_window(
+        profile, same_instant_utc
+    )

--- a/packages/mcp-chronometric/tests/test_profile_chronometric_fields.py
+++ b/packages/mcp-chronometric/tests/test_profile_chronometric_fields.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Unit tests for the R5 chronometric profile fields (loader + resolution).
+
+These exercise the loader's parsing of the optional fields added in R5 part A
+to ``packages/core/schemas/profile.schema.json`` under ``chronometric``:
+``weekday_overrides``, ``protected_windows``, ``calendar_phase``,
+``deadline_cluster_awareness`` and ``motor_fatigue_aware``. ``time_buffer_multiplier``
+is deliberately NOT read here — it is consumed by the task-fractionator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from neurodock_mcp_chronometric.profile import (
+    ProtectedWindow,
+    WeekdayOverride,
+    load_profile,
+)
+
+from .conftest import write_profile
+
+
+def test_absent_fields_default_to_today_behaviour(isolated_profile_path: Path) -> None:
+    """Backward-compat: a profile without any R5 field loads the neutral defaults."""
+
+    write_profile(
+        isolated_profile_path,
+        {"privacy": {"os_idle_consent": True}, "chronometric": {"hyperfocus_break_minutes": 90}},
+    )
+    profile = load_profile()
+
+    assert profile.os_idle_consent is True
+    assert profile.hyperfocus_break_minutes == 90
+    assert profile.end_of_day_local is None
+    assert profile.weekday_overrides == {}
+    assert profile.protected_windows == ()
+    assert profile.calendar_phase is None
+    assert profile.deadline_cluster_awareness is False
+    assert profile.motor_fatigue_aware is False
+
+
+def test_empty_profile_loads_all_neutral(isolated_profile_path: Path) -> None:
+    """A completely empty profile file yields the same neutral defaults."""
+
+    write_profile(isolated_profile_path, {})
+    profile = load_profile()
+
+    assert profile.hyperfocus_break_minutes is None
+    assert profile.end_of_day_local is None
+    assert profile.weekday_overrides == {}
+    assert profile.protected_windows == ()
+    assert profile.calendar_phase is None
+    assert profile.deadline_cluster_awareness is False
+    assert profile.motor_fatigue_aware is False
+
+
+def test_top_level_chronometric_thresholds_are_read(isolated_profile_path: Path) -> None:
+    """The base end_of_day_local and hyperfocus_break_minutes parse through."""
+
+    write_profile(
+        isolated_profile_path,
+        {
+            "chronometric": {
+                "hyperfocus_break_minutes": 60,
+                "end_of_day_local": "18:30",
+            }
+        },
+    )
+    profile = load_profile()
+
+    assert profile.hyperfocus_break_minutes == 60
+    assert profile.end_of_day_local == "18:30"
+
+
+def test_weekday_overrides_parse_into_typed_map(isolated_profile_path: Path) -> None:
+    """weekday_overrides keys map to WeekdayOverride values."""
+
+    write_profile(
+        isolated_profile_path,
+        {
+            "chronometric": {
+                "weekday_overrides": {
+                    "wednesday": {"end_of_day_local": "18:30"},
+                    "saturday": {"hyperfocus_break_minutes": 120},
+                    "monday": {},
+                }
+            }
+        },
+    )
+    profile = load_profile()
+
+    assert profile.weekday_overrides["wednesday"] == WeekdayOverride(
+        end_of_day_local="18:30", hyperfocus_break_minutes=None
+    )
+    assert profile.weekday_overrides["saturday"] == WeekdayOverride(
+        end_of_day_local=None, hyperfocus_break_minutes=120
+    )
+    # An empty override object is valid (named but inherits).
+    assert profile.weekday_overrides["monday"] == WeekdayOverride(
+        end_of_day_local=None, hyperfocus_break_minutes=None
+    )
+
+
+def test_unknown_weekday_key_is_ignored(isolated_profile_path: Path) -> None:
+    """A misspelt weekday key is a silent no-op (dropped), never crashes."""
+
+    write_profile(
+        isolated_profile_path,
+        {"chronometric": {"weekday_overrides": {"funday": {"hyperfocus_break_minutes": 30}}}},
+    )
+    profile = load_profile()
+
+    assert "funday" not in profile.weekday_overrides
+    assert profile.weekday_overrides == {}
+
+
+def test_protected_windows_parse_in_order(isolated_profile_path: Path) -> None:
+    """protected_windows parse into an ordered tuple of ProtectedWindow."""
+
+    write_profile(
+        isolated_profile_path,
+        {
+            "chronometric": {
+                "protected_windows": [
+                    {"start": "12:00", "end": "12:30", "label": "lunch"},
+                    {"start": "17:00", "end": "23:59"},
+                ]
+            }
+        },
+    )
+    profile = load_profile()
+
+    assert profile.protected_windows == (
+        ProtectedWindow(start="12:00", end="12:30", label="lunch"),
+        ProtectedWindow(start="17:00", end="23:59", label=None),
+    )
+
+
+def test_malformed_protected_window_is_dropped(isolated_profile_path: Path) -> None:
+    """A window missing start/end or with a bad time string is skipped, not fatal."""
+
+    write_profile(
+        isolated_profile_path,
+        {
+            "chronometric": {
+                "protected_windows": [
+                    {"start": "12:00", "end": "12:30", "label": "lunch"},
+                    {"start": "nope", "end": "12:30"},
+                    {"end": "12:30"},
+                    "garbage",
+                ]
+            }
+        },
+    )
+    profile = load_profile()
+
+    assert profile.protected_windows == (
+        ProtectedWindow(start="12:00", end="12:30", label="lunch"),
+    )
+
+
+def test_calendar_phase_and_boolean_hints_parse(isolated_profile_path: Path) -> None:
+    """calendar_phase enum + the two boolean hints parse through."""
+
+    write_profile(
+        isolated_profile_path,
+        {
+            "chronometric": {
+                "calendar_phase": "marking",
+                "deadline_cluster_awareness": True,
+                "motor_fatigue_aware": True,
+            }
+        },
+    )
+    profile = load_profile()
+
+    assert profile.calendar_phase == "marking"
+    assert profile.deadline_cluster_awareness is True
+    assert profile.motor_fatigue_aware is True
+
+
+def test_invalid_calendar_phase_is_dropped(isolated_profile_path: Path) -> None:
+    """An out-of-enum calendar_phase is ignored rather than surfaced."""
+
+    write_profile(
+        isolated_profile_path,
+        {"chronometric": {"calendar_phase": "vacation"}},
+    )
+    profile = load_profile()
+
+    assert profile.calendar_phase is None

--- a/packages/mcp-chronometric/tests/test_protocol_conformance.py
+++ b/packages/mcp-chronometric/tests/test_protocol_conformance.py
@@ -76,6 +76,95 @@ async def test_all_five_tools_conform_to_their_schemas() -> None:
 
 
 @pytest.mark.asyncio
+async def test_empty_profile_reproduces_pre_r5_wire_shape() -> None:
+    """Backward-compat over MCP: a neutral profile (no R5 fields) emits exactly
+    the pre-R5 keys — none of the additive fields leak into the payload."""
+
+    clock = FrozenClock(datetime(2026, 5, 15, 9, 0, 0, tzinfo=UTC))
+    state = SessionState()
+    # A bare profile with consent on but none of the R5 fields set.
+    profile = ChronometricProfile(os_idle_consent=True, raw_zones=None)
+    server = build_server(state=state, clock=clock, profile=profile)
+
+    async with Client(server) as client:
+        result = await client.call_tool("get_time_context", {})
+        assert set(result.data.keys()) == {
+            "now",
+            "day_of_week",
+            "time_since_last_prompt",
+            "current_session_length",
+            "energy_zone",
+        }
+
+        await client.call_tool("mark_session_start", {"intent": "finish draft RFC reply"})
+        clock.advance(seconds=91 * 60)
+        result = await client.call_tool("request_break_if_needed", {"threshold_minutes": 90})
+        assert set(result.data.keys()) == {
+            "elapsed",
+            "prior_intent",
+            "suggested_action",
+            "threshold_minutes",
+        }
+
+        result = await client.call_tool("idle_status", {})
+        assert "motor_fatigue_aware" not in result.data
+
+
+@pytest.mark.asyncio
+async def test_r5_populated_outputs_conform_to_their_schemas() -> None:
+    """Integration: with R5 profile fields set, the populated additive output of
+    get_time_context and request_break_if_needed still validates against the
+    schemas over the MCP protocol (the hard_surface + end-of-day paths)."""
+
+    from neurodock_mcp_chronometric.profile import ProtectedWindow, WeekdayOverride
+
+    # 2026-05-15 12:05 (Friday) sits inside the 12:00-13:00 protected window and
+    # is past the 11:00 weekday end-of-day override. Anchored in the SYSTEM-LOCAL
+    # zone (the tools normalise via .astimezone()) so the window/cutoff
+    # assertions are stable regardless of the test machine's timezone.
+    clock = FrozenClock(datetime(2026, 5, 15, 12, 5, 0).astimezone())
+    state = SessionState()
+    profile = ChronometricProfile(
+        os_idle_consent=True,
+        raw_zones=None,
+        hyperfocus_break_minutes=90,
+        end_of_day_local="18:30",
+        weekday_overrides={"friday": WeekdayOverride(end_of_day_local="11:00")},
+        protected_windows=(ProtectedWindow(start="12:00", end="13:00", label="lunch"),),
+        calendar_phase="marking",
+        deadline_cluster_awareness=True,
+        motor_fatigue_aware=True,
+    )
+    server = build_server(state=state, clock=clock, profile=profile)
+
+    async with Client(server) as client:
+        # get_time_context carries the populated R5 fields.
+        result = await client.call_tool("get_time_context", {})
+        _output_validator(_load_schema("get_time_context.schema.json")).validate(result.data)
+        # Guard the frozen-date assumption: the 11:00 end-of-day below is the
+        # FRIDAY weekday override, so a future date drift can't silently assert
+        # the wrong override value.
+        assert result.data["day_of_week"] == "Friday"
+        assert result.data["effective_end_of_day_local"] == "11:00"
+        assert result.data["past_end_of_day"] is True
+        assert result.data["calendar_phase"] == "marking"
+        assert result.data["deadline_cluster_awareness"] is True
+        assert result.data["motor_fatigue_aware"] is True
+
+        # Open a session and request a break while inside the protected window.
+        await client.call_tool("mark_session_start", {"intent": "finish draft RFC reply"})
+        result = await client.call_tool("request_break_if_needed", {"threshold_minutes": 90})
+        _output_validator(_load_schema("request_break_if_needed.schema.json")).validate(result.data)
+        assert result.data["escalation"] == "hard_surface"
+        assert result.data["protected_window_label"] == "lunch"
+
+        # idle_status surfaces the motor_fatigue_aware flag.
+        result = await client.call_tool("idle_status", {})
+        _output_validator(_load_schema("idle_status.schema.json")).validate(result.data)
+        assert result.data["motor_fatigue_aware"] is True
+
+
+@pytest.mark.asyncio
 async def test_all_five_tools_are_registered() -> None:
     """Sanity: the server exposes exactly the five tools, by name."""
 

--- a/packages/mcp-chronometric/tests/test_r5_tool_outputs.py
+++ b/packages/mcp-chronometric/tests/test_r5_tool_outputs.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tool-level tests for the R5 additive output fields.
+
+Per ADR 0011 every new output field is OPTIONAL and additive: it is present only
+when the profile declares the corresponding input, and absent (model default
+``None`` / falsey) otherwise so an untouched profile reproduces today's wire
+shape exactly.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from neurodock_mcp_chronometric.clock import FrozenClock
+from neurodock_mcp_chronometric.profile import (
+    ChronometricProfile,
+    ProtectedWindow,
+    WeekdayOverride,
+)
+from neurodock_mcp_chronometric.state import SessionState
+from neurodock_mcp_chronometric.tools.break_request import request_break_if_needed
+from neurodock_mcp_chronometric.tools.idle import idle_status
+from neurodock_mcp_chronometric.tools.session import mark_session_start
+from neurodock_mcp_chronometric.tools.time_context import get_time_context
+
+
+def _profile(**kwargs: object) -> ChronometricProfile:
+    base: dict[str, object] = {
+        "os_idle_consent": False,
+        "raw_zones": None,
+        "hyperfocus_break_minutes": None,
+        "end_of_day_local": None,
+        "weekday_overrides": {},
+        "protected_windows": (),
+        "calendar_phase": None,
+        "deadline_cluster_awareness": False,
+        "motor_fatigue_aware": False,
+    }
+    base.update(kwargs)
+    return ChronometricProfile(**base)  # type: ignore[arg-type]
+
+
+def _local_clock(year: int, month: int, day: int, hour: int, minute: int = 0) -> FrozenClock:
+    """A FrozenClock anchored in the SYSTEM-LOCAL zone at these wall-clock parts.
+
+    Protected windows and end-of-day are declared in the user's LOCAL HH:MM, and
+    the tools normalise ``now`` with ``.astimezone()`` (system-local). Anchoring
+    the clock in the local frame keeps wall-clock-sensitive assertions (window
+    membership, end-of-day cutoff) stable on any machine regardless of its
+    system timezone.
+    """
+
+    return FrozenClock(datetime(year, month, day, hour, minute).astimezone())
+
+
+# ---------------------------------------------------------------- get_time_context
+
+
+def test_time_context_without_profile_omits_new_fields() -> None:
+    """No profile -> none of the R5 fields are emitted (today's shape)."""
+
+    clock = FrozenClock(datetime(2026, 5, 15, 9, 0, tzinfo=UTC))
+    result = get_time_context(clock=clock, state=SessionState())
+
+    dumped = result.model_dump(exclude_none=True)
+    assert "effective_end_of_day_local" not in dumped
+    assert "past_end_of_day" not in dumped
+    assert "calendar_phase" not in dumped
+    assert "deadline_cluster_awareness" not in dumped
+    assert "motor_fatigue_aware" not in dumped
+
+
+def test_time_context_surfaces_calendar_phase_and_hints() -> None:
+    """calendar_phase + the boolean hints flow into the additive fields."""
+
+    clock = FrozenClock(datetime(2026, 5, 15, 9, 0, tzinfo=UTC))
+    profile = _profile(
+        calendar_phase="marking",
+        deadline_cluster_awareness=True,
+        motor_fatigue_aware=True,
+    )
+
+    result = get_time_context(clock=clock, state=SessionState(), profile=profile)
+
+    assert result.calendar_phase == "marking"
+    assert result.deadline_cluster_awareness is True
+    assert result.motor_fatigue_aware is True
+
+
+def test_time_context_effective_end_of_day_applies_weekday_override() -> None:
+    """The effective end-of-day reflects today's weekday override."""
+
+    # 2026-05-15 is a Friday (local frame so the cutoff compare is deterministic).
+    clock = _local_clock(2026, 5, 15, 9, 0)
+    profile = _profile(
+        end_of_day_local="18:30",
+        weekday_overrides={"friday": WeekdayOverride(end_of_day_local="16:00")},
+    )
+
+    result = get_time_context(clock=clock, state=SessionState(), profile=profile)
+
+    assert result.effective_end_of_day_local == "16:00"
+    # 09:00 is before 16:00, so not past end of day.
+    assert result.past_end_of_day is False
+
+
+def test_time_context_past_end_of_day_true_after_cutoff() -> None:
+    """past_end_of_day is True once the local clock is at/after the cutoff."""
+
+    clock = _local_clock(2026, 5, 15, 19, 0)  # Friday evening, local frame
+    profile = _profile(end_of_day_local="18:30")
+
+    result = get_time_context(clock=clock, state=SessionState(), profile=profile)
+
+    assert result.effective_end_of_day_local == "18:30"
+    assert result.past_end_of_day is True
+
+
+def test_time_context_past_end_of_day_true_at_exact_cutoff() -> None:
+    """The cutoff boundary is inclusive: at exactly HH:MM, past_end_of_day is True."""
+
+    # Frozen exactly at the 18:30 cutoff (local frame so the boundary is stable).
+    clock = _local_clock(2026, 5, 15, 18, 30)
+    profile = _profile(end_of_day_local="18:30")
+
+    result = get_time_context(clock=clock, state=SessionState(), profile=profile)
+
+    assert result.effective_end_of_day_local == "18:30"
+    assert result.past_end_of_day is True
+
+
+def test_time_context_past_end_of_day_independent_of_carried_offset() -> None:
+    """The cutoff comparison normalises to a single local frame, so the SAME
+    INSTANT carried in two different tz offsets yields the same past_end_of_day.
+
+    The two clocks denote one instant whose naive wall-clock minute differs by
+    +05:30 — one side reads after an 18:30 cutoff, the UTC side reads before it.
+    A correct, offset-independent comparison returns the same answer for both.
+    Holds on any test machine regardless of its system timezone.
+    """
+
+    profile = _profile(end_of_day_local="18:30")
+
+    plus_530 = timezone(timedelta(hours=5, minutes=30))
+    local_dt = datetime(2026, 5, 15, 19, 0, tzinfo=plus_530)  # local 19:00, past cutoff
+    same_instant_utc = local_dt.astimezone(UTC)  # 13:30 UTC, naive-before cutoff
+
+    # Sanity: same instant, divergent naive wall-clock fields (the bug surface).
+    assert local_dt == same_instant_utc
+    naive_local = local_dt.hour * 60 + local_dt.minute
+    naive_utc = same_instant_utc.hour * 60 + same_instant_utc.minute
+    assert naive_local != naive_utc
+    assert naive_local >= 18 * 60 + 30
+    assert naive_utc < 18 * 60 + 30
+
+    local_result = get_time_context(
+        clock=FrozenClock(local_dt), state=SessionState(), profile=profile
+    )
+    utc_result = get_time_context(
+        clock=FrozenClock(same_instant_utc), state=SessionState(), profile=profile
+    )
+    assert local_result.past_end_of_day == utc_result.past_end_of_day
+
+
+# ---------------------------------------------------------- request_break_if_needed
+
+
+def test_break_below_threshold_outside_window_still_none() -> None:
+    """Profile present but session short and not in a window: still None."""
+
+    clock = _local_clock(2026, 5, 15, 9, 0)
+    state = SessionState()
+    mark_session_start(intent="work", clock=clock, state=state)
+    clock.advance(seconds=60)
+
+    profile = _profile(protected_windows=(ProtectedWindow(start="12:00", end="12:30"),))
+    result = request_break_if_needed(
+        threshold_minutes=90, clock=clock, state=state, profile=profile
+    )
+    assert result is None
+
+
+def test_break_over_threshold_in_window_regime_is_nudge() -> None:
+    """Over threshold, windows configured but none matching -> escalation 'nudge'."""
+
+    # 09:00 is outside the 12:00-13:00 window, so we get the nudge rung but the
+    # field is annotated because a protected-window regime is in play.
+    clock = _local_clock(2026, 5, 15, 9, 0)
+    state = SessionState()
+    mark_session_start(intent="finish RFC", clock=clock, state=state)
+    clock.advance(seconds=91 * 60)  # now 10:31, still outside the window
+
+    profile = _profile(
+        protected_windows=(ProtectedWindow(start="12:00", end="13:00", label="lunch"),)
+    )
+    result = request_break_if_needed(
+        threshold_minutes=90, clock=clock, state=state, profile=profile
+    )
+    assert result is not None
+    assert result.escalation == "nudge"
+    assert result.protected_window_label is None
+
+
+def test_break_inside_protected_window_hard_surfaces() -> None:
+    """Inside a protected window, even an over-threshold break hard-surfaces."""
+
+    # Start at 11:00, advance 91 minutes -> 12:31. Window 12:00-13:00 matches.
+    clock = _local_clock(2026, 5, 15, 11, 0)
+    state = SessionState()
+    mark_session_start(intent="finish RFC", clock=clock, state=state)
+    clock.advance(seconds=91 * 60)  # now 12:31
+
+    profile = _profile(
+        protected_windows=(ProtectedWindow(start="12:00", end="13:00", label="lunch"),)
+    )
+    result = request_break_if_needed(
+        threshold_minutes=90, clock=clock, state=state, profile=profile
+    )
+    assert result is not None
+    assert result.escalation == "hard_surface"
+    assert result.protected_window_label == "lunch"
+
+
+def test_break_inside_protected_window_fires_below_threshold() -> None:
+    """A protected window hard-surfaces because the window is protected, not
+    because the session ran long: it fires even below the break threshold."""
+
+    # Start at 12:05, advance 1 minute -> 12:06, well under 90 min.
+    clock = _local_clock(2026, 5, 15, 12, 5)
+    state = SessionState()
+    mark_session_start(intent="quick fix", clock=clock, state=state)
+    clock.advance(seconds=60)
+
+    profile = _profile(
+        protected_windows=(ProtectedWindow(start="12:00", end="13:00", label="lunch"),)
+    )
+    result = request_break_if_needed(
+        threshold_minutes=90, clock=clock, state=state, profile=profile
+    )
+    assert result is not None
+    assert result.escalation == "hard_surface"
+    assert result.protected_window_label == "lunch"
+    # prior_intent is still quoted verbatim.
+    assert result.prior_intent == "quick fix"
+
+
+def test_break_hard_surface_without_label_omits_label_field() -> None:
+    """A labelless protected window still hard-surfaces; the label field stays
+    None and is dropped from the exclude_none wire payload."""
+
+    # Start at 12:05, advance 1 minute -> 12:06, inside an unlabelled window.
+    clock = _local_clock(2026, 5, 15, 12, 5)
+    state = SessionState()
+    mark_session_start(intent="quick fix", clock=clock, state=state)
+    clock.advance(seconds=60)
+
+    profile = _profile(protected_windows=(ProtectedWindow(start="12:00", end="13:00"),))
+    result = request_break_if_needed(
+        threshold_minutes=90, clock=clock, state=state, profile=profile
+    )
+    assert result is not None
+    assert result.escalation == "hard_surface"
+    assert result.protected_window_label is None
+    assert "protected_window_label" not in result.model_dump(exclude_none=True)
+
+
+def test_break_no_session_returns_none_even_in_window() -> None:
+    """No open session: nothing to break from, even inside a protected window."""
+
+    clock = FrozenClock(datetime(2026, 5, 15, 12, 15, tzinfo=UTC))
+    profile = _profile(
+        protected_windows=(ProtectedWindow(start="12:00", end="13:00", label="lunch"),)
+    )
+    result = request_break_if_needed(
+        threshold_minutes=90, clock=clock, state=SessionState(), profile=profile
+    )
+    assert result is None
+
+
+def test_break_without_profile_leaves_escalation_unset() -> None:
+    """Backward-compat: no profile -> escalation/label unset (pre-R5 wire shape)."""
+
+    clock = FrozenClock(datetime(2026, 5, 15, 9, 0, tzinfo=UTC))
+    state = SessionState()
+    mark_session_start(intent="work", clock=clock, state=state)
+    clock.advance(seconds=91 * 60)
+
+    result = request_break_if_needed(threshold_minutes=90, clock=clock, state=state)
+    assert result is not None
+    assert result.escalation is None
+    assert result.protected_window_label is None
+    # Wire shape is exactly the pre-R5 set of keys.
+    assert set(result.model_dump(exclude_none=True).keys()) == {
+        "elapsed",
+        "prior_intent",
+        "suggested_action",
+        "threshold_minutes",
+    }
+
+
+# ----------------------------------------------------------------------- idle_status
+
+
+def test_idle_status_surfaces_motor_fatigue_aware_flag() -> None:
+    """idle_status echoes motor_fatigue_aware so an activity-aware client knows."""
+
+    clock = FrozenClock(datetime(2026, 5, 15, 9, 0, tzinfo=UTC))
+    profile = _profile(os_idle_consent=True, motor_fatigue_aware=True)
+
+    result = idle_status(clock=clock, profile=profile)
+    assert result.motor_fatigue_aware is True
+
+
+def test_idle_status_motor_fatigue_absent_by_default() -> None:
+    """When the flag is unset, the field is None and dropped from exclude_none."""
+
+    clock = FrozenClock(datetime(2026, 5, 15, 9, 0, tzinfo=UTC))
+    profile = _profile(os_idle_consent=True)
+
+    result = idle_status(clock=clock, profile=profile)
+    assert result.motor_fatigue_aware is None
+    assert "motor_fatigue_aware" not in result.model_dump(exclude_none=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ provides-extras = ["test", "translation"]
 
 [[package]]
 name = "neurodock-mcp-chronometric"
-version = "0.0.3"
+version = "0.1.0"
 source = { editable = "packages/mcp-chronometric" }
 dependencies = [
     { name = "fastmcp" },
@@ -1350,6 +1350,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+    { name = "types-pyyaml" },
+]
 test = [
     { name = "jsonschema" },
     { name = "pytest" },
@@ -1360,13 +1365,16 @@ test = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.3.0" },
     { name = "jsonschema", marker = "extra == 'test'", specifier = ">=4.21.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
 ]
-provides-extras = ["test"]
+provides-extras = ["test", "dev"]
 
 [[package]]
 name = "neurodock-mcp-cognitive-graph"


### PR DESCRIPTION
## What

R5 (chronometric consumption). `packages/mcp-chronometric` now reads and honours the
optional `chronometric.*` profile fields added in #102, all **additive + optional** per
ADR-0011 (a profile declaring none of them produces the exact pre-R5 wire shape — asserted
by a protocol-conformance test):

- `weekday_overrides` re-anchor today's effective `end_of_day_local` + `hyperfocus_break_minutes`
- `protected_windows` (midnight-wrap supported) make `request_break_if_needed` **hard-surface**
  (the firm rung) — fires because the user declared that time protected, even below threshold
- `calendar_phase` / `deadline_cluster_awareness` / `motor_fatigue_aware` surfaced in
  `get_time_context`. `motor_fatigue_aware` is a declared preference — the server has no
  keystroke stream, so reading real activity stays gated by `os_idle_consent` (no faked data)

New additive output fields on `get_time_context`, `request_break_if_needed`, `idle_status`.
Protected-window/end-of-day matching normalises to local wall-clock so results are
independent of the caller datetime's timezone. `time_buffer_multiplier` is left for the
task-fractionator (B1). Bumps `pyproject` 0.0.3→0.1.0 (`@neurodock/core` carrier changeset
per repo PyPI convention).

## Review

`mcp-chronometric-expert` (TDD, RED→GREEN). Reviewed by `code-reviewer` + `python-reviewer`
(APPROVE), `adhd-advocate` (tone), and `clinical-expert` (**clinically sound, no changes** —
the escalation is user-configured and surfaces-with-agency; would have warranted clinical
co-sign under the un-waived gate, for the record). Fixes applied: timezone hardening
(`.astimezone()`) + offset-independence regression tests; `CalendarPhase` de-duplicated;
exact-cutoff/unlabeled-window/day-of-week tests; tone softening (dropped "strict", mirrored
the anti-scold framing, neutralized `past_end_of_day`); `types-PyYAML` dev dep.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy --strict src` → no issues (15 files)
- [x] `pytest -q` → 65 passed (+4)
- [x] backward-compat: neutral profile reproduces pre-R5 wire shape on all three tools
- [x] `wrangler.jsonc` excluded