### PR TITLE
feat(extension): tourette addendum + r5 ui-hint consumption (r3 part 2)

### DIFF
--- a/.changeset/extension-tourette-and-r5-ui-hints.md
+++ b/.changeset/extension-tourette-and-r5-ui-hints.md
@@ -1,0 +1,37 @@
+---
+"@neurodock/extension-browser": minor
+---
+
+feat(extension): tourette prompt addendum (r3) + voice_input_preferred and line_height_hint consumption (r5)
+
+three additive, opt-in signals. a profile that declares none of them produces
+exactly the pre-change behaviour (covered by back-compat tests).
+
+- **tourette addendum (r3):** `tourette` was an explicit no-op in the
+  per-neurotype prompt shaping. reviewed against the new `tourette-advocate`
+  lens, it now gets a genuine, concise text-shaping block: be answer-first
+  (less time held under attention + suppression load), plain and low-pressure,
+  with no reassuring/soothing/motivational register and no commentary on the
+  reader's behaviour, focus, or composure. the block is tool-independent and
+  fuses correctly with the existing audhd/overlap logic.
+- **voice_input_preferred (r5):** when set, the prompt builder appends a
+  cross-cutting line (regardless of neurotype) asking downstream prose to keep
+  any example, draft, or snippet as a single copy-pasteable block — dictation
+  and motor users cannot cheaply hand-edit punctuation scattered across a
+  response.
+- **line_height_hint (r5):** the band (`compact` | `default` | `relaxed`) now
+  drives the body line-height of rendered output across the popup, full-page
+  tab, and in-page island via a single `lh-*` class and a new
+  `--nd-body-line-height` token. mapping: compact = 1.5, default = 1.6,
+  relaxed = 1.75 — never below the wcag 1.4.8 / 1.4.12 conformance floor of
+  1.5 for any band. body paragraphs read `--nd-body-line-height` with a
+  fallback to `--nd-line-height`, and focus-mode (1.45) was reconciled so it
+  only re-binds ui-chrome line-height and can never combine with a set hint to
+  pull a body paragraph below 1.5 (the in-page island's focus-mode panel rule
+  was removed for the same reason). as a result, un-hinted island body
+  paragraphs now floor at 1.5 under focus-mode (previously 1.45, which was
+  below the wcag body floor).
+
+both new fields flow through the extension profile and the native-host on-disk
+mapping (`preferences.voice_input_preferred`, `preferences.line_height_hint`)
+as optional keys — they are only written to disk when the user sets them.

--- a/packages/extension-browser/entrypoints/_shared/bootstrap.tsx
+++ b/packages/extension-browser/entrypoints/_shared/bootstrap.tsx
@@ -42,6 +42,7 @@ import {
   applyReaderFontToDocument,
   loadReaderFont,
 } from "../../src/lib/reader-font.js";
+import { applyLineHeightHintToDocument } from "../../src/lib/line-height-hint.js";
 import type {
   Channel,
   ExtensionProfile,
@@ -67,6 +68,12 @@ export function bootstrapContent(options: BootstrapOptions): () => void {
         type: "profile:get",
       });
       if (res) profile = res;
+      // R5 line_height_hint: apply the body line-height band class to the
+      // island's shadow host so `:host(.lh-*)` binds --nd-body-line-height
+      // (>= 1.5). Absent hint clears any lh-* class — the island body
+      // then falls back to --nd-line-height (pre-R5 behaviour). Runs on
+      // initial load and on every storage-change-driven reload.
+      applyLineHeightHintToDocument(profile.lineHeightHint, island.shadow);
       return profile;
     } catch {
       // Background worker may be temporarily unreachable during SW restart

--- a/packages/extension-browser/entrypoints/_shared/mountIsland.ts
+++ b/packages/extension-browser/entrypoints/_shared/mountIsland.ts
@@ -215,13 +215,30 @@ export function mountIsland(hostId: string, doc: Document = document): Island {
         --nd-color-accent-high: oklch(100% 0 0);
       }
     }
-    /* RFC A3 — focus mode. Tighter line-height + hide the cloud-mode
-       banner inside the island. */
-    :host(.nd-focus-mode) .neurodock-panel {
-      line-height: 1.45;
-    }
+    /* RFC A3 — focus mode. Hide the cloud-mode banner inside the island.
+       NOTE: focus mode no longer tightens the panel body line-height. The
+       island body text (.neurodock-panel) is governed by
+       --nd-body-line-height (see the R5 lh-* bindings below), which has a
+       1.5 fallback. Pinning the panel to 1.45 under focus mode would drop
+       a hinted body paragraph below the WCAG 1.4.8 / 1.4.12 floor of 1.5
+       — see line-height-hint.ts. The banner hide is unaffected. */
     :host(.nd-focus-mode) .neurodock-banner {
       display: none;
+    }
+    /* R5 line_height_hint — body line-spacing band for the in-page island.
+       A single lh-<band> class on the shadow host binds
+       --nd-body-line-height, which .neurodock-panel reads (with a 1.5
+       fallback). Every band is >= 1.5 so the WCAG floor holds regardless
+       of focus mode. Keep values in sync with BAND_LINE_HEIGHT in
+       src/lib/line-height-hint.ts and the :root.lh-* rules in tokens.css. */
+    :host(.lh-compact) {
+      --nd-body-line-height: 1.5;
+    }
+    :host(.lh-default) {
+      --nd-body-line-height: 1.6;
+    }
+    :host(.lh-relaxed) {
+      --nd-body-line-height: 1.75;
     }
     /* A6 — reader-font switcher. Re-bind font stacks per selected font.
        Mirrors src/styles/tokens.css :host(.font-*) blocks exactly. */
@@ -266,7 +283,10 @@ export function mountIsland(hostId: string, doc: Document = document): Island {
       pointer-events: auto;
       font-family: var(--nd-font-body);
       font-size: calc(14px * var(--nd-island-font-scale, 1));
-      line-height: 1.5;
+      /* R5 line_height_hint: body paragraphs read --nd-body-line-height
+         (bound by the lh-* band class on the host, always >= 1.5) with a
+         1.5 fallback. Focus mode no longer pins this below the WCAG floor. */
+      line-height: var(--nd-body-line-height, 1.5);
       width: 420px;
       max-width: 92vw;
       max-height: 80vh;

--- a/packages/extension-browser/entrypoints/popup/App.tsx
+++ b/packages/extension-browser/entrypoints/popup/App.tsx
@@ -45,6 +45,7 @@ import {
   applyThemeModeToDocument,
   loadThemeMode,
 } from "../../src/lib/theme-mode.js";
+import { applyLineHeightHintToDocument } from "../../src/lib/line-height-hint.js";
 
 function isHistoryUpdatedMessage(msg: unknown): boolean {
   return (
@@ -160,6 +161,17 @@ export function App(): React.ReactElement {
     chrome.runtime.onMessage.addListener(handler);
     return () => chrome.runtime.onMessage.removeListener(handler);
   }, [profile.historyEnabled, refreshHistory]);
+
+  // R5 line_height_hint: keep the body line-height band class on <html>
+  // in lockstep with the profile. Runs on first resolve and on any later
+  // profile change (Settings save, sibling-window broadcast). An absent
+  // hint clears any lh-* class so the body falls back to
+  // --nd-line-height — byte-identical to the pre-R5 behaviour.
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      applyLineHeightHintToDocument(profile.lineHeightHint, document);
+    }
+  }, [profile.lineHeightHint]);
 
   // P1.1: pick up profile saves originating from other popup windows.
   // `chrome.storage.onChanged` only fires for non-popup contexts;

--- a/packages/extension-browser/entrypoints/popup/styles.css
+++ b/packages/extension-browser/entrypoints/popup/styles.css
@@ -68,7 +68,12 @@ picture {
 
 body {
   font-family: var(--nd-font-body);
-  line-height: var(--nd-line-height);
+  /* R5 line_height_hint: body paragraphs read --nd-body-line-height
+     (bound by the lh-* band class, always >= 1.5) with a fallback to
+     --nd-line-height. No hint set → byte-identical to before, including
+     focus-mode's 1.45. Hint set → focus-mode cannot pull body below the
+     WCAG 1.5 floor because it only re-binds --nd-line-height. */
+  line-height: var(--nd-body-line-height, var(--nd-line-height));
   color: var(--nd-color-fg);
   background: var(--nd-color-bg);
   text-rendering: optimizeLegibility;

--- a/packages/extension-browser/entrypoints/tab/App.tsx
+++ b/packages/extension-browser/entrypoints/tab/App.tsx
@@ -45,6 +45,7 @@ import {
   applyThemeModeToDocument,
   loadThemeMode,
 } from "../../src/lib/theme-mode.js";
+import { applyLineHeightHintToDocument } from "../../src/lib/line-height-hint.js";
 import { NeuroDockHeader } from "../../src/components/NeuroDockHeader.js";
 
 type TabView = "home" | "history" | "settings" | "notifications";
@@ -94,6 +95,15 @@ export function TabApp(): React.ReactElement {
       }
     })();
   }, []);
+
+  // R5 line_height_hint: keep the body line-height band class on <html>
+  // in lockstep with the profile. Absent hint clears any lh-* class so
+  // the body falls back to --nd-line-height (byte-identical to pre-R5).
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      applyLineHeightHintToDocument(data.profile.lineHeightHint, document);
+    }
+  }, [data.profile.lineHeightHint]);
 
   // Keep `view` synced with the URL so back/forward and shared links
   // restore the intended section. We do not deep-link into individual

--- a/packages/extension-browser/entrypoints/tab/styles.css
+++ b/packages/extension-browser/entrypoints/tab/styles.css
@@ -70,7 +70,12 @@ html {
 
 body {
   font-family: var(--nd-font-body);
-  line-height: var(--nd-line-height);
+  /* R5 line_height_hint: body paragraphs read --nd-body-line-height
+     (bound by the lh-* band class, always >= 1.5) with a fallback to
+     --nd-line-height. No hint set → byte-identical to before, including
+     focus-mode's 1.45. Hint set → focus-mode cannot pull body below the
+     WCAG 1.5 floor because it only re-binds --nd-line-height. */
+  line-height: var(--nd-body-line-height, var(--nd-line-height));
   color: var(--nd-color-fg);
   background: var(--nd-color-bg);
   text-rendering: optimizeLegibility;

--- a/packages/extension-browser/src/lib/line-height-hint.ts
+++ b/packages/extension-browser/src/lib/line-height-hint.ts
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * R5 UI hint: `line_height_hint` consumption (rendering).
+ *
+ * The merged profile schema added optional `preferences.line_height_hint`
+ * (compact | default | relaxed) with a documented WCAG 1.4.8 / 1.4.12
+ * CONFORMANCE FLOOR: body-paragraph line spacing MUST NOT render below
+ * 1.5 regardless of band. This module is the single source of truth for
+ * the band → body line-height mapping and for applying the hint as a
+ * single `lh-<band>` class on the popup/tab <html> or the in-page
+ * island's shadow host (mirrors `reader-font.ts`).
+ *
+ * Anchors (from the schema doc):
+ *   - compact ≈ 1.5
+ *   - default ≈ 1.5–1.6
+ *   - relaxed ≈ 1.65–1.8 (currently 1.75)
+ *
+ * Focus-mode reconciliation (see tokens.css): focus-mode re-binds
+ * `--nd-line-height` to 1.45 for tighter UI chrome. Body paragraphs read
+ * `--nd-body-line-height` with a fallback to `--nd-line-height`:
+ *   - No hint set  → `--nd-body-line-height` is undefined, so body falls
+ *     back to `--nd-line-height` (today's behaviour exactly, including
+ *     focus-mode's 1.45).
+ *   - Hint set     → the `lh-*` class binds `--nd-body-line-height` to a
+ *     value >= 1.5, which focus-mode never touches, so a hinted body
+ *     paragraph can never drop below the WCAG floor.
+ */
+import type { LineHeightHint } from "./types.js";
+
+/**
+ * WCAG 1.4.8 (Visual Presentation) / 1.4.12 (Text Spacing) line-height
+ * floor for body paragraphs. No band may render body text below this.
+ */
+export const WCAG_LINE_HEIGHT_FLOOR = 1.5 as const;
+
+/**
+ * Body line-height per band. Every value is >= the WCAG floor.
+ *   - compact : sits exactly at the floor.
+ *   - default : the surface default rhythm.
+ *   - relaxed : the most generous band.
+ */
+const BAND_LINE_HEIGHT: Readonly<Record<LineHeightHint, number>> =
+  Object.freeze({
+    compact: 1.5,
+    default: 1.6,
+    relaxed: 1.75,
+  });
+
+export const LINE_HEIGHT_HINT_CLASSES = [
+  "lh-compact",
+  "lh-default",
+  "lh-relaxed",
+] as const;
+
+/**
+ * Map a band to its body line-height, clamped so a future edit can never
+ * accidentally drop a band below the WCAG floor.
+ */
+export function lineHeightForHint(hint: LineHeightHint): number {
+  return Math.max(BAND_LINE_HEIGHT[hint], WCAG_LINE_HEIGHT_FLOOR);
+}
+
+/** Map a band to its `lh-*` class name. */
+export function lineHeightHintClass(
+  hint: LineHeightHint,
+): (typeof LINE_HEIGHT_HINT_CLASSES)[number] {
+  return `lh-${hint}` as const;
+}
+
+/**
+ * Apply the line-height hint to a Document's <html> or a ShadowRoot's
+ * host element. Idempotent: removes every other lh-* class first. An
+ * undefined hint clears all lh-* classes so the body falls back to
+ * `--nd-line-height` (today's behaviour).
+ */
+export function applyLineHeightHintToDocument(
+  hint: LineHeightHint | undefined,
+  target: Document | ShadowRoot = document,
+): void {
+  const el: Element =
+    target instanceof ShadowRoot ? target.host : target.documentElement;
+  el.classList.remove(...LINE_HEIGHT_HINT_CLASSES);
+  if (hint !== undefined) {
+    el.classList.add(lineHeightHintClass(hint));
+  }
+}

--- a/packages/extension-browser/src/lib/neurotype-addendum.ts
+++ b/packages/extension-browser/src/lib/neurotype-addendum.ts
@@ -66,7 +66,16 @@ export function buildNeurotypeAddendum(
   const hasNotes =
     profile.additionalNotes !== null && profile.additionalNotes.length > 0;
   const hasNonDefaultFormat = profile.outputFormat !== "answer_first";
-  if (effective.length === 0 && !hasNotes && !hasNonDefaultFormat) {
+  // R5 UI hint: the voice-input line is cross-cutting (it applies
+  // regardless of neurotype), so on its own it is enough to trigger the
+  // addendum — same contract as a non-default output_format.
+  const wantsVoiceInput = profile.voiceInputPreferred === true;
+  if (
+    effective.length === 0 &&
+    !hasNotes &&
+    !hasNonDefaultFormat &&
+    !wantsVoiceInput
+  ) {
     return "";
   }
 
@@ -81,6 +90,14 @@ export function buildNeurotypeAddendum(
   );
   sections.push("");
   sections.push(renderOutputFormatBlock(profile.outputFormat));
+
+  // R5 UI hint: cross-cutting voice-input shaping. Placed before the
+  // per-neurotype blocks because it is a global formatting rule, not a
+  // neurotype-specific one.
+  if (wantsVoiceInput) {
+    sections.push("");
+    sections.push(renderVoiceInputBlock());
+  }
 
   const ordered = orderByPriority(effective);
   for (const neurotype of ordered) {
@@ -134,8 +151,10 @@ function effectiveNeurotypes(
 
 /**
  * Priority ordering. Higher-priority addenda are placed LATER in the
- * prompt to exploit recency bias. Tourette is no-op so it's first;
- * `other` (user-authored notes) is always last to take precedence.
+ * prompt to exploit recency bias. Tourette is first because its wins are
+ * broad text-shaping defaults (concise, plain, low-pressure) that the
+ * more field-specific blocks below refine; `other` (user-authored notes)
+ * is always last to take precedence.
  */
 const PRIORITY: ReadonlyArray<Neurotype> = [
   "tourette",
@@ -156,6 +175,23 @@ function orderByPriority(
   );
 }
 
+/**
+ * R5 cross-cutting voice-input block.
+ *
+ * The reader dictates / voice-types. Hand-editing punctuation scattered
+ * across a response is expensive for them, so any example, snippet, or
+ * draft the model offers must stay copy-pasteable as ONE contiguous
+ * block — the reader copies it whole rather than stitching fragments
+ * together by hand. Applies regardless of neurotype.
+ */
+function renderVoiceInputBlock(): string {
+  return [
+    "Reader preferences (voice input):",
+    "- The reader dictates and cannot cheaply hand-edit fiddly punctuation.",
+    "- Keep any example, draft, or snippet as a single, copy-pasteable block — do not scatter editable fragments across the response.",
+  ].join("\n");
+}
+
 function renderOutputFormatBlock(format: OutputFormat): string {
   const descriptions: Record<OutputFormat, string> = {
     answer_first:
@@ -174,10 +210,7 @@ function renderNeurotypeBlock(
   tool: TranslationTool | undefined,
 ): string {
   if (neurotype === "tourette") {
-    // Explicit no-op so prompt logs show Tourette was considered. The
-    // motion-reduction relevant to Tourette is a UI concern handled by
-    // `preferences.motion`, not a prompt concern.
-    return "";
+    return renderTouretteBlock();
   }
 
   if (neurotype === "other") {
@@ -692,6 +725,43 @@ function renderGenericBlock(
         "- Group related items together; do not interleave asks from different topics.",
       ].join("\n");
   }
+}
+
+/**
+ * Tourette reader block (R3).
+ *
+ * Reviewed against `.claude/agents/tourette-advocate.md`. Tics themselves
+ * never change prose, and motion/startle safety is a UI concern owned by
+ * `motion: reduced` (ADR 0004) and the reduced-motion tokens — NOT a
+ * prompt concern. So this block is deliberately small. The genuine
+ * text-shaping wins from the advocate lens are:
+ *
+ *   - Concise / answer-first: every extra paragraph is extra time the
+ *     reader is held under attention while a premonitory urge builds and
+ *     suppression consumes working capacity. Short, answer-first prose
+ *     reduces that load.
+ *   - Plain and low-pressure: avoid demands and amplified urgency.
+ *
+ * Equally important is what this block MUST NOT do (advocate principles
+ * 4 + 5): never use a "relax / calm / breathe / you've got this"
+ * register, and never notice, name, or comment on the reader's
+ * behaviour, focus, fidgeting, repetition, or stillness. Those read as
+ * instructions to control the uncontrollable and carry stigma load.
+ *
+ * Kept under the 25-line cap like the other blocks. Where Tourette
+ * co-occurs with OCD or ADHD (common overlap), those blocks add their
+ * own field-level rules alongside this one — see effectiveNeurotypes()
+ * and the conflict-resolution footer.
+ */
+function renderTouretteBlock(): string {
+  return [
+    "Reader preferences (Tourette):",
+    "- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.",
+    "- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.",
+    "- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.",
+    "- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.",
+    "- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field.",
+  ].join("\n");
 }
 
 function renderOtherBlock(notes: string): string {

--- a/packages/extension-browser/src/lib/profile.ts
+++ b/packages/extension-browser/src/lib/profile.ts
@@ -30,6 +30,7 @@
 import type {
   ExtensionMode,
   ExtensionProfile,
+  LineHeightHint,
   Neurotype,
   OutputFormat,
 } from "./types.js";
@@ -310,6 +311,18 @@ function isOutputFormat(x: unknown): x is OutputFormat {
   return typeof x === "string" && OUTPUT_FORMAT_ENUM.has(x as OutputFormat);
 }
 
+const LINE_HEIGHT_HINT_ENUM: ReadonlySet<LineHeightHint> = new Set([
+  "compact",
+  "default",
+  "relaxed",
+]);
+
+function isLineHeightHint(x: unknown): x is LineHeightHint {
+  return (
+    typeof x === "string" && LINE_HEIGHT_HINT_ENUM.has(x as LineHeightHint)
+  );
+}
+
 export function normaliseProfile(
   input: Partial<ExtensionProfile>,
 ): ExtensionProfile {
@@ -364,6 +377,17 @@ export function normaliseProfile(
       input.additionalNotes.length > 0
         ? input.additionalNotes
         : null,
+    // R5 UI hints. Both are OPTIONAL: a non-true / invalid value settles
+    // the key to `undefined` (not present), so a profile that never set
+    // them stays byte-identical to the pre-R5 behaviour. Using a
+    // conditional spread keeps the keys absent rather than explicitly
+    // `undefined`, which matches the "absence === default" contract.
+    ...(input.voiceInputPreferred === true
+      ? { voiceInputPreferred: true as const }
+      : {}),
+    ...(isLineHeightHint(input.lineHeightHint)
+      ? { lineHeightHint: input.lineHeightHint }
+      : {}),
     onboardingComplete: resolveOnboardingComplete(input),
   };
 }
@@ -508,6 +532,18 @@ function mapOnDiskProfileToExtension(
       ? rawChunk
       : baseline.maxChunkSize;
 
+  // R5 UI hints. Read from the on-disk `preferences` block when present;
+  // otherwise inherit the baseline (which itself defaults to absent), so
+  // an on-disk profile that never set them keeps today's behaviour.
+  const voiceInputPreferred =
+    preferences["voice_input_preferred"] === true
+      ? true
+      : baseline.voiceInputPreferred;
+
+  const lineHeightHint = isLineHeightHint(preferences["line_height_hint"])
+    ? preferences["line_height_hint"]
+    : baseline.lineHeightHint;
+
   return normaliseProfile({
     ...baseline,
     displayName,
@@ -515,6 +551,8 @@ function mapOnDiskProfileToExtension(
     outputFormat,
     maxChunkSize,
     additionalNotes,
+    ...(voiceInputPreferred === true ? { voiceInputPreferred: true } : {}),
+    ...(lineHeightHint !== undefined ? { lineHeightHint } : {}),
   });
 }
 
@@ -533,11 +571,21 @@ export function mapExtensionProfileToOnDisk(
   if (profile.additionalNotes !== null) {
     identity["additional_notes"] = profile.additionalNotes;
   }
+  const preferences: Record<string, unknown> = {
+    output_format: profile.outputFormat,
+    max_chunk_size: profile.maxChunkSize,
+  };
+  // R5 UI hints: only write a key when the user actually set it, so a
+  // profile that never touched these does not gain new keys on disk
+  // (keeps hand-edited yaml and the pre-R5 wire shape stable).
+  if (profile.voiceInputPreferred === true) {
+    preferences["voice_input_preferred"] = true;
+  }
+  if (profile.lineHeightHint !== undefined) {
+    preferences["line_height_hint"] = profile.lineHeightHint;
+  }
   return {
     identity,
-    preferences: {
-      output_format: profile.outputFormat,
-      max_chunk_size: profile.maxChunkSize,
-    },
+    preferences,
   };
 }

--- a/packages/extension-browser/src/lib/types.ts
+++ b/packages/extension-browser/src/lib/types.ts
@@ -91,6 +91,19 @@ export type Neurotype =
  */
 export type OutputFormat = "answer_first" | "conventional" | "bullet_first";
 
+/**
+ * R5 UI hint: preferred body line-spacing band for rendered NeuroDock
+ * output. Mirrors `preferences.line_height_hint` in the profile schema.
+ *
+ *   - compact : tightest band still at the WCAG 1.4.8 floor (~1.5).
+ *   - default : the surface default (~1.6).
+ *   - relaxed : the most generous band (≈ 1.65–1.8, currently 1.75).
+ *
+ * The mapping (see `line-height-hint.ts`) enforces a hard floor of 1.5
+ * for body paragraphs regardless of band, per WCAG 1.4.8 / 1.4.12.
+ */
+export type LineHeightHint = "compact" | "default" | "relaxed";
+
 export interface ExtensionProfile {
   readonly mode: ExtensionMode;
   /**
@@ -162,6 +175,24 @@ export interface ExtensionProfile {
    * `identity.additional_notes`.
    */
   readonly additionalNotes: string | null;
+  /**
+   * R5 UI hint: the reader dictates/voice-types and cannot cheaply
+   * hand-edit punctuation scattered across a response. When true, the
+   * prompt builder asks downstream prose to keep examples copy-pasteable
+   * as a SINGLE block (cross-cutting — applies regardless of neurotype).
+   *
+   * Optional + absence-means-off so a profile without the field behaves
+   * exactly as before. Mirrors `preferences.voice_input_preferred`.
+   */
+  readonly voiceInputPreferred?: boolean;
+  /**
+   * R5 UI hint: preferred body line-spacing band for rendered output.
+   * Maps to a body line-height that NEVER drops below the WCAG 1.4.8 /
+   * 1.4.12 conformance floor of 1.5, regardless of band. Mirrors
+   * `preferences.line_height_hint`. Optional + absence-means-default so
+   * a profile without the field renders exactly as before.
+   */
+  readonly lineHeightHint?: LineHeightHint;
   /**
    * Roadmap A1: guided onboarding wizard completion flag.
    *

--- a/packages/extension-browser/src/styles/tokens.css
+++ b/packages/extension-browser/src/styles/tokens.css
@@ -313,6 +313,38 @@
 }
 
 /*
+ * R5 line_height_hint → body line-height (WCAG 1.4.8 / 1.4.12).
+ *
+ * A single `lh-<band>` class on <html> (popup/tab) or the shadow host
+ * (in-page island) binds `--nd-body-line-height`. The popup/tab `body`
+ * rules read `line-height: var(--nd-body-line-height, var(--nd-line-height))`
+ * so:
+ *   - NO hint set → `--nd-body-line-height` is undefined → body falls
+ *     back to `--nd-line-height` (today's behaviour, including the
+ *     focus-mode 1.45 below). Backward-compatible.
+ *   - hint set    → body uses `--nd-body-line-height`, which is >= 1.5
+ *     for every band. Focus-mode only re-binds `--nd-line-height` (UI
+ *     chrome), NOT `--nd-body-line-height`, so a hinted body paragraph
+ *     can never combine with focus-mode to drop below the WCAG floor.
+ *
+ * CONFORMANCE FLOOR: body line-height MUST NOT render below 1.5 for any
+ * band. compact = 1.5 (at the floor), default = 1.6, relaxed = 1.75.
+ * Keep these in sync with BAND_LINE_HEIGHT in src/lib/line-height-hint.ts.
+ */
+:root.lh-compact,
+:host(.lh-compact) {
+  --nd-body-line-height: 1.5;
+}
+:root.lh-default,
+:host(.lh-default) {
+  --nd-body-line-height: 1.6;
+}
+:root.lh-relaxed,
+:host(.lh-relaxed) {
+  --nd-body-line-height: 1.75;
+}
+
+/*
  * Reader-font hinting (neurodivergent font switcher).
  *
  * A single `font-<value>` class on <html> (popup/tab) or the shadow host

--- a/packages/extension-browser/tests/unit/island-line-height-hint.test.tsx
+++ b/packages/extension-browser/tests/unit/island-line-height-hint.test.tsx
@@ -1,0 +1,198 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * R5 line_height_hint — in-page island surface wiring.
+ *
+ * When the profile resolved over `profile:get` carries `lineHeightHint`,
+ * bootstrapContent must apply the matching `lh-*` class to the island's
+ * shadow-root HOST element so `:host(.lh-*)` binds --nd-body-line-height
+ * (>= 1.5). No hint → no lh-* class (today's behaviour).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "@testing-library/react";
+
+vi.mock("../../entrypoints/_shared/contentApp.js", () => ({
+  ContentApp: vi.fn(() => null),
+}));
+
+import { bootstrapContent } from "../../entrypoints/_shared/bootstrap.js";
+import { mountIsland } from "../../entrypoints/_shared/mountIsland.js";
+import { LINE_HEIGHT_HINT_CLASSES } from "../../src/lib/line-height-hint.js";
+import type { ExtensionProfile } from "../../src/lib/types.js";
+
+const HOST_ID = "nd-lh-island";
+
+function buildProfile(
+  overrides: Partial<ExtensionProfile> = {},
+): ExtensionProfile {
+  return {
+    mode: "local",
+    localProvider: "ollama",
+    localEndpoint: "http://localhost:11434",
+    localModel: "llama3.2:3b",
+    localApiKey: null,
+    cloudProvider: null,
+    cloudModel: null,
+    cloudApiKey: null,
+    cloudApiKeys: {},
+    historyEnabled: false,
+    displayName: "you",
+    neurotypes: [],
+    outputFormat: "answer_first",
+    maxChunkSize: 5,
+    additionalNotes: null,
+    ...overrides,
+  };
+}
+
+describe("island — line_height_hint wiring (R5)", () => {
+  let originalSendMessage: typeof chrome.runtime.sendMessage;
+
+  beforeEach(() => {
+    originalSendMessage = chrome.runtime.sendMessage;
+  });
+
+  afterEach(() => {
+    (chrome.runtime as Record<string, unknown>)["sendMessage"] =
+      originalSendMessage;
+    document.getElementById(HOST_ID)?.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("applies lh-compact to the shadow host when the profile carries the hint", async () => {
+    (chrome.runtime as Record<string, unknown>)["sendMessage"] = vi
+      .fn()
+      .mockResolvedValue(buildProfile({ lineHeightHint: "compact" }));
+
+    let cleanup!: () => void;
+    await act(async () => {
+      cleanup = bootstrapContent({ channel: "email", hostId: HOST_ID });
+    });
+
+    const host = document.getElementById(HOST_ID);
+    expect(host).not.toBeNull();
+    expect(host!.classList.contains("lh-compact")).toBe(true);
+    cleanup();
+  });
+
+  it("applies no lh-* class to the host when the profile has no hint", async () => {
+    (chrome.runtime as Record<string, unknown>)["sendMessage"] = vi
+      .fn()
+      .mockResolvedValue(buildProfile());
+
+    let cleanup!: () => void;
+    await act(async () => {
+      cleanup = bootstrapContent({ channel: "email", hostId: HOST_ID });
+    });
+
+    const host = document.getElementById(HOST_ID);
+    const present = LINE_HEIGHT_HINT_CLASSES.filter((c) =>
+      host!.classList.contains(c),
+    );
+    expect(present).toEqual([]);
+    cleanup();
+  });
+});
+
+describe("island stylesheet — line_height_hint conformance floor", () => {
+  // The island has its own hand-written stylesheet (`:host{all:initial}`
+  // severs inherited custom properties — the WS1 lesson). So the band
+  // rules and the focus-mode reconciliation must live in mountIsland.ts.
+  function islandCss(): string {
+    const island = mountIsland("nd-css-probe");
+    const style = island.shadow.querySelector("style");
+    const css = style?.textContent ?? "";
+    island.destroy();
+    return css;
+  }
+
+  afterEach(() => {
+    document.getElementById("nd-css-probe")?.remove();
+  });
+
+  it("the panel body reads --nd-body-line-height with a >=1.5 fallback", () => {
+    const css = islandCss();
+    expect(css).toMatch(
+      /\.neurodock-panel\s*{[^}]*line-height:\s*var\(\s*--nd-body-line-height\s*,\s*1\.5\s*\)/,
+    );
+  });
+
+  it("declares the three lh-* band bindings on the host (>=1.5)", () => {
+    const css = islandCss();
+    expect(css).toMatch(
+      /:host\(\.lh-compact\)\s*{[^}]*--nd-body-line-height:\s*1\.5\b/,
+    );
+    expect(css).toMatch(
+      /:host\(\.lh-default\)\s*{[^}]*--nd-body-line-height:\s*1\.6\b/,
+    );
+    expect(css).toMatch(
+      /:host\(\.lh-relaxed\)\s*{[^}]*--nd-body-line-height:\s*1\.75\b/,
+    );
+  });
+
+  it("focus-mode no longer hard-pins the panel to 1.45 below the floor", () => {
+    // The pre-R5 island pinned `.neurodock-panel { line-height: 1.45 }`
+    // under focus mode. That would drop a hinted body paragraph below the
+    // WCAG floor. Focus mode must now route through the same
+    // --nd-body-line-height variable so a set hint always wins at >=1.5.
+    const css = islandCss();
+    expect(css).not.toMatch(
+      /:host\(\.nd-focus-mode\)\s*\.neurodock-panel\s*{[^}]*line-height:\s*1\.45/,
+    );
+  });
+
+  /**
+   * Resolve the effective `.neurodock-panel` body line-height the way a
+   * browser would, for a given set of host classes:
+   *   1. A focus-mode panel override (`:host(.nd-focus-mode) .neurodock-panel
+   *      { line-height: N }`) wins outright if it exists — this is exactly the
+   *      sub-1.5 rule we removed, so re-adding it MUST flip the result.
+   *   2. Otherwise the panel reads `var(--nd-body-line-height, <fallback>)`.
+   *      `--nd-body-line-height` is bound only by an active `:host(.lh-*)`
+   *      band class; with no band class it is undefined, so the declared
+   *      fallback applies.
+   */
+  function resolvePanelLineHeight(css: string, hostClasses: string[]): number {
+    const hasClass = (c: string): boolean => hostClasses.includes(c);
+
+    // 1. Focus-mode panel override (the removed sub-floor rule).
+    if (hasClass("nd-focus-mode")) {
+      const override = css.match(
+        /:host\(\.nd-focus-mode\)\s*\.neurodock-panel\s*{[^}]*line-height:\s*([\d.]+)/,
+      );
+      if (override) return Number(override[1]);
+    }
+
+    // 2. Resolve --nd-body-line-height from any active lh-* band class.
+    const bandRules: Array<[string, number]> = [
+      ["lh-compact", 1.5],
+      ["lh-default", 1.6],
+      ["lh-relaxed", 1.75],
+    ];
+    for (const [cls, value] of bandRules) {
+      if (hasClass(cls)) return value;
+    }
+
+    // 3. No band → the panel's declared fallback applies.
+    const fallback = css.match(
+      /\.neurodock-panel\s*{[^}]*line-height:\s*var\(\s*--nd-body-line-height\s*,\s*([\d.]+)\s*\)/,
+    );
+    if (!fallback) throw new Error("panel line-height fallback not found");
+    return Number(fallback[1]);
+  }
+
+  it("floors an un-hinted panel body at 1.5 under focus-mode (not 1.45)", () => {
+    // code-reviewer MEDIUM lock: removing the island focus-mode panel rule
+    // means an un-hinted body paragraph under focus-mode now resolves to the
+    // panel's --nd-body-line-height fallback (1.5) instead of the old 1.45.
+    // 1.45 was below the WCAG 1.4.8 / 1.4.12 body floor; 1.5 is INTENTIONAL
+    // and CORRECT. This guards against anyone re-adding a sub-1.5 island
+    // focus-mode body rule (which would flip this back to 1.45 and fail).
+    const css = islandCss();
+    const resolved = resolvePanelLineHeight(css, ["nd-focus-mode"]);
+    expect(resolved).toBe(1.5);
+    expect(resolved).toBeGreaterThanOrEqual(1.5);
+    expect(resolved).not.toBe(1.45);
+  });
+});

--- a/packages/extension-browser/tests/unit/line-height-hint.test.ts
+++ b/packages/extension-browser/tests/unit/line-height-hint.test.ts
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * Unit tests for the R5 `line_height_hint` consumption path.
+ *
+ * Contract:
+ *   - The mapping function returns a body line-height per band, NEVER
+ *     below the WCAG 1.4.8 / 1.4.12 conformance floor of 1.5.
+ *   - The class applier toggles exactly one `lh-*` class on the root /
+ *     shadow host (mirrors reader-font.ts), so tokens.css can re-bind
+ *     `--nd-body-line-height` under that class.
+ *   - An absent / unknown hint applies no class (today's behaviour).
+ *   - tokens.css declares each band's `--nd-body-line-height` >= 1.5 and
+ *     binds the body to that variable so focus-mode's 1.45 cannot drop a
+ *     hinted body paragraph below the floor.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  LINE_HEIGHT_HINT_CLASSES,
+  WCAG_LINE_HEIGHT_FLOOR,
+  applyLineHeightHintToDocument,
+  lineHeightForHint,
+  lineHeightHintClass,
+} from "../../src/lib/line-height-hint.js";
+import type { LineHeightHint } from "../../src/lib/types.js";
+
+describe("line-height-hint — mapping respects the WCAG 1.5 floor", () => {
+  it("floor constant is 1.5", () => {
+    expect(WCAG_LINE_HEIGHT_FLOOR).toBe(1.5);
+  });
+
+  it("compact maps to ~1.5 (at the floor, never below)", () => {
+    expect(lineHeightForHint("compact")).toBeGreaterThanOrEqual(1.5);
+    expect(lineHeightForHint("compact")).toBeLessThanOrEqual(1.55);
+  });
+
+  it("default maps within the 1.5–1.6 anchor band", () => {
+    expect(lineHeightForHint("default")).toBeGreaterThanOrEqual(1.5);
+    expect(lineHeightForHint("default")).toBeLessThanOrEqual(1.6);
+  });
+
+  it("relaxed maps within the 1.65–1.8 anchor band", () => {
+    expect(lineHeightForHint("relaxed")).toBeGreaterThanOrEqual(1.65);
+    expect(lineHeightForHint("relaxed")).toBeLessThanOrEqual(1.8);
+  });
+
+  it("every band is monotonic and >= the floor", () => {
+    const bands: LineHeightHint[] = ["compact", "default", "relaxed"];
+    const values = bands.map(lineHeightForHint);
+    for (const v of values) {
+      expect(v).toBeGreaterThanOrEqual(WCAG_LINE_HEIGHT_FLOOR);
+    }
+    expect(values[0]).toBeLessThanOrEqual(values[1]!);
+    expect(values[1]).toBeLessThanOrEqual(values[2]!);
+  });
+});
+
+describe("line-height-hint — class mapping", () => {
+  it("maps each hint to its lh-* class", () => {
+    expect(lineHeightHintClass("compact")).toBe("lh-compact");
+    expect(lineHeightHintClass("default")).toBe("lh-default");
+    expect(lineHeightHintClass("relaxed")).toBe("lh-relaxed");
+  });
+});
+
+describe("line-height-hint — applyLineHeightHintToDocument", () => {
+  beforeEach(() => {
+    document.documentElement.className = "";
+  });
+
+  it("applies lh-relaxed and removes any prior lh-* class", () => {
+    applyLineHeightHintToDocument("compact", document);
+    applyLineHeightHintToDocument("relaxed", document);
+    const cls = document.documentElement.classList;
+    expect(cls.contains("lh-relaxed")).toBe(true);
+    expect(cls.contains("lh-compact")).toBe(false);
+  });
+
+  it("only ever has one lh-* class at a time", () => {
+    for (const h of ["compact", "default", "relaxed"] as const) {
+      applyLineHeightHintToDocument(h, document);
+    }
+    const present = LINE_HEIGHT_HINT_CLASSES.filter((c) =>
+      document.documentElement.classList.contains(c),
+    );
+    expect(present).toEqual(["lh-relaxed"]);
+  });
+
+  it("applies no lh-* class for an undefined hint (back-compat default)", () => {
+    document.documentElement.classList.add("lh-relaxed");
+    applyLineHeightHintToDocument(undefined, document);
+    const present = LINE_HEIGHT_HINT_CLASSES.filter((c) =>
+      document.documentElement.classList.contains(c),
+    );
+    expect(present).toEqual([]);
+  });
+
+  it("applies to a ShadowRoot's host element", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    applyLineHeightHintToDocument("default", shadow);
+    expect(host.classList.contains("lh-default")).toBe(true);
+    host.remove();
+  });
+});
+
+describe("line-height-hint — tokens.css conformance floor", () => {
+  // jsdom cannot resolve cascaded custom-property values, but the
+  // contract is assertable from the stylesheet source: every band binds
+  // --nd-body-line-height >= 1.5, and body reads --nd-body-line-height so
+  // focus-mode's 1.45 (which only re-binds --nd-line-height) cannot drop
+  // a hinted body paragraph below the floor.
+  const tokensCss = readFileSync(
+    resolve(process.cwd(), "src/styles/tokens.css"),
+    "utf8",
+  );
+
+  it("declares --nd-body-line-height for compact at the 1.5 floor", () => {
+    expect(tokensCss).toMatch(
+      /\.lh-compact[^{]*{[^}]*--nd-body-line-height:\s*1\.5\b/,
+    );
+  });
+
+  it("declares --nd-body-line-height for default at >= 1.5", () => {
+    const m = tokensCss.match(
+      /\.lh-default[^{]*{[^}]*--nd-body-line-height:\s*(1\.\d+)/,
+    );
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThanOrEqual(1.5);
+  });
+
+  it("declares --nd-body-line-height for relaxed within 1.65–1.8", () => {
+    const m = tokensCss.match(
+      /\.lh-relaxed[^{]*{[^}]*--nd-body-line-height:\s*(1\.\d+)/,
+    );
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThanOrEqual(1.65);
+    expect(Number(m![1])).toBeLessThanOrEqual(1.8);
+  });
+
+  it("the shadow-host (:host) variants also bind --nd-body-line-height for the island", () => {
+    expect(tokensCss).toMatch(
+      /:host\(\.lh-compact\)[^{]*{[^}]*--nd-body-line-height:\s*1\.5\b/,
+    );
+  });
+});
+
+describe("line-height-hint — popup + tab body bind the hinted variable", () => {
+  // Body paragraphs must read --nd-body-line-height with a fallback to
+  // --nd-line-height. The fallback keeps an un-hinted body byte-identical
+  // to today (focus-mode 1.45 still applies when NO hint is set); a set
+  // hint binds --nd-body-line-height >= 1.5, so focus-mode cannot pull a
+  // hinted body paragraph below the WCAG floor.
+  const popupCss = readFileSync(
+    resolve(process.cwd(), "entrypoints/popup/styles.css"),
+    "utf8",
+  );
+  const tabCss = readFileSync(
+    resolve(process.cwd(), "entrypoints/tab/styles.css"),
+    "utf8",
+  );
+
+  it("popup body line-height falls back to --nd-line-height when no hint set", () => {
+    expect(popupCss).toMatch(
+      /body\s*{[^}]*line-height:\s*var\(\s*--nd-body-line-height\s*,\s*var\(--nd-line-height\)\s*\)/,
+    );
+  });
+
+  it("tab body line-height falls back to --nd-line-height when no hint set", () => {
+    expect(tabCss).toMatch(
+      /body\s*{[^}]*line-height:\s*var\(\s*--nd-body-line-height\s*,\s*var\(--nd-line-height\)\s*\)/,
+    );
+  });
+});

--- a/packages/extension-browser/tests/unit/neurotype-addendum.test.ts
+++ b/packages/extension-browser/tests/unit/neurotype-addendum.test.ts
@@ -106,12 +106,44 @@ describe("buildNeurotypeAddendum", () => {
     );
   });
 
-  it("Tourette renders no block (explicit no-op)", () => {
+  it("renders a concise, low-pressure Tourette block (R3)", () => {
     const out = buildNeurotypeAddendum(profile({ neurotypes: ["tourette"] }));
-    // Tourette is no-op at the prompt layer; the addendum only carries
-    // the output_format header (because we triggered the addendum by
-    // having a neurotype, even if its block is empty).
-    expect(out).not.toContain("Reader preferences (Tourette)");
+    // R3: Tourette now gets a genuine text-shaping addendum. The wins
+    // from the advocate lens are: be concise / answer-first (less time
+    // held under attention + suppression load) and plain + low-pressure.
+    expect(out).toContain("Reader preferences (Tourette)");
+    expect(out).toContain("answer first");
+  });
+
+  it("Tourette block does NOT use a relax/calm/breathe register", () => {
+    // Advocate lens: no "relax / calm / breathe / you've got this"
+    // register and no comment on the user's behaviour/focus/stillness.
+    // These read as instructions to control the uncontrollable.
+    const out = buildNeurotypeAddendum(
+      profile({ neurotypes: ["tourette"] }),
+    ).toLowerCase();
+    expect(out).not.toContain("relax");
+    expect(out).not.toContain("calm");
+    expect(out).not.toContain("take a breath");
+    expect(out).not.toContain("breathe");
+    expect(out).not.toContain("you've got this");
+    // No commentary on the reader's behaviour, focus, fidgeting, or
+    // stillness anywhere in the rendered addendum.
+    expect(out).not.toContain("fidget");
+    expect(out).not.toContain("stillness");
+    expect(out).not.toContain("stay focused");
+    expect(out).not.toContain("hold still");
+  });
+
+  it("Tourette block fuses with other neurotypes without breaking AuDHD logic", () => {
+    // Respect effectiveNeurotypes(): adhd + asd still fuse to AuDHD even
+    // when tourette is also present; tourette adds its own block.
+    const out = buildNeurotypeAddendum(
+      profile({ neurotypes: ["tourette", "adhd", "asd"] }),
+    );
+    expect(out).toContain("Reader preferences (Tourette)");
+    expect(out).toContain("Reader preferences (AuDHD)");
+    expect(out).not.toContain("Reader preferences (ADHD):");
   });
 
   it("orders ASD before ADHD (priority — ADHD ergonomics win on recency)", () => {
@@ -123,6 +155,38 @@ describe("buildNeurotypeAddendum", () => {
     expect(dyslexiaIdx).toBeGreaterThan(-1);
     expect(adhdIdx).toBeGreaterThan(-1);
     expect(dyslexiaIdx).toBeLessThan(adhdIdx);
+  });
+
+  it("emits a single-block copy-paste instruction when voice_input_preferred is true (R5)", () => {
+    // R5 UI hint: dictation/motor users can't cheaply hand-edit fiddly
+    // punctuation scattered across a response, so examples must stay
+    // copy-pasteable as ONE block. Cross-cutting — applies regardless of
+    // neurotype (here triggered via output_format alone).
+    const out = buildNeurotypeAddendum(
+      profile({ outputFormat: "bullet_first", voiceInputPreferred: true }),
+    );
+    expect(out).toContain("single, copy-pasteable block");
+  });
+
+  it("surfaces the voice-input line even with no neurotypes selected (R5)", () => {
+    // The flag alone is enough to trigger the addendum, just like a
+    // non-default output_format is.
+    const out = buildNeurotypeAddendum(profile({ voiceInputPreferred: true }));
+    expect(out).not.toBe("");
+    expect(out).toContain("single, copy-pasteable block");
+  });
+
+  it("does NOT emit the voice-input line when the flag is false", () => {
+    const out = buildNeurotypeAddendum(
+      profile({ neurotypes: ["adhd"], voiceInputPreferred: false }),
+    );
+    expect(out).toContain("Reader preferences (ADHD)");
+    expect(out).not.toContain("copy-pasteable block");
+  });
+
+  it("does NOT emit the voice-input line when the flag is unset (back-compat)", () => {
+    const out = buildNeurotypeAddendum(profile({ neurotypes: ["adhd"] }));
+    expect(out).not.toContain("copy-pasteable block");
   });
 
   it("places `other` block LAST so user notes are the final word", () => {

--- a/packages/extension-browser/tests/unit/neurotype-tool-matrix.test.ts
+++ b/packages/extension-browser/tests/unit/neurotype-tool-matrix.test.ts
@@ -272,13 +272,19 @@ describe("neurotype-tool matrix — tool overload falls back gracefully", () => 
     expect(withoutTool).toContain("(ADHD)");
   });
 
-  it("Tourette stays no-op even with a tool argument", () => {
-    const out = buildNeurotypeAddendum(
+  it("Tourette renders the same tool-independent block with or without a tool (R3)", () => {
+    // R3: the Tourette wins are cross-tool text-shaping (concise /
+    // answer-first / plain / low-pressure), so the block is intentionally
+    // NOT per-tool — it is byte-identical whether or not a tool is passed.
+    const withTool = buildNeurotypeAddendum(
       profile({ neurotypes: ["tourette"] }),
       "describe_image",
     );
-    expect(out).not.toContain("(Tourette)");
-    expect(out).not.toContain("(tourette)");
+    const withoutTool = buildNeurotypeAddendum(
+      profile({ neurotypes: ["tourette"] }),
+    );
+    expect(withTool).toContain("Reader preferences (Tourette)");
+    expect(withTool).toBe(withoutTool);
   });
 
   it("`other` notes still pass through inline with a tool argument", () => {

--- a/packages/extension-browser/tests/unit/popup-line-height-hint.test.tsx
+++ b/packages/extension-browser/tests/unit/popup-line-height-hint.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * R5 line_height_hint — popup surface wiring.
+ *
+ * When the loaded profile carries `lineHeightHint`, the popup must apply
+ * the matching `lh-*` class to <html> so tokens.css binds
+ * `--nd-body-line-height` (>= 1.5). When the profile carries no hint, no
+ * lh-* class is applied (today's behaviour).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import * as profileModule from "../../src/lib/profile.js";
+import * as storage from "../../src/lib/storage.js";
+import * as nativeHost from "../../src/lib/native-host-client.js";
+import { App } from "../../entrypoints/popup/App.js";
+import { LINE_HEIGHT_HINT_CLASSES } from "../../src/lib/line-height-hint.js";
+import type { ExtensionProfile } from "../../src/lib/types.js";
+
+function completedProfile(
+  overrides: Partial<ExtensionProfile> = {},
+): ExtensionProfile {
+  return {
+    mode: "mock",
+    localProvider: "ollama",
+    localEndpoint: "http://localhost:11434",
+    localModel: "llama3.2:3b",
+    localApiKey: null,
+    cloudProvider: null,
+    cloudModel: null,
+    cloudApiKey: null,
+    cloudApiKeys: {},
+    historyEnabled: false,
+    displayName: "you",
+    neurotypes: [],
+    outputFormat: "answer_first",
+    maxChunkSize: 5,
+    additionalNotes: null,
+    onboardingComplete: true,
+    ...overrides,
+  };
+}
+
+function mockProfile(profile: ExtensionProfile): void {
+  vi.spyOn(profileModule, "loadProfile").mockResolvedValue(profile);
+  vi.spyOn(profileModule, "getSyncStatus").mockResolvedValue({
+    source: "extension-local",
+    nativeHostStatus: "absent",
+    path: null,
+    detail: null,
+  });
+  vi.spyOn(storage, "listHistory").mockResolvedValue([]);
+  vi.spyOn(nativeHost, "probeNativeHost").mockResolvedValue({
+    status: "absent",
+  });
+}
+
+describe("Popup — line_height_hint wiring (R5)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = "";
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("applies lh-relaxed to <html> when the profile has lineHeightHint=relaxed", async () => {
+    mockProfile(completedProfile({ lineHeightHint: "relaxed" }));
+    render(<App />);
+    await waitFor(() => screen.getByTestId("tab-home"));
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("lh-relaxed")).toBe(
+        true,
+      );
+    });
+  });
+
+  it("applies no lh-* class when the profile has no hint (back-compat)", async () => {
+    mockProfile(completedProfile());
+    render(<App />);
+    await waitFor(() => screen.getByTestId("tab-home"));
+    const present = LINE_HEIGHT_HINT_CLASSES.filter((c) =>
+      document.documentElement.classList.contains(c),
+    );
+    expect(present).toEqual([]);
+  });
+});

--- a/packages/extension-browser/tests/unit/profile-r5-ui-hints.test.ts
+++ b/packages/extension-browser/tests/unit/profile-r5-ui-hints.test.ts
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * R5 UI-hint profile plumbing.
+ *
+ * The two new OPTIONAL preference fields must flow through the extension
+ * profile mapping in both directions:
+ *   - `voiceInputPreferred`  ↔ `preferences.voice_input_preferred`
+ *   - `lineHeightHint`       ↔ `preferences.line_height_hint`
+ *
+ * Both are optional; absence MUST mean exactly today's behaviour
+ * (backward-compatible). A profile that declares neither field must
+ * normalise byte-identically to the pre-R5 normaliser output.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  normaliseProfile,
+  mapExtensionProfileToOnDisk,
+} from "../../src/lib/profile.js";
+
+describe("profile R5 UI hints — normaliseProfile", () => {
+  it("preserves voiceInputPreferred=true", () => {
+    const p = normaliseProfile({ voiceInputPreferred: true });
+    expect(p.voiceInputPreferred).toBe(true);
+  });
+
+  it("preserves a valid lineHeightHint", () => {
+    const p = normaliseProfile({ lineHeightHint: "relaxed" });
+    expect(p.lineHeightHint).toBe("relaxed");
+  });
+
+  it("drops an invalid lineHeightHint (defends the WCAG mapping)", () => {
+    const p = normaliseProfile({
+      lineHeightHint: "huge" as unknown as "relaxed",
+    });
+    expect(p.lineHeightHint).toBeUndefined();
+  });
+
+  it("coerces a non-boolean voiceInputPreferred to undefined/false-y", () => {
+    const p = normaliseProfile({
+      voiceInputPreferred: "yes" as unknown as boolean,
+    });
+    expect(p.voiceInputPreferred).not.toBe(true);
+  });
+
+  it("leaves both fields undefined when neither is provided (back-compat)", () => {
+    const p = normaliseProfile({ neurotypes: ["adhd"] });
+    expect(p.voiceInputPreferred).toBeUndefined();
+    expect(p.lineHeightHint).toBeUndefined();
+  });
+
+  it("a profile without the R5 fields normalises identically to before", () => {
+    // The presence of the new optional fields must not perturb any
+    // existing field for a profile that does not declare them.
+    const legacyInput = {
+      mode: "local" as const,
+      localProvider: "ollama" as const,
+      localEndpoint: "http://localhost:11434",
+      localModel: "llama3.2:3b",
+      cloudProvider: null,
+      cloudApiKey: null,
+      cloudApiKeys: {},
+      historyEnabled: true,
+      displayName: "T",
+      neurotypes: ["adhd"] as const,
+      outputFormat: "bullet_first" as const,
+      maxChunkSize: 4,
+      additionalNotes: "keep it short",
+      onboardingComplete: true,
+    };
+    const out = normaliseProfile({ ...legacyInput });
+    // No R5 keys leak in.
+    expect(out.voiceInputPreferred).toBeUndefined();
+    expect(out.lineHeightHint).toBeUndefined();
+    // Every pre-R5 field is preserved exactly.
+    expect(out.displayName).toBe("T");
+    expect(out.historyEnabled).toBe(true);
+    expect(out.neurotypes).toEqual(["adhd"]);
+    expect(out.outputFormat).toBe("bullet_first");
+    expect(out.maxChunkSize).toBe(4);
+    expect(out.additionalNotes).toBe("keep it short");
+    expect(out.onboardingComplete).toBe(true);
+  });
+});
+
+describe("profile R5 UI hints — mapExtensionProfileToOnDisk", () => {
+  function base() {
+    return normaliseProfile({ displayName: "you" });
+  }
+
+  it("writes voice_input_preferred only when set", () => {
+    const withFlag = mapExtensionProfileToOnDisk(
+      normaliseProfile({ voiceInputPreferred: true }),
+    );
+    const prefs = (withFlag as { preferences: Record<string, unknown> })
+      .preferences;
+    expect(prefs["voice_input_preferred"]).toBe(true);
+  });
+
+  it("writes line_height_hint only when set", () => {
+    const withHint = mapExtensionProfileToOnDisk(
+      normaliseProfile({ lineHeightHint: "compact" }),
+    );
+    const prefs = (withHint as { preferences: Record<string, unknown> })
+      .preferences;
+    expect(prefs["line_height_hint"]).toBe("compact");
+  });
+
+  it("omits both keys from the on-disk shape when unset (back-compat)", () => {
+    const onDisk = mapExtensionProfileToOnDisk(base());
+    const prefs = (onDisk as { preferences: Record<string, unknown> })
+      .preferences;
+    expect("voice_input_preferred" in prefs).toBe(false);
+    expect("line_height_hint" in prefs).toBe(false);
+    // The pre-R5 preference keys are still written.
+    expect(prefs["output_format"]).toBeDefined();
+    expect(prefs["max_chunk_size"]).toBeDefined();
+  });
+});

--- a/packages/extension-browser/tests/unit/prompt-builder.test.ts
+++ b/packages/extension-browser/tests/unit/prompt-builder.test.ts
@@ -18,7 +18,28 @@
 
 import { describe, it, expect } from "vitest";
 import { buildPrompt } from "../../src/lib/prompt-builder.js";
-import type { TranslationTool } from "../../src/lib/types.js";
+import type { ExtensionProfile, TranslationTool } from "../../src/lib/types.js";
+
+function profile(overrides: Partial<ExtensionProfile> = {}): ExtensionProfile {
+  return {
+    mode: "local",
+    localProvider: "ollama",
+    localEndpoint: "http://localhost:11434",
+    localModel: "llama3.2:3b",
+    localApiKey: null,
+    cloudProvider: null,
+    cloudModel: null,
+    cloudApiKey: null,
+    cloudApiKeys: {},
+    historyEnabled: false,
+    displayName: "you",
+    neurotypes: [],
+    outputFormat: "answer_first",
+    maxChunkSize: 5,
+    additionalNotes: null,
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Minimal valid inputs per tool (all template placeholders populated so we
@@ -386,6 +407,43 @@ describe("buildPrompt — schema suffix", () => {
       expect((parsed as Record<string, unknown>).type).toBeDefined();
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// 6b. R5 UI hints flow end-to-end through buildPrompt via the profile
+// ---------------------------------------------------------------------------
+
+describe("buildPrompt — R5 voice_input_preferred addendum", () => {
+  it("appends the single-block instruction when the profile flag is true", () => {
+    const result = buildPrompt({
+      tool: "translate_incoming",
+      input: TRANSLATE_INCOMING_INPUT,
+      profile: profile({ voiceInputPreferred: true }),
+    });
+    expect(result).toContain("single, copy-pasteable block");
+  });
+
+  it("omits the instruction when the flag is unset (back-compat)", () => {
+    const result = buildPrompt({
+      tool: "translate_incoming",
+      input: TRANSLATE_INCOMING_INPUT,
+      profile: profile(),
+    });
+    expect(result).not.toContain("copy-pasteable block");
+  });
+
+  it("produces the byte-identical pre-R5 prompt for an all-default profile", () => {
+    const withDefaultProfile = buildPrompt({
+      tool: "check_tone",
+      input: CHECK_TONE_INPUT,
+      profile: profile(),
+    });
+    const withoutProfile = buildPrompt({
+      tool: "check_tone",
+      input: CHECK_TONE_INPUT,
+    });
+    expect(withDefaultProfile).toBe(withoutProfile);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/extension-browser/tests/unit/tab-line-height-hint.test.tsx
+++ b/packages/extension-browser/tests/unit/tab-line-height-hint.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * R5 line_height_hint — full-page tab surface wiring.
+ *
+ * When the loaded profile carries `lineHeightHint`, the tab view must
+ * apply the matching `lh-*` class to <html> so tokens.css binds
+ * --nd-body-line-height (>= 1.5). No hint → no lh-* class.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import * as storage from "../../src/lib/storage.js";
+import * as profileModule from "../../src/lib/profile.js";
+import { TabApp } from "../../entrypoints/tab/App.js";
+import { LINE_HEIGHT_HINT_CLASSES } from "../../src/lib/line-height-hint.js";
+import type { ExtensionProfile } from "../../src/lib/types.js";
+
+type ChromeMessageListener = (msg: unknown) => void;
+
+function buildProfile(
+  overrides: Partial<ExtensionProfile> = {},
+): ExtensionProfile {
+  return {
+    mode: "local",
+    localProvider: "ollama",
+    localEndpoint: "http://localhost:11434",
+    localModel: "llama3.2:3b",
+    localApiKey: null,
+    cloudProvider: null,
+    cloudModel: null,
+    cloudApiKey: null,
+    cloudApiKeys: {},
+    historyEnabled: false,
+    displayName: "you",
+    neurotypes: [],
+    outputFormat: "answer_first",
+    maxChunkSize: 5,
+    additionalNotes: null,
+    onboardingComplete: true,
+    ...overrides,
+  };
+}
+
+describe("Tab — line_height_hint wiring (R5)", () => {
+  let originalOnMessage: typeof chrome.runtime.onMessage;
+
+  beforeEach(() => {
+    document.documentElement.className = "";
+    originalOnMessage = chrome.runtime.onMessage;
+    (chrome.runtime as { onMessage: unknown }).onMessage = {
+      addListener: (_l: ChromeMessageListener) => {},
+      removeListener: (_l: ChromeMessageListener) => {},
+    };
+    vi.spyOn(profileModule, "getSyncStatus").mockResolvedValue({
+      source: "extension-local",
+      nativeHostStatus: "absent",
+      path: null,
+      detail: null,
+    });
+    vi.spyOn(storage, "listHistory").mockResolvedValue([]);
+    window.location.hash = "";
+  });
+
+  afterEach(() => {
+    (
+      chrome.runtime as { onMessage: typeof chrome.runtime.onMessage }
+    ).onMessage = originalOnMessage;
+    window.location.hash = "";
+    vi.restoreAllMocks();
+  });
+
+  it("applies lh-default to <html> when the profile carries the hint", async () => {
+    vi.spyOn(profileModule, "loadProfile").mockResolvedValue(
+      buildProfile({ lineHeightHint: "default" }),
+    );
+    render(<TabApp />);
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("lh-default")).toBe(
+        true,
+      );
+    });
+  });
+
+  it("applies no lh-* class when the profile has no hint (back-compat)", async () => {
+    vi.spyOn(profileModule, "loadProfile").mockResolvedValue(buildProfile());
+    render(<TabApp />);
+    await waitFor(() => {
+      expect(profileModule.loadProfile).toHaveBeenCalled();
+    });
+    const present = LINE_HEIGHT_HINT_CLASSES.filter((c) =>
+      document.documentElement.classList.contains(c),
+    );
+    expect(present).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

R3 part 2 + the R5 UI-hint consumers deferred from the schema PR. Extension-only.

- **Tourette prompt addendum** (was an explicit no-op): concise/answer-first, neutral
  register, no "relax/calm/breathe/pep" wording, never comments on the reader's
  behaviour/movement/stillness. Fuses correctly with the AuDHD logic.
- **`voice_input_preferred`**: a cross-cutting prompt block telling the model to keep
  examples copy-pasteable as a single block (dictation-friendly), emitted only when set.
- **`line_height_hint`**: compact→1.5 / default→1.6 / relaxed→1.75 via a `--nd-body-line-height`
  token + `lh-<band>` class across popup/tab/island, with a hard **1.5 WCAG body floor**
  (`Math.max` clamp + tests). Focus-mode's 1.45 rebinds only `--nd-line-height` (UI chrome),
  never the body token — so a hinted body paragraph can't drop below 1.5. The island's old
  1.45 body rule was removed, so un-hinted island body now floors at 1.5 too (1.45 was below
  the body floor) — locked by a test.
- Plumbs both optional fields through `ExtensionProfile` + the native-host read path; absent
  fields = byte-identical pre-R5 behaviour (asserted).

## Review

`browser-extension-builder` (TDD). `code-reviewer` (APPROVE), `accessibility-auditor`
(**CONFORMANT** — verified ≥1.5 for every band in built/minified CSS, focus-mode never reaches
hinted body, default 1.65 retained), `design-system-keeper` (addendum + tokens sound). Fixes:
locked the island floor-lift with a test + changeset note; aligned doc comments. (New
advocates dyspraxia/tourette aren't invocable until a session reload; tracked.)

## Test plan

- [x] `pnpm --filter @neurodock/extension-browser test` → 693 (80 files)
- [x] typecheck clean; chrome/firefox/edge MV3 builds clean
- [x] built-CSS verified: `--nd-body-line-height: 1.5/1.6/1.75`, no sub-1.5 body rule, no inline scripts
- [x] back-compat: no-hint profile byte-identical pre-R5
- [x] `wrangler.jsonc` excluded