### PR TITLE
feat: dyspraxia-task-pacer skill + tourette no-skill decision (r3 part 3)

### DIFF
--- a/claude-code/neurodock/README.md
+++ b/claude-code/neurodock/README.md
@@ -41,7 +41,7 @@ time it runs.
 
 ### Skills (`skills/`)
 
-Twelve ND-aware skills ship with the plugin, in two groups.
+Thirteen ND-aware skills ship with the plugin, in two groups.
 
 **Substrate skills** — each teaches Claude the exact tool contract and the
 ND-aware "voice" for surfacing one server's results:
@@ -52,7 +52,8 @@ ND-aware "voice" for surfacing one server's results:
 neurotype (authored in `packages/skills/` and bundled here verbatim via
 `scripts/sync-skills.mjs`, with a CI drift guard keeping the two in sync):
 `adhd-daily-planner`, `asd-meeting-translator`, `audhd-context-recovery`,
-`hyperfocus-formatter`, `ocd-decision-finalizer`, `visual-organizer`.
+`dyspraxia-task-pacer`, `hyperfocus-formatter`, `ocd-decision-finalizer`,
+`visual-organizer`.
 
 ## Privacy
 

--- a/claude-code/neurodock/skills/dyspraxia-task-pacer/SKILL.md
+++ b/claude-code/neurodock/skills/dyspraxia-task-pacer/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: dyspraxia-task-pacer
+version: 0.1.0
+description: Motor-aware pacing — decomposes a goal, pads each estimate by the profile buffer, names why.
+neurotypes: ["dyspraxia"]
+status: stable
+triggers:
+  - command: "/pace"
+  - phrase: "break this down"
+  - phrase: "pace this for me"
+  - phrase: "how long will this take"
+  - phrase: "what's the next step"
+mcp_dependencies:
+  - server: mcp-chronometric
+    tools: [get_time_context]
+  - server: mcp-task-fractionator
+    tools: [decompose, next_one]
+profile_dependencies:
+  - identity.neurotypes
+  - preferences.max_chunk_size
+  - preferences.voice_input_preferred
+  - chronometric.time_buffer_multiplier
+  - chronometric.motor_fatigue_aware
+license: AGPL-3.0-or-later
+authors:
+  - neurodock-core
+---
+
+# dyspraxia-task-pacer
+
+This skill decomposes a goal into atomic steps and presents each step's time estimate **padded** by the user's `chronometric.time_buffer_multiplier`, stating plainly that the figure is padded and why. Motor execution of a task routinely runs longer than the raw cognitive estimate predicts; the skill applies the buffer in its own output because the task-fractionator returns unpadded estimates. It uses absolute, source-order references throughout, keeps any command as one copy-pasteable block when the user dictates, and factors motor load into break pacing when the profile opts in.
+
+## Activation criteria
+
+Activate when any of the following is true:
+
+- The user types `/pace`.
+- The user's message contains one of: `break this down`, `pace this for me`, `how long will this take`, `what's the next step`.
+- `identity.neurotypes` contains `dyspraxia` AND the user states a goal larger than a single step and asks for a plan or a duration.
+
+Do not activate when the user only wants the goal recorded (that is `record-fact`), or when they want a Mermaid picture of an overwhelm state (that is `visual-organizer`).
+
+## Operating instructions
+
+Follow these steps in order. Do not skip steps. Do not improvise additional tool calls.
+
+1. **Read the pacing inputs.** Read `chronometric.time_buffer_multiplier`, `preferences.max_chunk_size`, `preferences.voice_input_preferred`, and `chronometric.motor_fatigue_aware` from the profile. If `time_buffer_multiplier` is absent or unset, treat it as **1.0** — no padding, and make no padding claim (see "Do not"). If `max_chunk_size` is absent, default to **4** for this neurotype.
+
+2. **Anchor the day for pacing only.** Call `mcp-chronometric.get_time_context()`. Read `current_session_length`, `energy_zone`, and — only when present — `motor_fatigue_aware`. Do not narrate the time; you need it for the break line at the end, not for the headline.
+
+3. **Decompose the goal.** Call `mcp-task-fractionator.decompose(goal=<the user's goal verbatim>)`. If the user supplied a time budget as an ISO 8601 duration (e.g. `PT3H`), pass it as `time_budget`; otherwise omit it. Use the returned `tasks[]` and `estimated_minutes` verbatim as the **raw** estimate. Do not paraphrase task titles.
+
+   - On `BUDGET_INFEASIBLE`, say so plainly and stop: the budget cannot hold a credible list — do not truncate silently.
+   - On `GOAL_REQUIRED` / `GOAL_TOO_LONG`, surface the error and stop.
+
+4. **Pad every estimate.** For each task, compute `padded = round(estimated_minutes × time_buffer_multiplier)`. The padded figure is what the user sees. When the multiplier is greater than 1.0, the closing block must name the padding and its reason (step 7). When the multiplier is 1.0, show the raw figure with no padding claim.
+
+5. **Cap the list.** Keep the first `max_chunk_size` tasks in `sequence` order (lowest first). If the decomposition produced more, note the count of further steps in the closing block — do not list them. Each shown step is one atomic action.
+
+6. **Get the single next action.** Call `mcp-task-fractionator.next_one(project=<the goal's project, or the goal text trimmed to 120 chars>)` once.
+
+   - Success — quote the `task.title` and the padded estimate, and name the confidence to two decimal places.
+   - Error `NO_TASKS_AVAILABLE` — the goal was not yet recorded as a project, so say "this plan is not saved yet; the steps above are the start-here list" and do not fabricate a task.
+   - `ALL_TASKS_BLOCKED` or any other error — note the error code in the next-action line and move on.
+
+7. **Render the plan.** See "Output format" below.
+
+8. **Stop.** Do not offer to start the first step, rearrange the order, or ask a follow-up question. The padded plan is the deliverable.
+
+## Output format
+
+Strict "Answer First" structure. The first sentence must fit in 80 characters and must name the start-here step in plain prose.
+
+```
+<One sentence, ≤ 80 chars: name the first step and its padded minutes. Plain prose.>
+
+Steps (source order, start at the top):
+1. <task.title> — <padded> min
+2. <task.title> — <padded> min
+...
+
+Next one to pick up: <next_one.task.title> — <padded> min (conf <confidence>)
+
+---
+Estimates padded ×<time_buffer_multiplier> (≈+<percent>%): motor execution
+runs longer than the raw estimate predicts. Raw figures were <raw1>, <raw2>, ... min.
+<Optional further-steps line.>
+<Optional break line — only when motor_fatigue_aware is set.>
+```
+
+Rules:
+
+- Steps are numbered top-to-bottom in `sequence` order. Never reorder. Never use "the one above" / "drag this" / relative spatial language — refer to a step by its number or its title.
+- Padded minutes are integers. Show the raw minutes once, in the closing block, so the user can see what was padded — never silently.
+- Confidence on the next-action line is always two decimal places.
+- When `motor_fatigue_aware` is set, the break line factors motor load, not just clock time: e.g. `This list is mostly typing and clicking. That load builds faster than the minutes suggest, so a pause between step 2 and step 3 is worth taking.` Suggest, never demand. Never read a movement or a tic as a fatigue signal.
+- When `time_buffer_multiplier` is 1.0 (or unset), omit the padding line entirely and show the raw estimate inline. Do not claim anything was padded.
+
+### Voice-input mode
+
+When `preferences.voice_input_preferred` is true and the plan includes a command to run, emit that command as a **single copy-pasteable block** — one fenced block, no inline edits to make, no scattered fragments the user would have to hand-correct:
+
+```
+cp profiles/dyspraxia.yaml ~/.neurodock/profile.yaml
+```
+
+Never split a command across prose or ask the user to "change the bit in the middle". If a value must change, give the whole line with the value already in place.
+
+### Empty / infeasible fallback
+
+If `decompose` returns `BUDGET_INFEASIBLE`:
+
+```
+The budget you gave can't hold a credible list of steps. Nothing padded — there's
+nothing to pad yet.
+
+If you'd like, give a longer budget (an ISO 8601 duration like PT4H) or drop the
+budget entirely and I'll decompose without one.
+```
+
+## Distress signal handling
+
+If the invoking message contains overwhelm phrases — `I can't`, `too much`, `everything is urgent`, `I'm stuck`, `exhausted`, `burned out` — reduce the shown-step cap to **3** instead of `max_chunk_size`, drop the confidence number from the next-action line (state "this is a safe one to start with" instead), and append one sentence to the closing block: `If three is still too many, ask for "just the next one" and I'll show only that.` Do not lecture. Do not diagnose. Do not comment on the user's state.
+
+## Do not
+
+- Do not present a raw, unpadded estimate to a dyspraxia-tagged user as if it were the wall-clock cost. Padding is the point of this skill.
+- Do not claim an estimate was padded when `time_buffer_multiplier` is 1.0 or unset — that is a false statement about the number.
+- Do not use relative spatial or temporal references: no "drag this there", "the step above", "move it up", "the one on the right", "recently". Refer to steps by number or title, top-to-bottom, in source order.
+- Do not scatter a command across inline edits when `voice_input_preferred` is true. One copy-pasteable block, value already in place.
+- Do not read a movement, a tic, or input cadence as a fatigue signal. Motor-load pacing is about the _kind of work_ in the list, not about watching the user.
+- Do not use "just", "simply", "quick", "easy", or "a sec" for any duration. Durations are absolute minutes.
+- Do not use the words "superpower", "crusher", "smash", "let's go", "you got this", "differently abled", "clumsy", or any clinical term (`dyspraxia`, `dyspraxic`, `coordination disorder`, `motor deficit`) in user-visible output.
+- Do not animate, auto-scroll, or propose a moving target — this is text output; keep it still.
+- Do not offer to start the work or ask a follow-up. The plan is the deliverable.
+
+## What this skill is not
+
+It is not a productivity maximiser and it does not grade the user against the estimate. The padded number exists so the day is planned against a figure that holds, not so the user can be measured against a tighter one.
+
+## Examples
+
+See `tests/01-pace-with-buffer.md`, `tests/02-no-buffer-no-padding-claim.md`, and `tests/03-voice-input-single-block.md` for the full invocation traces.

--- a/packages/repo-tooling/tests/skills-bundle-drift.test.ts
+++ b/packages/repo-tooling/tests/skills-bundle-drift.test.ts
@@ -31,6 +31,7 @@ const EXPECTED_SKILLS = [
   "adhd-daily-planner",
   "asd-meeting-translator",
   "audhd-context-recovery",
+  "dyspraxia-task-pacer",
   "hyperfocus-formatter",
   "ocd-decision-finalizer",
   "visual-organizer",

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -40,6 +40,19 @@ neurodock install-skills --dry-run  # print the planned targets, write nothing
 - `ocd-decision-finalizer` — Surfaces prior decision evidence on repeat-validation requests; declines re-analysis without new information.
 - `hyperfocus-formatter` — "Answer First" output structure on long sessions and design-critique surfaces.
 - `visual-organizer` — Mermaid generation for overwhelm states.
+- `dyspraxia-task-pacer` — Decomposes a goal and presents each estimate padded by the profile's motor time-buffer, naming why.
+
+## Neurotypes served without a dedicated skill
+
+Some neurotypes are served well by profile presets, the reduced-motion default, and the prompt addendum — not by a prose-shaping skill. Forcing a token skill where one is not warranted would dilute the library, so we document the decision instead.
+
+- **Tourette** — no dedicated `tourette-` skill ships; the neurotype is served through the profile preset and the prompt addendum instead.
+
+  What serves it: `profiles/tourette.yaml` (hard-pinned `motion: reduced` for startle/tic-trigger safety, `max_chunk_size`, `chronometric.motor_fatigue_aware`), the per-neurotype prompt addendum, and the browser-extension motion handling. The one workflow a Tourette skill might own — a suppression-fatigue-aware session/break helper that respects "outwardly-still ≠ rested" — is already provided neurotype-blind by `hyperfocus-formatter`, which surfaces session data without editorialising, never comments on the body, and consumes the `motor_fatigue_aware` signal at the chronometric layer.
+
+  What a skill would have to avoid: the Tourette lens forbids the only content a dedicated skill would add — commenting on movement, instructing stillness, a "calm/relax" register, or focus scorecards — so a `tourette-` skill would be an empty shell or a duplicate of `hyperfocus-formatter`.
+
+  The `tourette-advocate` keeps the gap flagged, so the decision is revisited if a genuinely Tourette-specific, non-duplicative workflow emerges.
 
 ## Authoring a new skill
 

--- a/packages/skills/dyspraxia-task-pacer/README.md
+++ b/packages/skills/dyspraxia-task-pacer/README.md
@@ -1,0 +1,33 @@
+# dyspraxia-task-pacer
+
+A motor-aware pacing skill. It takes a goal, decomposes it into atomic steps, and presents each step's time estimate **padded** by the buffer in your profile — stating plainly that the figure is padded and why.
+
+## Why padding
+
+Motor execution of a task routinely runs 30–50% longer than the raw cognitive estimate predicts. The task-fractionator returns the raw estimate; this skill applies your `chronometric.time_buffer_multiplier` (1.3 in the `dyspraxia.yaml` preset, ≈+30%) so the day is planned against a figure that holds. The raw figures are still shown once, in the closing block, so nothing is hidden.
+
+## When it fires
+
+- You type `/pace` or one of `break this down`, `pace this for me`, `how long will this take`, `what's the next step`.
+- You state a goal larger than one step and ask for a plan or a duration.
+
+## How it reads your profile
+
+- `chronometric.time_buffer_multiplier` — the padding factor. If it is unset, nothing is padded and no padding claim is made; you see the raw estimate.
+- `preferences.max_chunk_size` — how many steps are shown (4 in the preset). Extra steps are counted, not listed.
+- `preferences.voice_input_preferred` — when true, any command is emitted as a single copy-pasteable block, value already in place, nothing to hand-edit.
+- `chronometric.motor_fatigue_aware` — when set, the closing break line factors the _kind of work_ in the list (typing, clicking) into the pacing, not just the clock. It never reads a movement as a signal.
+
+## What it does not do
+
+It does not grade you against the estimate, does not start the work for you, and does not use relative spatial references ("the step above", "drag this"). Steps are numbered top-to-bottom in source order.
+
+## References
+
+- [ADR 0003 — task-fractionator tool design](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0003-task-fractionator-tool-design.md)
+- ADR 0011 — per-neurotype tailoring fields (`time_buffer_multiplier`, `voice_input_preferred`, `motor_fatigue_aware`).
+- `profiles/dyspraxia.yaml` — the preset this skill is tuned for.
+
+## License
+
+AGPL-3.0-or-later.

--- a/packages/skills/dyspraxia-task-pacer/SKILL.md
+++ b/packages/skills/dyspraxia-task-pacer/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: dyspraxia-task-pacer
+version: 0.1.0
+description: Motor-aware pacing — decomposes a goal, pads each estimate by the profile buffer, names why.
+neurotypes: ["dyspraxia"]
+status: stable
+triggers:
+  - command: "/pace"
+  - phrase: "break this down"
+  - phrase: "pace this for me"
+  - phrase: "how long will this take"
+  - phrase: "what's the next step"
+mcp_dependencies:
+  - server: mcp-chronometric
+    tools: [get_time_context]
+  - server: mcp-task-fractionator
+    tools: [decompose, next_one]
+profile_dependencies:
+  - identity.neurotypes
+  - preferences.max_chunk_size
+  - preferences.voice_input_preferred
+  - chronometric.time_buffer_multiplier
+  - chronometric.motor_fatigue_aware
+license: AGPL-3.0-or-later
+authors:
+  - neurodock-core
+---
+
+# dyspraxia-task-pacer
+
+This skill decomposes a goal into atomic steps and presents each step's time estimate **padded** by the user's `chronometric.time_buffer_multiplier`, stating plainly that the figure is padded and why. Motor execution of a task routinely runs longer than the raw cognitive estimate predicts; the skill applies the buffer in its own output because the task-fractionator returns unpadded estimates. It uses absolute, source-order references throughout, keeps any command as one copy-pasteable block when the user dictates, and factors motor load into break pacing when the profile opts in.
+
+## Activation criteria
+
+Activate when any of the following is true:
+
+- The user types `/pace`.
+- The user's message contains one of: `break this down`, `pace this for me`, `how long will this take`, `what's the next step`.
+- `identity.neurotypes` contains `dyspraxia` AND the user states a goal larger than a single step and asks for a plan or a duration.
+
+Do not activate when the user only wants the goal recorded (that is `record-fact`), or when they want a Mermaid picture of an overwhelm state (that is `visual-organizer`).
+
+## Operating instructions
+
+Follow these steps in order. Do not skip steps. Do not improvise additional tool calls.
+
+1. **Read the pacing inputs.** Read `chronometric.time_buffer_multiplier`, `preferences.max_chunk_size`, `preferences.voice_input_preferred`, and `chronometric.motor_fatigue_aware` from the profile. If `time_buffer_multiplier` is absent or unset, treat it as **1.0** — no padding, and make no padding claim (see "Do not"). If `max_chunk_size` is absent, default to **4** for this neurotype.
+
+2. **Anchor the day for pacing only.** Call `mcp-chronometric.get_time_context()`. Read `current_session_length`, `energy_zone`, and — only when present — `motor_fatigue_aware`. Do not narrate the time; you need it for the break line at the end, not for the headline.
+
+3. **Decompose the goal.** Call `mcp-task-fractionator.decompose(goal=<the user's goal verbatim>)`. If the user supplied a time budget as an ISO 8601 duration (e.g. `PT3H`), pass it as `time_budget`; otherwise omit it. Use the returned `tasks[]` and `estimated_minutes` verbatim as the **raw** estimate. Do not paraphrase task titles.
+
+   - On `BUDGET_INFEASIBLE`, say so plainly and stop: the budget cannot hold a credible list — do not truncate silently.
+   - On `GOAL_REQUIRED` / `GOAL_TOO_LONG`, surface the error and stop.
+
+4. **Pad every estimate.** For each task, compute `padded = round(estimated_minutes × time_buffer_multiplier)`. The padded figure is what the user sees. When the multiplier is greater than 1.0, the closing block must name the padding and its reason (step 7). When the multiplier is 1.0, show the raw figure with no padding claim.
+
+5. **Cap the list.** Keep the first `max_chunk_size` tasks in `sequence` order (lowest first). If the decomposition produced more, note the count of further steps in the closing block — do not list them. Each shown step is one atomic action.
+
+6. **Get the single next action.** Call `mcp-task-fractionator.next_one(project=<the goal's project, or the goal text trimmed to 120 chars>)` once.
+
+   - Success — quote the `task.title` and the padded estimate, and name the confidence to two decimal places.
+   - Error `NO_TASKS_AVAILABLE` — the goal was not yet recorded as a project, so say "this plan is not saved yet; the steps above are the start-here list" and do not fabricate a task.
+   - `ALL_TASKS_BLOCKED` or any other error — note the error code in the next-action line and move on.
+
+7. **Render the plan.** See "Output format" below.
+
+8. **Stop.** Do not offer to start the first step, rearrange the order, or ask a follow-up question. The padded plan is the deliverable.
+
+## Output format
+
+Strict "Answer First" structure. The first sentence must fit in 80 characters and must name the start-here step in plain prose.
+
+```
+<One sentence, ≤ 80 chars: name the first step and its padded minutes. Plain prose.>
+
+Steps (source order, start at the top):
+1. <task.title> — <padded> min
+2. <task.title> — <padded> min
+...
+
+Next one to pick up: <next_one.task.title> — <padded> min (conf <confidence>)
+
+---
+Estimates padded ×<time_buffer_multiplier> (≈+<percent>%): motor execution
+runs longer than the raw estimate predicts. Raw figures were <raw1>, <raw2>, ... min.
+<Optional further-steps line.>
+<Optional break line — only when motor_fatigue_aware is set.>
+```
+
+Rules:
+
+- Steps are numbered top-to-bottom in `sequence` order. Never reorder. Never use "the one above" / "drag this" / relative spatial language — refer to a step by its number or its title.
+- Padded minutes are integers. Show the raw minutes once, in the closing block, so the user can see what was padded — never silently.
+- Confidence on the next-action line is always two decimal places.
+- When `motor_fatigue_aware` is set, the break line factors motor load, not just clock time: e.g. `This list is mostly typing and clicking. That load builds faster than the minutes suggest, so a pause between step 2 and step 3 is worth taking.` Suggest, never demand. Never read a movement or a tic as a fatigue signal.
+- When `time_buffer_multiplier` is 1.0 (or unset), omit the padding line entirely and show the raw estimate inline. Do not claim anything was padded.
+
+### Voice-input mode
+
+When `preferences.voice_input_preferred` is true and the plan includes a command to run, emit that command as a **single copy-pasteable block** — one fenced block, no inline edits to make, no scattered fragments the user would have to hand-correct:
+
+```
+cp profiles/dyspraxia.yaml ~/.neurodock/profile.yaml
+```
+
+Never split a command across prose or ask the user to "change the bit in the middle". If a value must change, give the whole line with the value already in place.
+
+### Empty / infeasible fallback
+
+If `decompose` returns `BUDGET_INFEASIBLE`:
+
+```
+The budget you gave can't hold a credible list of steps. Nothing padded — there's
+nothing to pad yet.
+
+If you'd like, give a longer budget (an ISO 8601 duration like PT4H) or drop the
+budget entirely and I'll decompose without one.
+```
+
+## Distress signal handling
+
+If the invoking message contains overwhelm phrases — `I can't`, `too much`, `everything is urgent`, `I'm stuck`, `exhausted`, `burned out` — reduce the shown-step cap to **3** instead of `max_chunk_size`, drop the confidence number from the next-action line (state "this is a safe one to start with" instead), and append one sentence to the closing block: `If three is still too many, ask for "just the next one" and I'll show only that.` Do not lecture. Do not diagnose. Do not comment on the user's state.
+
+## Do not
+
+- Do not present a raw, unpadded estimate to a dyspraxia-tagged user as if it were the wall-clock cost. Padding is the point of this skill.
+- Do not claim an estimate was padded when `time_buffer_multiplier` is 1.0 or unset — that is a false statement about the number.
+- Do not use relative spatial or temporal references: no "drag this there", "the step above", "move it up", "the one on the right", "recently". Refer to steps by number or title, top-to-bottom, in source order.
+- Do not scatter a command across inline edits when `voice_input_preferred` is true. One copy-pasteable block, value already in place.
+- Do not read a movement, a tic, or input cadence as a fatigue signal. Motor-load pacing is about the _kind of work_ in the list, not about watching the user.
+- Do not use "just", "simply", "quick", "easy", or "a sec" for any duration. Durations are absolute minutes.
+- Do not use the words "superpower", "crusher", "smash", "let's go", "you got this", "differently abled", "clumsy", or any clinical term (`dyspraxia`, `dyspraxic`, `coordination disorder`, `motor deficit`) in user-visible output.
+- Do not animate, auto-scroll, or propose a moving target — this is text output; keep it still.
+- Do not offer to start the work or ask a follow-up. The plan is the deliverable.
+
+## What this skill is not
+
+It is not a productivity maximiser and it does not grade the user against the estimate. The padded number exists so the day is planned against a figure that holds, not so the user can be measured against a tighter one.
+
+## Examples
+
+See `tests/01-pace-with-buffer.md`, `tests/02-no-buffer-no-padding-claim.md`, and `tests/03-voice-input-single-block.md` for the full invocation traces.

--- a/packages/skills/dyspraxia-task-pacer/tests/01-pace-with-buffer.md
+++ b/packages/skills/dyspraxia-task-pacer/tests/01-pace-with-buffer.md
@@ -1,0 +1,108 @@
+# Test: 01 — Pace a goal with the buffer applied, happy path
+
+## Scenario
+
+It is Wednesday, 2026-05-20, 14:10 local time. The user has the `dyspraxia.yaml` preset installed: `identity.neurotypes: ["dyspraxia"]`, `preferences.max_chunk_size: 4`, `preferences.voice_input_preferred: true`, `chronometric.time_buffer_multiplier: 1.3`, `chronometric.motor_fatigue_aware: true`. They type `pace this for me: wire the new settings panel into the popup`. The goal is bigger than one step. There is no project recorded for it yet, so `next_one` will return `NO_TASKS_AVAILABLE`. The decomposition produces four atomic tasks, none of which involve a command to copy-paste.
+
+## Expected MCP tool sequence
+
+1. `mcp-chronometric.get_time_context()` →
+   ```json
+   {
+     "now": "2026-05-20T14:10:03+01:00",
+     "day_of_week": "Wednesday",
+     "time_since_last_prompt": "PT0S",
+     "current_session_length": "PT12M",
+     "energy_zone": "afternoon_dip",
+     "motor_fatigue_aware": true
+   }
+   ```
+2. `mcp-task-fractionator.decompose(goal="wire the new settings panel into the popup")` →
+   ```json
+   {
+     "tasks": [
+       {
+         "id": "a1b2c3d4-1111-4aaa-8bbb-000000000001",
+         "title": "Add the SettingsPanel component file",
+         "description": "Create the SettingsPanel.tsx component with the four reader fields, no wiring yet.",
+         "estimated_minutes": 30,
+         "acceptance_criteria": [
+           "File exists at the named path",
+           "Component renders the four fields"
+         ],
+         "dependencies": [],
+         "sequence": 1,
+         "tags": ["frontend"]
+       },
+       {
+         "id": "a1b2c3d4-1111-4aaa-8bbb-000000000002",
+         "title": "Import SettingsPanel into the popup entrypoint",
+         "description": "Add the import and render SettingsPanel under the existing Home view.",
+         "estimated_minutes": 20,
+         "acceptance_criteria": [
+           "Popup mounts SettingsPanel",
+           "No console errors on open"
+         ],
+         "dependencies": ["a1b2c3d4-1111-4aaa-8bbb-000000000001"],
+         "sequence": 2,
+         "tags": ["frontend"]
+       },
+       {
+         "id": "a1b2c3d4-1111-4aaa-8bbb-000000000003",
+         "title": "Persist the four fields to local storage",
+         "description": "Read and write the four field values via the existing storage helper.",
+         "estimated_minutes": 40,
+         "acceptance_criteria": ["Values survive a popup reopen"],
+         "dependencies": ["a1b2c3d4-1111-4aaa-8bbb-000000000002"],
+         "sequence": 3,
+         "tags": ["frontend"]
+       },
+       {
+         "id": "a1b2c3d4-1111-4aaa-8bbb-000000000004",
+         "title": "Add a regression test for the panel mount",
+         "description": "Assert SettingsPanel renders the four fields in the popup test.",
+         "estimated_minutes": 25,
+         "acceptance_criteria": ["Test passes", "Covers the four-field render"],
+         "dependencies": ["a1b2c3d4-1111-4aaa-8bbb-000000000003"],
+         "sequence": 4,
+         "tags": ["test"]
+       }
+     ],
+     "rationale": "Split into create, wire, persist, test so each step is startable cold."
+   }
+   ```
+3. `mcp-task-fractionator.next_one(project="wire the new settings panel into the popup")` → error `NO_TASKS_AVAILABLE` (the goal was never recorded as a project; this is a fresh decomposition).
+
+(The skill MUST NOT call `decompose` more than once and MUST NOT retry `next_one`.)
+
+## Padding arithmetic (multiplier 1.3, round half-up to integer minutes)
+
+| Step | Raw min | Padded min |
+| ---- | ------- | ---------- |
+| 1    | 30      | 39         |
+| 2    | 20      | 26         |
+| 3    | 40      | 52         |
+| 4    | 25      | 33         |
+
+## Expected response shape
+
+- Opens with one sentence ≤ 80 characters that names step 1 (`Add the SettingsPanel component file`) and its padded figure `39 min`.
+- A numbered `Steps` list, in `sequence` order 1→4, each line `<title> — <padded> min`. Exactly four steps (equals `max_chunk_size`, none elided).
+- A `Next one to pick up:` line. Because `next_one` returned `NO_TASKS_AVAILABLE`, it states the plan is not saved yet and that the steps above are the start-here list — it does NOT fabricate a task or a confidence number.
+- Closing block names the multiplier (`×1.3`), an approximate percentage (`+30%`), and the four raw figures (`30, 20, 40, 25`).
+- Because `motor_fatigue_aware` is set, the closing block includes one suggestion-framed break line that refers to the _kind of work_ (frontend / typing-and-clicking), not to anything observed about the user, and refers to steps by number.
+- Total response length ≤ 1400 characters.
+
+## Pass criteria
+
+- [ ] Tool sequence is exactly three calls in order: `get_time_context()`, one `decompose(...)`, one `next_one(...)`.
+- [ ] First sentence is ≤ 80 characters and contains both the step-1 title and the number `39`.
+- [ ] Exactly four numbered steps appear, in sequence order, each showing the padded minute figure (`39`, `26`, `52`, `33`).
+- [ ] None of the raw figures (`30`, `20`, `40`, `25`) appears on a step line; the raw figures appear only in the closing block.
+- [ ] The next-action line contains `not saved yet` (or equivalent) and contains no fabricated task title and no `conf` number.
+- [ ] The closing block contains `×1.3`, `30%`, and all four raw figures.
+- [ ] A break line is present (motor_fatigue_aware is set) and contains no comment on the user's body, movement, or tics; it refers to a step by number.
+- [ ] No relative spatial language appears: none of `drag`, `the step above`, `move it up`, `on the right`, `recently`.
+- [ ] None of these substrings appear: `just`, `simply`, `quick`, `easy`, `superpower`, `crusher`, `smash`, `you got this`, `let's go`, `differently abled`, `clumsy`, `dyspraxia`, `dyspraxic`.
+- [ ] No `!` anywhere in the response.
+- [ ] Total response is ≤ 1400 characters.

--- a/packages/skills/dyspraxia-task-pacer/tests/02-no-buffer-no-padding-claim.md
+++ b/packages/skills/dyspraxia-task-pacer/tests/02-no-buffer-no-padding-claim.md
@@ -1,0 +1,91 @@
+# Test: 02 — No buffer set, no padding claim
+
+## Scenario
+
+It is Thursday, 2026-05-21, 10:00 local time. The user identifies with dyspraxia but is running a **hand-edited profile that does not set `chronometric.time_buffer_multiplier`** (the field is absent), and `chronometric.motor_fatigue_aware` is also absent. `identity.neurotypes: ["dyspraxia"]`, `preferences.max_chunk_size: 4`, `preferences.voice_input_preferred: false`. They type `/pace draft the release notes for 0.0.39`. The goal decomposes into two atomic tasks. A project for it exists, so `next_one` succeeds.
+
+This test guards the edge case: with no buffer, the skill must show **raw** estimates and must **not** claim anything was padded.
+
+## Expected MCP tool sequence
+
+1. `mcp-chronometric.get_time_context()` →
+   ```json
+   {
+     "now": "2026-05-21T10:00:00+01:00",
+     "day_of_week": "Thursday",
+     "time_since_last_prompt": "PT0S",
+     "current_session_length": "PT3M",
+     "energy_zone": "morning_peak"
+   }
+   ```
+   (Note: no `motor_fatigue_aware` field — the profile did not opt in.)
+2. `mcp-task-fractionator.decompose(goal="draft the release notes for 0.0.39")` →
+   ```json
+   {
+     "tasks": [
+       {
+         "id": "b2c3d4e5-2222-4aaa-8bbb-000000000001",
+         "title": "Collect the merged PRs since 0.0.38",
+         "description": "List the PR titles merged since the 0.0.38 tag from the changelog.",
+         "estimated_minutes": 15,
+         "acceptance_criteria": ["List covers every PR since the tag"],
+         "dependencies": [],
+         "sequence": 1,
+         "tags": ["writing"]
+       },
+       {
+         "id": "b2c3d4e5-2222-4aaa-8bbb-000000000002",
+         "title": "Write the user-facing summary block",
+         "description": "Turn the PR list into a short user-facing notes block.",
+         "estimated_minutes": 30,
+         "acceptance_criteria": [
+           "Block reads in plain prose",
+           "No internal jargon"
+         ],
+         "dependencies": ["b2c3d4e5-2222-4aaa-8bbb-000000000001"],
+         "sequence": 2,
+         "tags": ["writing"]
+       }
+     ],
+     "rationale": "Split into gather then write so the writing step starts from a fixed list."
+   }
+   ```
+3. `mcp-task-fractionator.next_one(project="draft the release notes for 0.0.39")` →
+   ```json
+   {
+     "task": {
+       "id": "b2c3d4e5-2222-4aaa-8bbb-000000000001",
+       "title": "Collect the merged PRs since 0.0.38",
+       "description": "List the PR titles merged since the 0.0.38 tag from the changelog.",
+       "estimated_minutes": 15,
+       "acceptance_criteria": ["List covers every PR since the tag"],
+       "dependencies": [],
+       "sequence": 1,
+       "tags": ["writing"]
+     },
+     "reasoning": "Sequence 1 with all dependencies satisfied. No other unblocked candidates, so this is the unique next step. 2 task(s) still pending in this project.",
+     "confidence": 0.95
+   }
+   ```
+
+## Expected response shape
+
+- Opens with one sentence ≤ 80 characters naming step 1 (`Collect the merged PRs since 0.0.38`) and `15 min` (raw, because there is no buffer).
+- Two numbered steps in sequence order, each showing the raw figure (`15`, `30`). No multiplier is applied.
+- A `Next one to pick up:` line quoting `Collect the merged PRs since 0.0.38`, `15 min`, and `conf 0.95`.
+- The closing block does NOT contain a padding line. It does NOT contain the strings `padded`, `×`, `buffer`, or any percentage. There is nothing to declare.
+- No break line, because `motor_fatigue_aware` is not set.
+- Total response length ≤ 900 characters.
+
+## Pass criteria
+
+- [ ] Tool sequence is exactly three calls in order: `get_time_context()`, one `decompose(...)`, one `next_one(...)`.
+- [ ] First sentence is ≤ 80 characters and contains `15`.
+- [ ] Exactly two numbered steps; the figures shown are `15` and `30` (raw, unmodified).
+- [ ] The response does NOT contain a percentage-padding claim: none of `padded`, `pad`, `×1.`, `multiplier`, `buffer`, `30%`, `+%`, or the pattern `+<digits>%` (e.g. `+30%`). (A bare `+` is fine — it may legitimately appear in a task title such as `TypeScript + React`.)
+- [ ] The next-action line contains `conf 0.95`.
+- [ ] No break line appears (motor_fatigue_aware absent).
+- [ ] No relative spatial language: none of `drag`, `the step above`, `move it up`, `on the right`, `recently`.
+- [ ] None of these substrings appear: `just`, `simply`, `quick`, `easy`, `superpower`, `crusher`, `smash`, `you got this`, `differently abled`, `clumsy`, `dyspraxia`, `dyspraxic`.
+- [ ] No `!` anywhere in the response.
+- [ ] Total response is ≤ 900 characters.

--- a/packages/skills/dyspraxia-task-pacer/tests/03-voice-input-single-block.md
+++ b/packages/skills/dyspraxia-task-pacer/tests/03-voice-input-single-block.md
@@ -1,0 +1,69 @@
+# Test: 03 — Voice-input mode, command as a single copy-pasteable block, with elision
+
+## Scenario
+
+It is Friday, 2026-05-22, 09:30 local time. The user has the `dyspraxia.yaml` preset: `identity.neurotypes: ["dyspraxia"]`, `preferences.max_chunk_size: 4`, `preferences.voice_input_preferred: true`, `chronometric.time_buffer_multiplier: 1.3`, `chronometric.motor_fatigue_aware: true`. They dictate `break this down: set up the dyspraxia profile and run the first session`. The decomposition produces **six** atomic tasks (two more than `max_chunk_size`, so two must be elided with a count). The plan's first step is a shell command, so voice-input mode applies: the command must be one copy-pasteable block. `next_one` succeeds with a sequence-1 task.
+
+This test guards two edges at once: list capping with an elision count, and the voice-input single-block rule.
+
+## Expected MCP tool sequence
+
+1. `mcp-chronometric.get_time_context()` →
+   ```json
+   {
+     "now": "2026-05-22T09:30:00+01:00",
+     "day_of_week": "Friday",
+     "current_session_length": "PT5M",
+     "energy_zone": "morning_peak",
+     "motor_fatigue_aware": true
+   }
+   ```
+2. `mcp-task-fractionator.decompose(goal="set up the dyspraxia profile and run the first session")` → six tasks, `estimated_minutes` per sequence:
+
+   | Sequence | Title                                         | Raw min |
+   | -------- | --------------------------------------------- | ------- |
+   | 1        | Copy the dyspraxia preset to the profile path | 5       |
+   | 2        | Open the profile and confirm the four fields  | 10      |
+   | 3        | Start the first session with a stated intent  | 5       |
+   | 4        | Decompose the first real goal                 | 15      |
+   | 5        | Pick the next single action                   | 5       |
+   | 6        | Mark the session end                          | 5       |
+
+   Step 1's `description` names the exact command `cp profiles/dyspraxia.yaml ~/.neurodock/profile.yaml`.
+
+3. `mcp-task-fractionator.next_one(project="set up the dyspraxia profile and run the first session")` → task = sequence-1 (`Copy the dyspraxia preset to the profile path`), `confidence: 0.95`.
+
+## Padding arithmetic (multiplier 1.3, round half-up)
+
+| Sequence | Raw | Padded |
+| -------- | --- | ------ |
+| 1        | 5   | 7      |
+| 2        | 10  | 13     |
+| 3        | 5   | 7      |
+| 4        | 15  | 20     |
+
+(Sequences 5 and 6 are elided — only the first `max_chunk_size = 4` are shown.)
+
+## Expected response shape
+
+- Opens with one sentence ≤ 80 characters naming step 1 and its padded figure `7 min`.
+- Exactly four numbered steps (sequences 1–4), padded figures `7`, `13`, `7`, `20`.
+- The step-1 command appears exactly once, as a single fenced code block containing the whole line `cp profiles/dyspraxia.yaml ~/.neurodock/profile.yaml` — value already in place, nothing to hand-edit. The command is NOT split across prose and is NOT presented as a fragment to insert into a larger file.
+- A `Next one to pick up:` line quoting `Copy the dyspraxia preset to the profile path`, `7 min`, `conf 0.95`.
+- The closing block names `×1.3`, `+30%`, the four shown raw figures (`5, 10, 5, 15`), an elision line stating `2 further steps` (count only, no titles for sequences 5–6), and one suggestion-framed break line referring to step numbers.
+- Total response length ≤ 1500 characters.
+
+## Pass criteria
+
+- [ ] Tool sequence is exactly three calls in order: `get_time_context()`, one `decompose(...)`, one `next_one(...)`.
+- [ ] Exactly four numbered steps appear (sequences 1–4); sequences 5 and 6 are not shown.
+- [ ] The padded figures `7`, `13`, `7`, `20` appear on the step lines; the raw figures appear only in the closing block.
+- [ ] The command `cp profiles/dyspraxia.yaml ~/.neurodock/profile.yaml` appears exactly once, inside a single fenced code block, as a complete line.
+- [ ] The command is not broken across two code blocks and not embedded in prose with an instruction to edit part of it.
+- [ ] The closing block contains `2 further steps` (or `Elided 2`) and does NOT contain the sequence-5 or sequence-6 titles (`Pick the next single action`, `Mark the session end`).
+- [ ] The closing block contains `×1.3` and `30%`.
+- [ ] A break line is present and contains no comment on the user's body, movement, or tics.
+- [ ] No relative spatial language: none of `drag`, `the step above`, `move it up`, `on the right`, `recently`.
+- [ ] None of these substrings appear: `just`, `simply`, `quick`, `easy`, `superpower`, `crusher`, `smash`, `you got this`, `differently abled`, `clumsy`, `dyspraxia`, `dyspraxic` (note: the literal file path `dyspraxia.yaml` inside the command block is exempt — it is a real filename, asserted separately above).
+- [ ] No `!` anywhere in the response.
+- [ ] Total response is ≤ 1500 characters.

--- a/profiles/dyspraxia.yaml
+++ b/profiles/dyspraxia.yaml
@@ -47,8 +47,10 @@
 #       estimates are systematically unreliable for dyspraxic users —
 #       the motor execution of a "five minute task" often takes 30-50%
 #       longer than the cognitive estimate predicts. Planning skills
-#       scale presented estimates by this factor (~+30%). (Consumer
-#       pending: task-fractionator.)
+#       scale presented estimates by this factor (~+30%). Now read by the
+#       dyspraxia-task-pacer skill (client/skill layer), which pads each
+#       estimate and names why. Server-side task-fractionator padding is
+#       still pending.
 #     - chronometric.motor_fatigue_aware = true   distinct from
 #       cognitive fatigue: a dyspraxic user can be cognitively sharp and
 #       motorically wrecked at once. When true the hyperfocus monitor
@@ -103,7 +105,9 @@ chronometric:
   # end_of_day_local: "18:30"   # uncomment to enable the after-hours nudge
   session_overlap_policy: "auto_close"
   # Pad presented time estimates by ~30%: motor execution of a task
-  # routinely runs longer than the cognitive estimate predicts.
+  # routinely runs longer than the cognitive estimate predicts. Read by
+  # the dyspraxia-task-pacer skill, which pads each estimate and names
+  # why; server-side task-fractionator padding is still pending.
   time_buffer_multiplier: 1.3
   # Weight clicks / keystrokes / window-switches into the fatigue
   # signal, not just continuous-session length.


### PR DESCRIPTION
## What

R3 part 3 — fills the Dyspraxia skill gap; documents the Tourette decision.

**`dyspraxia-task-pacer`** (new per-neurotype skill, `neurotypes: ["dyspraxia"]`): a motor-aware
planning/pacer. Decomposes a goal via the task-fractionator, **pads each estimate by the profile
`time_buffer_multiplier`** (the skill applies the buffer itself — the server doesn't pad yet — and
names *why*: motor-heavy work runs longer than the raw estimate, not "you're slow"), keeps output
**voice-input friendly** (single copy-pasteable blocks when `voice_input_preferred`), uses
absolute/sequential references, factors `motor_fatigue_aware` into pacing (never reads a tic/movement
as a signal), and caps lists at `max_chunk_size`. 3 invocation-trace tests (main + no-buffer +
voice-input/elision edges).

Ships to users automatically: bundled into the plugin via `scripts/sync-skills.mjs` (drift-guard
`EXPECTED_SKILLS` updated) and into `@neurodock/cli` via its build glob. Plugin skill count 12→13.

**No Tourette skill** (deliberate, documented in `packages/skills/README.md`): a non-duplicative,
lens-compliant Tourette skill couldn't be justified — it would duplicate `hyperfocus-formatter` or
contain only content the Tourette lens forbids (commenting on movement, "calm/relax" register, focus
scorecards). Tourette is served by `tourette.yaml` prefs + the prompt addendum; `tourette-advocate`
keeps the gap flagged.

## Review

`skill-author` authored; `code-reviewer` + `design-system-keeper` (APPROVE — "a good exemplar of the
house voice"; non-pathologising buffer/fatigue framing). Fixes: tightened a test's banned-substring;
renumbered steps to a clean integer sequence; split a dense example; refreshed the `dyspraxia.yaml`
"consumer" comment now that the skill reads `time_buffer_multiplier`.

## Test plan

- [x] `pnpm --filter @neurodock/repo-tooling test` → 16/16 (drift guard; `EXPECTED_SKILLS` updated)
- [x] `node scripts/sync-skills.mjs --check` green (CI/Linux; local Windows shows a CRLF-only false-positive on pre-existing files)
- [x] SKILL.md matches the convention; 3 tests; no changeset (skills auto-discovered by CLI build + plugin)
- [x] `wrangler.jsonc` excluded