### PR TITLE
feat(mcp-task-fractionator): neurotype hooks + dyspraxia skill alignment (r2)

### DIFF
--- a/.changeset/task-fractionator-r2-neurotype-hooks.md
+++ b/.changeset/task-fractionator-r2-neurotype-hooks.md
@@ -1,0 +1,38 @@
+---
+"@neurodock/core": minor
+---
+
+feat(mcp-task-fractionator): optional neurotype hooks on decompose (r2)
+
+`neurodock-mcp-task-fractionator` (Python, PyPI) `decompose` gains three
+optional, additive inputs that let decomposition respect the user's knobs.
+Every change is additive and optional per adr 0011: new optional inputs and
+new output fields only, never a change to an existing field, and never a
+neurotype branch. a call with none of the new inputs returns the exact pre-r2
+wire shape (covered by a backward-compat test).
+
+new optional inputs:
+
+- `max_chunk_size` (1-20) — caps the number of tasks returned below the normal
+  3-12 target. when the goal naturally needs more steps the server keeps the
+  lowest-sequence prefix (a valid sub-dag, dangling deps filtered), sets the
+  new optional `truncated` flag, and names the truncation in the rationale —
+  never a silent drop or an invalid topo order.
+- `time_buffer_multiplier` (1.0-3.0) — when > 1.0, each task gains an additive
+  `padded_minutes` = round(estimated_minutes × multiplier). `estimated_minutes`
+  stays raw so a presentation layer (the dyspraxia-task-pacer skill) never
+  double-pads. multiplier echoed and named in the rationale. 1.0 is a no-op.
+- `motor_fatigue_aware` (bool) — echoed and named in the rationale; the server
+  has no keystroke/click stream and does not infer fatigue (honest scoping,
+  mirroring mcp-chronometric #103).
+
+tool output changes (all additive optional, omitted when the knob is inactive):
+
+- `decompose` — per-task `padded_minutes`; top-level `time_buffer_multiplier`,
+  `motor_fatigue_aware`, `truncated`. dumped with `exclude_none=true`.
+- new error `INPUT_INVALID` for an out-of-range knob (rejected, never clamped).
+- `next_one` now also dumps with `exclude_none=true` so the shared
+  `Task.padded_minutes` (always unset there) stays off its wire — shape unchanged.
+
+json schemas under `packages/mcp-task-fractionator/schemas/` and the pydantic
+models are updated together and validated by the protocol conformance test.

--- a/claude-code/neurodock/skills/dyspraxia-task-pacer/SKILL.md
+++ b/claude-code/neurodock/skills/dyspraxia-task-pacer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dyspraxia-task-pacer
-version: 0.1.0
-description: Motor-aware pacing — decomposes a goal, pads each estimate by the profile buffer, names why.
+version: 0.2.0
+description: Motor-aware pacing — decomposes a goal, shows each estimate padded by the profile buffer, names why.
 neurotypes: ["dyspraxia"]
 status: stable
 triggers:
@@ -15,6 +15,16 @@ mcp_dependencies:
     tools: [get_time_context]
   - server: mcp-task-fractionator
     tools: [decompose, next_one]
+    inputs:
+      decompose:
+        [
+          goal,
+          time_budget,
+          max_chunk_size,
+          time_buffer_multiplier,
+          motor_fatigue_aware,
+        ]
+      next_one: [project]
 profile_dependencies:
   - identity.neurotypes
   - preferences.max_chunk_size
@@ -28,7 +38,7 @@ authors:
 
 # dyspraxia-task-pacer
 
-This skill decomposes a goal into atomic steps and presents each step's time estimate **padded** by the user's `chronometric.time_buffer_multiplier`, stating plainly that the figure is padded and why. Motor execution of a task routinely runs longer than the raw cognitive estimate predicts; the skill applies the buffer in its own output because the task-fractionator returns unpadded estimates. It uses absolute, source-order references throughout, keeps any command as one copy-pasteable block when the user dictates, and factors motor load into break pacing when the profile opts in.
+This skill decomposes a goal into atomic steps and presents each step's time estimate **padded** by the user's `chronometric.time_buffer_multiplier`, stating plainly that the figure is padded and why. Motor-heavy work routinely runs longer than the raw cognitive estimate predicts — the world underestimates that work, not the user — so the padded figure is the one the day should be planned against. The task-fractionator server is the single source of truth for the padding: the skill passes the buffer to `decompose` and displays the `padded_minutes` the server returns, never re-multiplying a figure that was already padded. It uses absolute, source-order references throughout, keeps any command as one copy-pasteable block when the user dictates, and factors motor load into break pacing when the profile opts in.
 
 ## Activation criteria
 
@@ -44,22 +54,38 @@ Do not activate when the user only wants the goal recorded (that is `record-fact
 
 Follow these steps in order. Do not skip steps. Do not improvise additional tool calls.
 
-1. **Read the pacing inputs.** Read `chronometric.time_buffer_multiplier`, `preferences.max_chunk_size`, `preferences.voice_input_preferred`, and `chronometric.motor_fatigue_aware` from the profile. If `time_buffer_multiplier` is absent or unset, treat it as **1.0** — no padding, and make no padding claim (see "Do not"). If `max_chunk_size` is absent, default to **4** for this neurotype.
+1. **Read the pacing inputs.** Read `chronometric.time_buffer_multiplier`, `preferences.max_chunk_size`, `preferences.voice_input_preferred`, and `chronometric.motor_fatigue_aware` from the profile. If `time_buffer_multiplier` is absent or unset, treat it as **1.0** — no buffer, no padding claim (see "Do not"). If `max_chunk_size` is absent, default to **4** for this neurotype.
 
 2. **Anchor the day for pacing only.** Call `mcp-chronometric.get_time_context()`. Read `current_session_length`, `energy_zone`, and — only when present — `motor_fatigue_aware`. Do not narrate the time; you need it for the break line at the end, not for the headline.
 
-3. **Decompose the goal.** Call `mcp-task-fractionator.decompose(goal=<the user's goal verbatim>)`. If the user supplied a time budget as an ISO 8601 duration (e.g. `PT3H`), pass it as `time_budget`; otherwise omit it. Use the returned `tasks[]` and `estimated_minutes` verbatim as the **raw** estimate. Do not paraphrase task titles.
+3. **Decompose the goal, passing the profile knobs.** Call `mcp-task-fractionator.decompose` with the goal verbatim and the profile knobs the server now understands:
+
+   - `goal` = the user's goal verbatim.
+   - `time_budget` = the user's ISO 8601 duration (e.g. `PT3H`) if they gave one, otherwise omit.
+   - `max_chunk_size` = `preferences.max_chunk_size` (default 4). **The server does the capping now** — do not cap the list yourself (see step 5).
+   - `time_buffer_multiplier` = `chronometric.time_buffer_multiplier`, but **only pass it when it is greater than 1.0**. When it is 1.0 or unset, omit it so the server returns the raw, unpadded shape.
+   - `motor_fatigue_aware` = `chronometric.motor_fatigue_aware` when it is `true`, otherwise omit.
+
+   Use the returned `tasks[]` verbatim. Do not paraphrase task titles.
 
    - On `BUDGET_INFEASIBLE`, say so plainly and stop: the budget cannot hold a credible list — do not truncate silently.
-   - On `GOAL_REQUIRED` / `GOAL_TOO_LONG`, surface the error and stop.
+   - On `GOAL_REQUIRED` / `GOAL_TOO_LONG` / `INPUT_INVALID`, surface the error and stop.
 
-4. **Pad every estimate.** For each task, compute `padded = round(estimated_minutes × time_buffer_multiplier)`. The padded figure is what the user sees. When the multiplier is greater than 1.0, the closing block must name the padding and its reason (step 7). When the multiplier is 1.0, show the raw figure with no padding claim.
+4. **Read the displayed estimate from the server (single source of truth).** For each task, the figure the user sees is:
 
-5. **Cap the list.** Keep the first `max_chunk_size` tasks in `sequence` order (lowest first). If the decomposition produced more, note the count of further steps in the closing block — do not list them. Each shown step is one atomic action.
+   - **When `padded_minutes` is present on the task** — show `padded_minutes`. The server already multiplied the raw estimate by the buffer; do **not** multiply again. The server also echoes `time_buffer_multiplier` at the top level and names the buffer in `rationale`; use the echoed multiplier for the closing line.
+   - **When `padded_minutes` is absent** — there is no server-side padding (the multiplier was 1.0/unset, or the server predates this field). Fall back to showing the raw `estimated_minutes`. **Only in this fallback, and only when the profile's `time_buffer_multiplier` is greater than 1.0**, compute the padding yourself as `round(estimated_minutes × time_buffer_multiplier)` and treat that as the displayed figure. If `padded_minutes` was present you have already padded once via the server, so the skill's own multiply must not run — this is how a double-pad is prevented.
 
-6. **Get the single next action.** Call `mcp-task-fractionator.next_one(project=<the goal's project, or the goal text trimmed to 120 chars>)` once.
+   In short: server `padded_minutes` wins when present; the skill's own arithmetic is a fallback that runs only when the server returned no padded figure.
 
-   - Success — quote the `task.title` and the padded estimate, and name the confidence to two decimal places.
+5. **Do not re-cap the list — the server already did.** Because `max_chunk_size` was passed to `decompose`, the returned `tasks[]` is already the capped prefix; show every task it contains, in `sequence` order. Capping is the server's responsibility now; surfacing the cut is the skill's.
+
+   - If the response carries `truncated: true`, the goal needed more steps than the cap. State this honestly in the closing block: name that further steps were left off and that they are still in the plan (you can lean on the server's `rationale`, which names the count and the recovery action — re-run without the cap to see them). Do not list the dropped steps and do not re-elide steps the server already returned.
+   - If `truncated` is absent, the list is complete for this cap; add no truncation line.
+
+6. **Get the single next action.** Call `mcp-task-fractionator.next_one(project=<the goal's project, or the goal text trimmed to 120 chars>)` once. `next_one` takes no knobs and its `task` carries **no** `padded_minutes` — so derive the displayed figure for the next action from the matching `decompose` task (match by `id`, falling back to `sequence`): show that task's `padded_minutes` when present, else the same raw/fallback figure rule as step 4. If no `decompose` task matches (e.g. the `next_one` task came from a saved project and was beyond this run's `max_chunk_size` cap), fall back to `next_one.task.estimated_minutes` with the step-4 fallback pad rule. Never multiply a `next_one` estimate a second time.
+
+   - Success — quote the `task.title` and the displayed (padded) estimate, and name the confidence to two decimal places.
    - Error `NO_TASKS_AVAILABLE` — the goal was not yet recorded as a project, so say "this plan is not saved yet; the steps above are the start-here list" and do not fabricate a task.
    - `ALL_TASKS_BLOCKED` or any other error — note the error code in the next-action line and move on.
 
@@ -72,29 +98,32 @@ Follow these steps in order. Do not skip steps. Do not improvise additional tool
 Strict "Answer First" structure. The first sentence must fit in 80 characters and must name the start-here step in plain prose.
 
 ```
-<One sentence, ≤ 80 chars: name the first step and its padded minutes. Plain prose.>
+<One sentence, ≤ 80 chars: name the first step and its displayed minutes. Plain prose.>
 
 Steps (source order, start at the top):
-1. <task.title> — <padded> min
-2. <task.title> — <padded> min
+1. <task.title> — <displayed> min
+2. <task.title> — <displayed> min
 ...
 
-Next one to pick up: <next_one.task.title> — <padded> min (conf <confidence>)
+Next one to pick up: <next_one.task.title> — <displayed> min (conf <confidence>)
 
 ---
-Estimates padded ×<time_buffer_multiplier> (≈+<percent>%): motor execution
+Estimates padded ×<time_buffer_multiplier> (≈+<percent>%): motor-heavy work
 runs longer than the raw estimate predicts. Raw figures were <raw1>, <raw2>, ... min.
-<Optional further-steps line.>
+<Optional truncation line — only when the server set truncated: true.>
 <Optional break line — only when motor_fatigue_aware is set.>
 ```
 
 Rules:
 
-- Steps are numbered top-to-bottom in `sequence` order. Never reorder. Never use "the one above" / "drag this" / relative spatial language — refer to a step by its number or its title.
-- Padded minutes are integers. Show the raw minutes once, in the closing block, so the user can see what was padded — never silently.
+- "Displayed minutes" is the server's `padded_minutes` when present, else the raw `estimated_minutes` (or the skill's fallback pad — step 4). Never the result of multiplying a `padded_minutes` again.
+- Steps are numbered top-to-bottom in `sequence` order. Never reorder. Never use "the one above" / "drag this" / relative spatial language — refer to a step by its number or title.
+- Displayed minutes are integers. Show the raw minutes once, in the closing block, so the user can see what was padded — never silently.
+- Use the server's echoed top-level `time_buffer_multiplier` for the `×` figure in the closing line. Do not invent a multiplier the server did not echo.
 - Confidence on the next-action line is always two decimal places.
+- The truncation line reports the server's `truncated` flag honestly: that there were more steps than the cap and they are still in the plan (re-run without the cap to see them). Count is fine; do not list dropped titles.
 - When `motor_fatigue_aware` is set, the break line factors motor load, not just clock time: e.g. `This list is mostly typing and clicking. That load builds faster than the minutes suggest, so a pause between step 2 and step 3 is worth taking.` Suggest, never demand. Never read a movement or a tic as a fatigue signal.
-- When `time_buffer_multiplier` is 1.0 (or unset), omit the padding line entirely and show the raw estimate inline. Do not claim anything was padded.
+- When `time_buffer_multiplier` is 1.0 (or unset) — and so the server returned no `padded_minutes` and echoed no multiplier — omit the padding line entirely and show the raw estimate inline. Do not claim anything was padded.
 
 ### Voice-input mode
 
@@ -120,12 +149,14 @@ budget entirely and I'll decompose without one.
 
 ## Distress signal handling
 
-If the invoking message contains overwhelm phrases — `I can't`, `too much`, `everything is urgent`, `I'm stuck`, `exhausted`, `burned out` — reduce the shown-step cap to **3** instead of `max_chunk_size`, drop the confidence number from the next-action line (state "this is a safe one to start with" instead), and append one sentence to the closing block: `If three is still too many, ask for "just the next one" and I'll show only that.` Do not lecture. Do not diagnose. Do not comment on the user's state.
+If the invoking message contains overwhelm phrases — `I can't`, `too much`, `everything is urgent`, `I'm stuck`, `exhausted`, `burned out` — pass a smaller `max_chunk_size` of **3** to `decompose` (instead of the profile value) so the server returns a shorter prefix, drop the confidence number from the next-action line (state "this is a safe one to start with" instead), and append one sentence to the closing block: `If three is still too many, ask for "just the next one" and I'll show only that.` Do not lecture. Do not diagnose. Do not comment on the user's state.
 
 ## Do not
 
-- Do not present a raw, unpadded estimate to a dyspraxia-tagged user as if it were the wall-clock cost. Padding is the point of this skill.
-- Do not claim an estimate was padded when `time_buffer_multiplier` is 1.0 or unset — that is a false statement about the number.
+- Do not present a raw, unpadded estimate to a dyspraxia-tagged user as if it were the wall-clock cost when a buffer is set. The padded figure is the point of this skill.
+- Do not pad twice. When the server returned `padded_minutes`, that figure is already padded — displaying it is enough. The skill's own `round(estimated_minutes × multiplier)` runs ONLY in the fallback where `padded_minutes` is absent. There is never a path where both the server and the skill multiply the same estimate.
+- Do not claim an estimate was padded when `time_buffer_multiplier` is 1.0 or unset (the server returns no `padded_minutes` and echoes no multiplier) — that is a false statement about the number.
+- Do not re-cap or re-elide the task list. `decompose` was given `max_chunk_size`, so the returned list is already the prefix; surface the server's `truncated` flag instead of trimming a second time.
 - Do not use relative spatial or temporal references: no "drag this there", "the step above", "move it up", "the one on the right", "recently". Refer to steps by number or title, top-to-bottom, in source order.
 - Do not scatter a command across inline edits when `voice_input_preferred` is true. One copy-pasteable block, value already in place.
 - Do not read a movement, a tic, or input cadence as a fatigue signal. Motor-load pacing is about the _kind of work_ in the list, not about watching the user.
@@ -136,7 +167,7 @@ If the invoking message contains overwhelm phrases — `I can't`, `too much`, `e
 
 ## What this skill is not
 
-It is not a productivity maximiser and it does not grade the user against the estimate. The padded number exists so the day is planned against a figure that holds, not so the user can be measured against a tighter one.
+It is not a productivity maximiser and it does not grade the user against the estimate. The padded number exists so the day is planned against a figure that holds, not so the user can be measured against a tighter one. The buffer reflects that motor-heavy work is routinely under-budgeted by everyone — it is not a measure of the user.
 
 ## Examples
 

--- a/docs/src/content/docs/reference/mcp-servers/task-fractionator.mdx
+++ b/docs/src/content/docs/reference/mcp-servers/task-fractionator.mdx
@@ -38,7 +38,7 @@ The rationale paragraph that ships with the response surfaces every assumption (
 
 | Tool | Input | Output |
 |---|---|---|
-| `decompose` | `{ goal: string, time_budget?: string }` | `{ tasks: Task[], rationale: string }` |
+| `decompose` | `{ goal: string, time_budget?: string, max_chunk_size?: integer, time_buffer_multiplier?: number, motor_fatigue_aware?: boolean }` | `{ tasks: Task[], rationale: string, time_buffer_multiplier?, motor_fatigue_aware?, truncated? }` |
 | `next_one` | `{ project: string }` | `{ task: Task, reasoning: string, confidence: number }` |
 
 ### `decompose`
@@ -48,17 +48,25 @@ Input:
 - `goal` — plain-language goal, 5–500 characters. Treated as private user data; never logged.
 - `time_budget` — optional ISO 8601 duration (`PT4H`, `P3D`, `PT30M`). The total `estimated_minutes` across returned tasks fits within the budget; otherwise the server returns `BUDGET_INFEASIBLE` rather than silently truncating.
 
+Optional neurotype knobs (ADR 0011 — additive, default to today's behaviour when absent; the server never branches on a neurotype enum):
+
+- `max_chunk_size` — integer `1–20`. Caps the *number* of tasks returned, below the normal 3–12 target. When the goal naturally needs more steps, the server keeps the lowest-`sequence` prefix (a valid sub-DAG with no dangling dependencies), sets `truncated: true`, and says so in the rationale. It never silently drops steps or returns an invalid order.
+- `time_buffer_multiplier` — number `1.0–3.0`. When greater than 1.0, each task gains an additive `padded_minutes` equal to `round(estimated_minutes × multiplier)`; `estimated_minutes` stays **raw** so a presentation layer never double-pads. A value of `1.0` (or omitting the field) produces no padding. Out-of-range values are rejected with `INPUT_INVALID`.
+- `motor_fatigue_aware` — boolean. When true, the server echoes the preference and names it in the rationale so the client/skill can pace breaks. The server has no view of keystroke/click activity and does **not** infer fatigue.
+
 Output:
 
 - `tasks` — array of 1–20 tasks (target 3–12, per ADR 0003). Each task has:
   - `id` — UUIDv4, server-generated.
   - `title`, `description` — verb-led, concrete.
-  - `estimated_minutes` — integer in `[5, 90]`. Floor prevents trivial-shred; ceiling enforces atomicity.
+  - `estimated_minutes` — integer in `[5, 90]`. Floor prevents trivial-shred; ceiling enforces atomicity. Always **raw** — never buffer-adjusted.
+  - `padded_minutes` — *optional, additive.* Present only when `time_buffer_multiplier` greater than 1.0 was supplied; equals `round(estimated_minutes × multiplier)`. Omitted otherwise.
   - `acceptance_criteria` — non-empty array. Required. An empty array is rejected as `ACCEPTANCE_CRITERIA_REQUIRED`.
   - `dependencies` — UUIDv4 references to siblings in the same response. Cycles are rejected.
   - `sequence` — 1-indexed total order. Distinct for every task; `next_one` is "sequence = 1 of the unfinished subset".
   - `tags` — free-form labels for filtering.
-- `rationale` — one paragraph the user can read in 5 seconds. Surfaces assumptions ("I assumed Friday meant end-of-business Friday in your local timezone"). Not a marketing summary.
+- `rationale` — one paragraph the user can read in 5 seconds. Surfaces assumptions ("I assumed Friday meant end-of-business Friday in your local timezone"). Not a marketing summary. Names any active knob (the padding multiplier, truncation, motor-fatigue-aware preference).
+- `time_buffer_multiplier`, `motor_fatigue_aware`, `truncated` — *optional, additive echoes.* Each is present only when the corresponding knob was active; omitted otherwise so a no-knob call is byte-identical to the pre-R2 wire shape.
 
 ### `next_one`
 
@@ -73,6 +81,7 @@ The fractionator owns the *decomposition algorithm*; the graph owns the *state*.
 | `GOAL_REQUIRED` | Goal missing or shorter than 5 characters after trimming. |
 | `GOAL_TOO_LONG` | Goal exceeded 500 characters. Split the goal itself. |
 | `TIME_BUDGET_UNPARSEABLE` | Budget did not match the ISO 8601 duration regex. No silent fallback. |
+| `INPUT_INVALID` | An R2 neurotype knob was out of range: `max_chunk_size` not a positive integer 1–20, or `time_buffer_multiplier` outside `[1.0, 3.0]`. Rejected, never clamped. |
 | `BUDGET_INFEASIBLE` | No task list fits the budget while still covering the goal. May include `minimum_feasible_minutes`. |
 | `DEPENDENCY_CYCLE` | Candidate decomposition produced a cycle. Server bug, surfaced explicitly. |
 | `ACCEPTANCE_CRITERIA_REQUIRED` | Internal invariant — a candidate task had zero acceptance criteria. |

--- a/packages/mcp-task-fractionator/CHANGELOG.md
+++ b/packages/mcp-task-fractionator/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this package will be documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-06-18
+
+### Added — optional neurotype hooks on `decompose` (R2; ADR 0011)
+
+`decompose` gained three OPTIONAL, ADDITIVE inputs. Each defaults to today's
+behaviour when absent, so a call with none of them returns the exact pre-R2
+wire shape (covered by a backward-compat test). The server stays neurotype-
+**blind** in the ADR-0011 sense: these are call-time KNOBS, not a neurotype
+enum, and the engine never branches on a neurotype.
+
+- `max_chunk_size` (integer `1–20`) — caps the _number_ of tasks returned,
+  below the normal 3–12 target / hard cap of 20. When the goal naturally needs
+  more steps, the server keeps the lowest-`sequence` prefix (a valid sub-DAG
+  with dangling dependency references filtered out), sets the new optional
+  `truncated: true` output flag, and names the truncation in the rationale —
+  it never silently drops steps or returns an invalid topological order.
+- `time_buffer_multiplier` (number `1.0–3.0`) — when greater than 1.0, each
+  task gains an additive `padded_minutes` = `round(estimated_minutes ×
+multiplier)`. **`estimated_minutes` stays raw** so a presentation layer
+  (e.g. the `dyspraxia-task-pacer` skill) never double-pads. The multiplier is
+  echoed at top level and named in the rationale. A value of `1.0` (or omitting
+  the field) produces no padding and no echo.
+- `motor_fatigue_aware` (boolean) — when true, the server echoes the
+  preference and names it in the rationale so the client/skill can pace breaks.
+  The server has no view of keystroke/click activity and does **not** infer
+  fatigue (honest scoping, mirroring `mcp-chronometric` #103).
+
+New optional output fields (all omitted from the wire when their knob is
+inactive, via `model_dump(exclude_none=True)`): per-task `padded_minutes`, and
+top-level `time_buffer_multiplier`, `motor_fatigue_aware`, `truncated`.
+
+New error code `INPUT_INVALID` — an out-of-range knob (`max_chunk_size` not a
+positive integer 1–20, or `time_buffer_multiplier` outside `[1.0, 3.0]`) is
+rejected rather than silently clamped.
+
+JSON schemas under `schemas/` and the Pydantic models in `types.py` were
+updated together; the protocol-conformance test validates both tools'
+responses against the schemas. `next_one` now also dumps with
+`exclude_none=True` so the shared `Task.padded_minutes` field (always unset
+there) stays off `next_one`'s wire — its shape is unchanged.
+
 ## [0.0.5] - 2026-06-11
 
 ### Changed

--- a/packages/mcp-task-fractionator/pyproject.toml
+++ b/packages/mcp-task-fractionator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-task-fractionator"
-version = "0.0.5"
+version = "0.1.0"
 description = "NeuroDock task fractionator MCP server — goal decomposition and next-action selection."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/mcp-task-fractionator/schemas/decompose.schema.json
+++ b/packages/mcp-task-fractionator/schemas/decompose.schema.json
@@ -27,6 +27,25 @@
           "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(\\.\\d+)?S)?)?$",
           "description": "Optional ISO 8601 duration capping total estimated_minutes across the returned tasks. MUST be ISO 8601 format — natural language like '3 hours' is rejected with TIME_BUDGET_UNPARSEABLE. Common values: 'PT30M' = 30 minutes, 'PT3H' = 3 hours, 'PT1H30M' = 1 hour 30 minutes, 'PT4H' = 4 hours, 'P1D' = 1 day, 'P3D' = 3 days. When absent the server returns the smallest credible set of atomic tasks that fully covers the goal — 'unbounded' does NOT mean 'maximally decomposed'. When present, total estimated_minutes across returned tasks MUST fit within the budget; if the server cannot construct such a list it returns BUDGET_INFEASIBLE rather than silently truncating.",
           "examples": ["PT30M", "PT3H", "PT1H30M", "PT4H", "P1D", "P3D"]
+        },
+        "max_chunk_size": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Optional neurotype knob (ADR 0011, additive). Caps the NUMBER of tasks returned, below the normal 3-12 target and hard cap of 20. When the goal naturally needs more steps than the cap, the server keeps the lowest-sequence prefix — a valid sub-DAG with no dangling dependency references — and records the truncation in the rationale and via the optional output flag 'truncated'; it never silently drops steps or returns an invalid topological order. Knob only: the server never branches on a neurotype enum. When absent the task count is the server's normal choice.",
+          "examples": [3, 4, 5]
+        },
+        "time_buffer_multiplier": {
+          "type": "number",
+          "minimum": 1.0,
+          "maximum": 3.0,
+          "description": "Optional neurotype knob (ADR 0011, additive). When greater than 1.0, the server attaches an additive per-task 'padded_minutes' equal to round(estimated_minutes * multiplier) and echoes the multiplier in the output. 'estimated_minutes' stays RAW so a presentation layer never double-pads. A value of exactly 1.0 (or omitting the field) produces no padding and leaves the wire shape unchanged. Values below 1.0 (which would shrink an estimate) or above 3.0 are rejected with INPUT_INVALID.",
+          "examples": [1.25, 1.5, 2.0]
+        },
+        "motor_fatigue_aware": {
+          "type": "boolean",
+          "description": "Optional neurotype knob (ADR 0011, additive). When true, the server echoes 'motor_fatigue_aware: true' in the output and names it in the rationale so the client/skill can pace breaks. The server has NO view of actual keystroke/click activity and does NOT infer fatigue — it only surfaces the declared preference. When absent or false the wire shape is unchanged.",
+          "examples": [true]
         }
       }
     },
@@ -77,7 +96,12 @@
                 "type": "integer",
                 "minimum": 5,
                 "maximum": 90,
-                "description": "Estimated minutes to complete. Floor of 5 prevents trivial-shred decomposition; ceiling of 90 enforces atomicity — anything longer is a goal, not a task. Server SHOULD round to multiples of 5 for legibility."
+                "description": "Estimated minutes to complete. Floor of 5 prevents trivial-shred decomposition; ceiling of 90 enforces atomicity — anything longer is a goal, not a task. Server SHOULD round to multiples of 5 for legibility. This figure is always RAW — it is never adjusted by time_buffer_multiplier (see padded_minutes)."
+              },
+              "padded_minutes": {
+                "type": "integer",
+                "minimum": 5,
+                "description": "Optional, additive (ADR 0011, R2). Present only when the request supplied a time_buffer_multiplier greater than 1.0. Equals round(estimated_minutes * time_buffer_multiplier). estimated_minutes stays RAW alongside it, so a presentation layer that shows the padded figure does not pad a second time. Omitted entirely when no buffer is in effect."
               },
               "acceptance_criteria": {
                 "type": "array",
@@ -122,7 +146,21 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 1000,
-          "description": "One paragraph the user can read in 5 seconds explaining how the goal was carved. Surfaces assumptions ('I assumed Friday meant end-of-business Friday in your local timezone') so the user can correct them on the next call. NOT a marketing summary."
+          "description": "One paragraph the user can read in 5 seconds explaining how the goal was carved. Surfaces assumptions ('I assumed Friday meant end-of-business Friday in your local timezone') so the user can correct them on the next call. NOT a marketing summary. When an R2 knob is active it also names the padding multiplier, any truncation, and the motor-fatigue-aware preference."
+        },
+        "time_buffer_multiplier": {
+          "type": "number",
+          "minimum": 1.0,
+          "maximum": 3.0,
+          "description": "Optional, additive (ADR 0011, R2). Echoes the request's time_buffer_multiplier when it was greater than 1.0 (so a presentation layer knows what padded_minutes was computed with). Omitted when no buffer was applied."
+        },
+        "motor_fatigue_aware": {
+          "type": "boolean",
+          "description": "Optional, additive (ADR 0011, R2). Echoes the request's motor_fatigue_aware preference when it was true. The server does not infer fatigue. Omitted when the preference was absent or false."
+        },
+        "truncated": {
+          "type": "boolean",
+          "description": "Optional, additive (ADR 0011, R2). Present and true only when max_chunk_size was lower than the number of tasks the goal would naturally produce, so the returned list is a prefix and further steps remain. Omitted when no truncation occurred."
         }
       }
     }
@@ -139,6 +177,9 @@
       },
       "TIME_BUDGET_UNPARSEABLE": {
         "description": "time_budget did not match the ISO 8601 duration regex. The server does NOT silently fall back to unbounded — that would mask the caller's bug."
+      },
+      "INPUT_INVALID": {
+        "description": "An R2 neurotype knob was supplied with an out-of-range value: max_chunk_size was not a positive integer (1-20), or time_buffer_multiplier was outside [1.0, 3.0]. The server rejects rather than silently clamping, so the caller's bug is not masked."
       },
       "BUDGET_INFEASIBLE": {
         "description": "The server could not construct any task list with total estimated_minutes <= time_budget that also covers the goal. Caller SHOULD retry with a larger budget or a smaller goal. Error payload MAY include a 'minimum_feasible_minutes' integer to guide the retry."

--- a/packages/mcp-task-fractionator/schemas/next_one.schema.json
+++ b/packages/mcp-task-fractionator/schemas/next_one.schema.json
@@ -62,7 +62,12 @@
               "type": "integer",
               "minimum": 5,
               "maximum": 90,
-              "description": "Estimated minutes to complete."
+              "description": "Estimated minutes to complete. Always RAW (never buffer-adjusted)."
+            },
+            "padded_minutes": {
+              "type": "integer",
+              "minimum": 5,
+              "description": "Optional, additive (ADR 0011, R2). Present only if the source task carries a buffer-padded estimate; next_one itself does not pad and omits this field. estimated_minutes stays RAW alongside it."
             },
             "acceptance_criteria": {
               "type": "array",

--- a/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/decomposer.py
+++ b/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/decomposer.py
@@ -46,6 +46,26 @@ class GoalTooLongError(ValueError):
     """Raised when the goal exceeds 500 characters."""
 
 
+class MaxChunkSizeInvalidError(ValueError):
+    """Raised when ``max_chunk_size`` is supplied but is out of range.
+
+    R2 neurotype hook (ADR 0011): the cap is an optional knob in 1..20. A
+    non-integer, non-positive, or above-20 value is a caller bug — surfaced,
+    never silently ignored. The pure decomposer enforces the same 1..20 band as
+    the server's ``Field(ge=1, le=20)`` so direct/library callers cannot bypass
+    the contract.
+    """
+
+
+class TimeBufferMultiplierInvalidError(ValueError):
+    """Raised when ``time_buffer_multiplier`` is outside the supported band.
+
+    R2 neurotype hook (ADR 0011): the buffer is an optional knob in roughly
+    [1.0, 3.0]. Values below 1.0 (which would *shrink* an estimate) or above
+    3.0 are rejected rather than silently clamped.
+    """
+
+
 class BudgetInfeasibleError(RuntimeError):
     """Raised when no task list can fit inside ``time_budget``.
 
@@ -169,10 +189,19 @@ class _Skeleton:
 
 @dataclass(frozen=True)
 class _DecomposePlan:
-    """A candidate, pre-sort decomposition. Used to test budget feasibility."""
+    """A candidate, pre-sort decomposition. Used to test budget feasibility.
+
+    The rationale is held as two parts so the formatter can swap *only* the
+    opening count sentence under truncation while leaving the budget/time-marker
+    tail untouched. ``rationale_opening`` is the "Carved the goal into N task(s)"
+    sentence; ``rationale_extra`` is the optional budget/time-marker sentences
+    that follow it. Concatenated with a single space they reproduce the
+    pre-R2 seed byte-for-byte.
+    """
 
     skeletons: tuple[_Skeleton, ...]
-    rationale_seed: str
+    rationale_opening: str
+    rationale_extra: str
 
     @property
     def total_minutes(self) -> int:
@@ -236,11 +265,33 @@ def decompose(
     *,
     goal: str,
     time_budget: str | None = None,
+    max_chunk_size: int | None = None,
+    time_buffer_multiplier: float | None = None,
+    motor_fatigue_aware: bool | None = None,
     uuid_factory: UuidFactory | None = None,
 ) -> DecomposeOutput:
     """Local-heuristic decomposition of ``goal``.
 
     Pure function: no I/O, no logging of the goal text.
+
+    The three optional R2 neurotype hooks (ADR 0011) all default to today's
+    behaviour when absent, so a call with none of them is byte-identical to the
+    pre-R2 contract:
+
+    - ``max_chunk_size`` — lower the ceiling on the number of returned tasks.
+      The existing 3..12 target / hard-cap-20 logic still applies above this.
+      When the natural plan is longer than the cap we keep the lowest-sequence
+      prefix (a valid sub-DAG by construction — the chain only points
+      backward), drop any now-dangling dependency references, and record the
+      truncation in the rationale rather than silently dropping steps.
+    - ``time_buffer_multiplier`` — when > 1.0, attach an additive
+      ``padded_minutes`` (= round(estimated_minutes * multiplier)) to each
+      task; ``estimated_minutes`` stays RAW so a presentation layer never
+      double-pads. Echoed in the output and named in the rationale. A value of
+      exactly 1.0 is a no-op.
+    - ``motor_fatigue_aware`` — a declared preference the server echoes. The
+      server has no keystroke/click stream, so it surfaces the flag and says so
+      in the rationale rather than fabricating activity data.
     """
 
     if not isinstance(goal, str):
@@ -250,6 +301,24 @@ def decompose(
         raise GoalRequiredError("goal must be at least 5 non-whitespace characters")
     if len(trimmed) > 500:
         raise GoalTooLongError("goal exceeds 500 characters")
+
+    if max_chunk_size is not None:
+        if not isinstance(max_chunk_size, int) or isinstance(max_chunk_size, bool):
+            raise MaxChunkSizeInvalidError("max_chunk_size must be an integer")
+        if max_chunk_size < 1:
+            raise MaxChunkSizeInvalidError("max_chunk_size must be a positive integer")
+        if max_chunk_size > 20:
+            raise MaxChunkSizeInvalidError("max_chunk_size must be 20 or fewer")
+
+    if time_buffer_multiplier is not None:
+        if not isinstance(time_buffer_multiplier, int | float) or isinstance(
+            time_buffer_multiplier, bool
+        ):
+            raise TimeBufferMultiplierInvalidError("time_buffer_multiplier must be a number")
+        if time_buffer_multiplier < 1.0 or time_buffer_multiplier > 3.0:
+            raise TimeBufferMultiplierInvalidError(
+                "time_buffer_multiplier must be between 1.0 and 3.0"
+            )
 
     parsed_budget: ParsedTimeBudget | None = None
     if time_budget is not None:
@@ -309,18 +378,34 @@ def decompose(
         # Re-raise — server boundary translates to DEPENDENCY_CYCLE.
         raise
 
+    # R2: apply the max_chunk_size cap. We keep the lowest-sequence prefix of
+    # the total order. Because every dependency in this engine points strictly
+    # backward along the chain, the prefix is a valid sub-DAG; we still filter
+    # dangling dependency references defensively so a future non-linear plan
+    # can never produce an invalid topo order.
+    natural_count = len(ordered_ids)
+    truncated = max_chunk_size is not None and max_chunk_size < natural_count
+    if max_chunk_size is not None:
+        kept_ids = ordered_ids[:max_chunk_size]
+    else:
+        kept_ids = ordered_ids
+    kept_id_set = set(kept_ids)
+
     by_id = {s.task_id: s for s in plan.skeletons}
     tasks: list[Task] = []
-    for index, task_id in enumerate(ordered_ids, start=1):
+    for index, task_id in enumerate(kept_ids, start=1):
         skeleton = by_id[task_id]
+        kept_dependencies = [dep for dep in skeleton.dependencies if dep in kept_id_set]
+        padded_minutes = _padded_minutes(skeleton.estimated_minutes, time_buffer_multiplier)
         tasks.append(
             Task(
                 id=skeleton.task_id,
                 title=skeleton.title,
                 description=skeleton.description,
                 estimated_minutes=skeleton.estimated_minutes,
+                padded_minutes=padded_minutes,
                 acceptance_criteria=list(skeleton.acceptance_criteria),
-                dependencies=list(skeleton.dependencies),
+                dependencies=kept_dependencies,
                 sequence=index,
                 tags=list(skeleton.tags),
             )
@@ -331,8 +416,44 @@ def decompose(
         plan=plan,
         budget=parsed_budget,
         time_markers=detected_time_markers,
+        truncated=truncated,
+        natural_count=natural_count,
+        time_buffer_multiplier=time_buffer_multiplier,
+        motor_fatigue_aware=motor_fatigue_aware,
     )
-    return DecomposeOutput(tasks=tasks, rationale=rationale)
+
+    # Only echo a hook when it is actively in effect, so an unused hook leaves
+    # the wire shape byte-identical to pre-R2 (server dumps exclude_none=True).
+    echoed_multiplier = (
+        time_buffer_multiplier
+        if time_buffer_multiplier is not None and time_buffer_multiplier > 1.0
+        else None
+    )
+    # `False` is intentionally equivalent to absent here: there is no distinct
+    # "explicit denial" wire state. Both an unset flag and `motor_fatigue_aware=False`
+    # collapse to None and are dropped by exclude_none=True, keeping the wire
+    # byte-identical to pre-R2. This is a documented design choice, not an oversight.
+    echoed_motor = True if motor_fatigue_aware else None
+    return DecomposeOutput(
+        tasks=tasks,
+        rationale=rationale,
+        time_buffer_multiplier=echoed_multiplier,
+        motor_fatigue_aware=echoed_motor,
+        truncated=True if truncated else None,
+    )
+
+
+def _padded_minutes(estimated_minutes: int, multiplier: float | None) -> int | None:
+    """Return round(estimated * multiplier) when padding is active, else None.
+
+    A multiplier of exactly 1.0 (or absent) is a no-op: returns ``None`` so the
+    additive field is dropped from the wire. ``estimated_minutes`` is never
+    mutated — the caller stores this alongside the raw value.
+    """
+
+    if multiplier is None or multiplier <= 1.0:
+        return None
+    return round(estimated_minutes * multiplier)
 
 
 # Internal helpers -----------------------------------------------------------
@@ -496,16 +617,24 @@ def _build_plan(
             )
         )
 
-    rationale_seed = f"Carved the goal into {len(skeletons)} task(s) around '{goal_summary_hint}'."
+    rationale_opening = (
+        f"Carved the goal into {len(skeletons)} task(s) around '{goal_summary_hint}'."
+    )
+    extra_pieces: list[str] = []
     if budget is not None:
-        rationale_seed += (
-            f" Budget ceiling {budget.minutes_ceiling} min; "
+        extra_pieces.append(
+            f"Budget ceiling {budget.minutes_ceiling} min; "
             f"plan totals {sum(s.estimated_minutes for s in skeletons)} min."
         )
     if time_markers:
-        rationale_seed += " Detected a time marker; the plan is sequenced linearly."
+        extra_pieces.append("Detected a time marker; the plan is sequenced linearly.")
+    rationale_extra = " ".join(extra_pieces)
 
-    return _DecomposePlan(skeletons=tuple(skeletons), rationale_seed=rationale_seed)
+    return _DecomposePlan(
+        skeletons=tuple(skeletons),
+        rationale_opening=rationale_opening,
+        rationale_extra=rationale_extra,
+    )
 
 
 def _format_rationale(
@@ -514,11 +643,38 @@ def _format_rationale(
     plan: _DecomposePlan,
     budget: ParsedTimeBudget | None,
     time_markers: list[str],
+    truncated: bool = False,
+    natural_count: int | None = None,
+    time_buffer_multiplier: float | None = None,
+    motor_fatigue_aware: bool | None = None,
 ) -> str:
-    """Build the one-paragraph rationale. NEVER includes goal text."""
+    """Build the one-paragraph rationale. NEVER includes goal text.
 
-    pieces = [plan.rationale_seed]
+    The non-truncated rationale is byte-identical to the pre-R2 contract: the
+    opening sentence is the natural "Carved the goal into N task(s)…" seed and
+    the count agrees with the delivered task list (no truncation, so they are
+    the same number). Under truncation the *opening* is rebuilt so the delivered
+    count and the opening never contradict each other, and the closing note uses
+    existence framing ("still in the plan") rather than obligation framing
+    ("still need doing") — this string is effectively user-facing and must meet
+    the no-shame bar on its own.
+    """
+
     total = sum(t.estimated_minutes for t in tasks)
+
+    if truncated and natural_count is not None:
+        # Lead with the relationship between the natural plan and what we are
+        # returning, so the opening count and the delivered count agree.
+        opening = (
+            f"Planned {natural_count} tasks; returning the first {len(tasks)} "
+            f"at your max_chunk_size."
+        )
+    else:
+        opening = plan.rationale_opening
+    # Reconstruct the pre-R2 seed: opening + optional budget/time-marker tail.
+    seed = f"{opening} {plan.rationale_extra}".rstrip() if plan.rationale_extra else opening
+
+    pieces = [seed]
     pieces.append(f"Estimated total: {total} minutes across {len(tasks)} tasks.")
     if budget is not None:
         headroom = budget.minutes_ceiling - total
@@ -528,6 +684,26 @@ def _format_rationale(
         "Sequence is a total order; tasks at the same topological depth are "
         "tie-broken by estimated_minutes then id."
     )
+    # R2 hook rationale lines. Each appears only when its hook is in effect, so
+    # the default rationale is unchanged from pre-R2.
+    if truncated and natural_count is not None:
+        dropped = natural_count - len(tasks)
+        pieces.append(
+            f"The other {dropped} are still in the plan — re-run without "
+            f"the cap (or raise it) to see them."
+        )
+    if time_buffer_multiplier is not None and time_buffer_multiplier > 1.0:
+        pieces.append(
+            f"padded_minutes is each raw estimate multiplied by your "
+            f"time_buffer_multiplier of {time_buffer_multiplier:g}; estimated_minutes "
+            f"stays raw so nothing is padded twice."
+        )
+    if motor_fatigue_aware:
+        pieces.append(
+            "motor_fatigue_aware is on: this server has no view of your actual "
+            "motor activity, so it only flags the preference for the client to act on "
+            "and does not infer fatigue."
+        )
     rationale = " ".join(pieces)
     # Defensive cap at the schema's 1000-character limit.
     if len(rationale) > 1000:
@@ -542,6 +718,8 @@ __all__ = [
     "DecompositionUnavailableError",
     "GoalRequiredError",
     "GoalTooLongError",
+    "MaxChunkSizeInvalidError",
     "TimeBudgetUnparseableError",
+    "TimeBufferMultiplierInvalidError",
     "decompose",
 ]

--- a/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/server.py
+++ b/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/server.py
@@ -31,7 +31,9 @@ from neurodock_mcp_task_fractionator.decomposer import (
     DecompositionUnavailableError,
     GoalRequiredError,
     GoalTooLongError,
+    MaxChunkSizeInvalidError,
     TimeBudgetUnparseableError,
+    TimeBufferMultiplierInvalidError,
 )
 from neurodock_mcp_task_fractionator.sources import (
     CognitiveGraphUnavailableError,
@@ -116,14 +118,62 @@ def build_server(
                 ),
             ),
         ] = None,
+        max_chunk_size: Annotated[
+            int | None,
+            Field(
+                ge=1,
+                le=20,
+                description=(
+                    "Optional neurotype knob (ADR 0011). Caps the NUMBER of tasks "
+                    "returned, below the normal 3-12 target / hard cap of 20. When "
+                    "the goal naturally needs more steps, the server keeps the "
+                    "lowest-sequence prefix (a valid sub-DAG with no dangling "
+                    "dependencies) and notes the truncation in the rationale rather "
+                    "than silently dropping steps. Omit for default behaviour."
+                ),
+            ),
+        ] = None,
+        time_buffer_multiplier: Annotated[
+            float | None,
+            Field(
+                ge=1.0,
+                le=3.0,
+                description=(
+                    "Optional neurotype knob (ADR 0011). When greater than 1.0, the "
+                    "server attaches an additive 'padded_minutes' to each task equal "
+                    "to round(estimated_minutes * multiplier). 'estimated_minutes' "
+                    "stays RAW so the figure is never padded twice. A value of 1.0 "
+                    "(or omitting it) produces no padding."
+                ),
+            ),
+        ] = None,
+        motor_fatigue_aware: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "Optional neurotype knob (ADR 0011). When true, the server echoes "
+                    "the preference and names it in the rationale so the client can "
+                    "act on it. The server has no view of actual motor activity and "
+                    "does NOT infer fatigue."
+                ),
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "decompose"})
         try:
-            result = decompose(goal=goal, time_budget=time_budget)
+            result = decompose(
+                goal=goal,
+                time_budget=time_budget,
+                max_chunk_size=max_chunk_size,
+                time_buffer_multiplier=time_buffer_multiplier,
+                motor_fatigue_aware=motor_fatigue_aware,
+            )
         except GoalRequiredError as exc:
             raise _ToolError("GOAL_REQUIRED", str(exc)) from exc
         except GoalTooLongError as exc:
             raise _ToolError("GOAL_TOO_LONG", str(exc)) from exc
+        except (MaxChunkSizeInvalidError, TimeBufferMultiplierInvalidError) as exc:
+            raise _ToolError("INPUT_INVALID", str(exc)) from exc
         except TimeBudgetUnparseableError as exc:
             raise _ToolError("TIME_BUDGET_UNPARSEABLE", str(exc)) from exc
         except BudgetInfeasibleError as exc:
@@ -156,7 +206,11 @@ def build_server(
         except AcceptanceCriteriaRequiredError as exc:
             _LOG.error("acceptance_criteria_required")
             raise _ToolError("ACCEPTANCE_CRITERIA_REQUIRED", str(exc)) from exc
-        return result.model_dump(exclude_none=False)
+        # exclude_none=True so the optional, additive R2 fields (padded_minutes,
+        # time_buffer_multiplier, motor_fatigue_aware, truncated) are dropped
+        # from the wire when unset — keeping a no-hook call byte-identical to
+        # the pre-R2 contract. The required pre-R2 fields are never None.
+        return result.model_dump(exclude_none=True)
 
     # ``next_one`` reads the LOCAL cognitive graph and is NOT remote-safe
     # (ADR 0008/0009). It is registered in stdio mode only; in HTTP mode it is
@@ -188,7 +242,10 @@ def build_server(
                 ) from exc
             except CognitiveGraphUnavailableError as exc:
                 raise _ToolError("COGNITIVE_GRAPH_UNAVAILABLE", str(exc)) from exc
-            return result.model_dump(exclude_none=False)
+            # exclude_none=True drops the nested optional Task.padded_minutes
+            # (always None here — next_one does not pad), keeping next_one's
+            # wire shape byte-identical to the pre-R2 contract.
+            return result.model_dump(exclude_none=True)
 
     return mcp
 

--- a/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/tools/decompose.py
+++ b/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/tools/decompose.py
@@ -22,8 +22,23 @@ def decompose(
     *,
     goal: str,
     time_budget: str | None = None,
+    max_chunk_size: int | None = None,
+    time_buffer_multiplier: float | None = None,
+    motor_fatigue_aware: bool | None = None,
     uuid_factory: UuidFactory | None = None,
 ) -> DecomposeOutput:
-    """Decompose ``goal`` into 1..20 atomic tasks. See the module docstring."""
+    """Decompose ``goal`` into 1..20 atomic tasks. See the module docstring.
 
-    return _heuristic_decompose(goal=goal, time_budget=time_budget, uuid_factory=uuid_factory)
+    The R2 neurotype hooks (``max_chunk_size``, ``time_buffer_multiplier``,
+    ``motor_fatigue_aware``) are optional and additive (ADR 0011); when absent
+    the result is byte-identical to the pre-R2 contract.
+    """
+
+    return _heuristic_decompose(
+        goal=goal,
+        time_budget=time_budget,
+        max_chunk_size=max_chunk_size,
+        time_buffer_multiplier=time_buffer_multiplier,
+        motor_fatigue_aware=motor_fatigue_aware,
+        uuid_factory=uuid_factory,
+    )

--- a/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/types.py
+++ b/packages/mcp-task-fractionator/src/neurodock_mcp_task_fractionator/types.py
@@ -23,12 +23,21 @@ class _Base(BaseModel):
 
 
 class Task(_Base):
-    """A single atomic task. Shape is shared by ``decompose`` and ``next_one``."""
+    """A single atomic task. Shape is shared by ``decompose`` and ``next_one``.
+
+    ``padded_minutes`` is an OPTIONAL, ADDITIVE field (ADR 0011 / R2). It is
+    populated only when ``decompose`` is called with a
+    ``time_buffer_multiplier`` greater than 1.0; ``estimated_minutes`` always
+    stays RAW so a presentation layer never double-pads. When absent it is
+    ``None`` and is dropped from the wire (server dumps with
+    ``exclude_none=True``).
+    """
 
     id: str = Field(pattern=UUID4_PATTERN)
     title: str = Field(min_length=1, max_length=120)
     description: str = Field(min_length=1, max_length=1000)
     estimated_minutes: int = Field(ge=5, le=90)
+    padded_minutes: int | None = Field(default=None, ge=5)
     acceptance_criteria: list[str] = Field(min_length=1, max_length=8)
     dependencies: list[str] = Field(default_factory=list)
     sequence: int = Field(ge=1)
@@ -36,17 +45,34 @@ class Task(_Base):
 
 
 class DecomposeInput(_Base):
-    """Input arguments for ``decompose``. Validated at the server boundary."""
+    """Input arguments for ``decompose``. Validated at the server boundary.
+
+    The three R2 neurotype-hook inputs are OPTIONAL knobs (ADR 0011): they
+    default to today's behaviour when absent and never branch on a neurotype
+    enum. They are call-time parameters, exactly like the guardrail server's
+    thresholds.
+    """
 
     goal: str = Field(min_length=5, max_length=500)
     time_budget: str | None = None
+    max_chunk_size: int | None = Field(default=None, ge=1, le=20)
+    time_buffer_multiplier: float | None = Field(default=None, ge=1.0, le=3.0)
+    motor_fatigue_aware: bool | None = None
 
 
 class DecomposeOutput(_Base):
-    """Successful response from ``decompose``."""
+    """Successful response from ``decompose``.
+
+    ``time_buffer_multiplier``, ``motor_fatigue_aware`` and ``truncated`` are
+    OPTIONAL, ADDITIVE echoes (ADR 0011 / R2). Each is ``None`` (and dropped
+    from the wire) unless the corresponding hook was supplied and active.
+    """
 
     tasks: list[Task] = Field(min_length=1, max_length=20)
     rationale: str = Field(min_length=1, max_length=1000)
+    time_buffer_multiplier: float | None = Field(default=None, ge=1.0, le=3.0)
+    motor_fatigue_aware: bool | None = None
+    truncated: bool | None = None
 
 
 class NextOneInput(_Base):

--- a/packages/mcp-task-fractionator/tests/test_decompose.py
+++ b/packages/mcp-task-fractionator/tests/test_decompose.py
@@ -12,7 +12,9 @@ from neurodock_mcp_task_fractionator.decomposer import (
     DecompositionUnavailableError,
     GoalRequiredError,
     GoalTooLongError,
+    MaxChunkSizeInvalidError,
     TimeBudgetUnparseableError,
+    TimeBufferMultiplierInvalidError,
     decompose,
 )
 
@@ -114,3 +116,238 @@ def test_rationale_does_not_contain_goal_text(uuid_factory: Any) -> None:
     for task in output.tasks:
         assert "acorn-pancake" not in task.title
         assert "acorn-pancake" not in task.description
+
+
+# --- R2: neurotype hooks (optional, additive per ADR 0011) ------------------
+
+
+def test_no_neurotype_inputs_returns_pre_r2_wire_shape(uuid_factory: Any) -> None:
+    """Backward-compat: with NONE of the new inputs the wire shape is unchanged.
+
+    No ``padded_minutes`` on any task, no ``time_buffer_multiplier`` /
+    ``motor_fatigue_aware`` / ``truncated`` top-level keys. The dumped payload
+    must be byte-identical to the pre-R2 contract (only ``tasks`` + ``rationale``).
+    """
+
+    output = decompose(
+        goal="ship the founding-scope RFC by Friday",
+        uuid_factory=uuid_factory,
+    )
+
+    # The server boundary dumps with exclude_none=True (the chronometric R5
+    # pattern): unset optional additive fields never reach the wire.
+    dumped = output.model_dump(exclude_none=True)
+    assert set(dumped.keys()) == {"tasks", "rationale"}
+    for task in dumped["tasks"]:
+        assert "padded_minutes" not in task
+        assert set(task.keys()) == {
+            "id",
+            "title",
+            "description",
+            "estimated_minutes",
+            "acceptance_criteria",
+            "dependencies",
+            "sequence",
+            "tags",
+        }
+
+
+def test_max_chunk_size_caps_returned_task_count(uuid_factory: Any) -> None:
+    """``max_chunk_size`` lowers the ceiling on the number of returned tasks."""
+
+    full = decompose(
+        goal="ship and review and refactor the migration doc",
+        uuid_factory=uuid_factory,
+    )
+    assert len(full.tasks) > 2
+
+    capped = decompose(
+        goal="ship and review and refactor the migration doc",
+        max_chunk_size=2,
+        uuid_factory=uuid_factory,
+    )
+    assert len(capped.tasks) == 2
+
+
+def test_max_chunk_size_keeps_a_valid_prefix_and_no_dangling_deps(
+    uuid_factory: Any,
+) -> None:
+    """Truncation keeps a valid prefix: sequences contiguous, no dangling deps."""
+
+    capped = decompose(
+        goal="ship and review and refactor the migration doc",
+        max_chunk_size=2,
+        uuid_factory=uuid_factory,
+    )
+
+    sequences = [t.sequence for t in capped.tasks]
+    assert sequences == list(range(1, len(capped.tasks) + 1))
+
+    kept_ids = {t.id for t in capped.tasks}
+    for task in capped.tasks:
+        for dep in task.dependencies:
+            assert dep in kept_ids, "truncated task references a dropped dependency"
+
+
+def test_max_chunk_size_notes_truncation_in_rationale(uuid_factory: Any) -> None:
+    """When the plan is reduced the rationale must say so (no silent drop).
+
+    The note uses existence framing ("still in the plan") rather than obligation
+    framing, and the opening count must agree with the delivered count: the
+    rationale leads with the natural plan size and names how many are returned.
+    """
+
+    capped = decompose(
+        goal="ship and review and refactor the migration doc",
+        max_chunk_size=2,
+        uuid_factory=uuid_factory,
+    )
+    lowered = capped.rationale.lower()
+    # No silent drop: the rationale states the natural plan and what is returned.
+    assert "returning the first 2" in lowered
+    assert "still in the plan" in lowered
+    # Existence framing, not task-debt/obligation framing (rejection-sensitivity).
+    assert "still need doing" not in lowered
+    # Coherence: the delivered count appears, the contradictory "across 5 tasks"
+    # opening does not.
+    assert "across 2 tasks" in lowered
+
+
+def test_max_chunk_size_above_natural_count_is_a_no_op(uuid_factory: Any) -> None:
+    """A cap larger than the natural plan does not change anything."""
+
+    natural = decompose(goal="fix the bug today", uuid_factory=uuid_factory)
+    capped = decompose(
+        goal="fix the bug today",
+        max_chunk_size=min(len(natural.tasks) + 50, 20),
+        uuid_factory=uuid_factory,
+    )
+    assert len(capped.tasks) == len(natural.tasks)
+    assert "truncat" not in capped.rationale.lower()
+
+
+def test_max_chunk_size_below_one_raises(uuid_factory: Any) -> None:
+    """A non-positive cap is a caller bug; the boundary rejects it."""
+
+    with pytest.raises(MaxChunkSizeInvalidError):
+        decompose(
+            goal="fix the bug today",
+            max_chunk_size=0,
+            uuid_factory=uuid_factory,
+        )
+
+
+def test_max_chunk_size_above_twenty_raises(uuid_factory: Any) -> None:
+    """The pure decomposer enforces the same 1..20 band as the server.
+
+    The server's ``Field(le=20)`` guards MCP callers, but a direct/library
+    caller must not be able to bypass the contract by passing a larger cap.
+    """
+
+    with pytest.raises(MaxChunkSizeInvalidError):
+        decompose(
+            goal="fix the bug today",
+            max_chunk_size=21,
+            uuid_factory=uuid_factory,
+        )
+
+
+def test_time_buffer_multiplier_below_band_raises(uuid_factory: Any) -> None:
+    """A multiplier below 1.0 would *shrink* an estimate and is rejected."""
+
+    with pytest.raises(TimeBufferMultiplierInvalidError):
+        decompose(
+            goal="fix the bug today",
+            time_buffer_multiplier=0.9,
+            uuid_factory=uuid_factory,
+        )
+
+
+def test_time_buffer_multiplier_above_band_raises(uuid_factory: Any) -> None:
+    """A multiplier above 3.0 is out of the supported band and is rejected."""
+
+    with pytest.raises(TimeBufferMultiplierInvalidError):
+        decompose(
+            goal="fix the bug today",
+            time_buffer_multiplier=3.1,
+            uuid_factory=uuid_factory,
+        )
+
+
+def test_time_buffer_multiplier_adds_padded_minutes_without_touching_raw(
+    uuid_factory: Any,
+) -> None:
+    """``time_buffer_multiplier`` > 1.0 adds optional ``padded_minutes`` per task.
+
+    ``estimated_minutes`` MUST stay raw (no double-pad), and ``padded_minutes``
+    MUST equal round(estimated_minutes * multiplier).
+    """
+
+    output = decompose(
+        goal="ship the founding-scope RFC by Friday",
+        time_buffer_multiplier=1.5,
+        uuid_factory=uuid_factory,
+    )
+
+    assert output.time_buffer_multiplier == 1.5
+    for task in output.tasks:
+        assert task.padded_minutes == round(task.estimated_minutes * 1.5)
+        # raw estimate is unchanged and still within the contract band
+        assert 5 <= task.estimated_minutes <= 90
+    # the multiplier is named in the rationale so the user can correct it
+    assert "1.5" in output.rationale
+
+
+def test_multiplier_of_one_omits_padding_entirely(uuid_factory: Any) -> None:
+    """A multiplier of exactly 1.0 is a no-op: no padding, no echo, no rationale."""
+
+    output = decompose(
+        goal="ship the founding-scope RFC by Friday",
+        time_buffer_multiplier=1.0,
+        uuid_factory=uuid_factory,
+    )
+
+    dumped = output.model_dump(exclude_none=True)
+    assert set(dumped.keys()) == {"tasks", "rationale"}
+    for task in output.tasks:
+        assert task.padded_minutes is None
+
+
+def test_motor_fatigue_aware_is_echoed_honestly(uuid_factory: Any) -> None:
+    """``motor_fatigue_aware`` is echoed; the server claims no activity data."""
+
+    output = decompose(
+        goal="ship the founding-scope RFC by Friday",
+        motor_fatigue_aware=True,
+        uuid_factory=uuid_factory,
+    )
+
+    assert output.motor_fatigue_aware is True
+    # honest scope: the server can't see motor activity, so it says so
+    assert "motor" in output.rationale.lower()
+
+
+def test_motor_fatigue_aware_false_is_omitted(uuid_factory: Any) -> None:
+    """``motor_fatigue_aware`` defaulting to False keeps the pre-R2 shape."""
+
+    output = decompose(
+        goal="ship the founding-scope RFC by Friday",
+        motor_fatigue_aware=False,
+        uuid_factory=uuid_factory,
+    )
+    dumped = output.model_dump(exclude_none=True)
+    assert set(dumped.keys()) == {"tasks", "rationale"}
+
+
+def test_padded_minutes_respected_under_truncation(uuid_factory: Any) -> None:
+    """The hooks compose: padding + capping at once stays consistent."""
+
+    output = decompose(
+        goal="ship and review and refactor the migration doc",
+        max_chunk_size=2,
+        time_buffer_multiplier=2.0,
+        uuid_factory=uuid_factory,
+    )
+    assert len(output.tasks) == 2
+    for task in output.tasks:
+        assert task.padded_minutes == round(task.estimated_minutes * 2.0)

--- a/packages/skills/dyspraxia-task-pacer/README.md
+++ b/packages/skills/dyspraxia-task-pacer/README.md
@@ -4,7 +4,7 @@ A motor-aware pacing skill. It takes a goal, decomposes it into atomic steps, an
 
 ## Why padding
 
-Motor execution of a task routinely runs 30–50% longer than the raw cognitive estimate predicts. The task-fractionator returns the raw estimate; this skill applies your `chronometric.time_buffer_multiplier` (1.3 in the `dyspraxia.yaml` preset, ≈+30%) so the day is planned against a figure that holds. The raw figures are still shown once, in the closing block, so nothing is hidden.
+Motor-heavy work routinely runs 30–50% longer than the raw cognitive estimate predicts — the world under-budgets that work, it is not a measure of you. The task-fractionator server applies your `chronometric.time_buffer_multiplier` (1.3 in the `dyspraxia.yaml` preset, ≈+30%) and returns a `padded_minutes` figure alongside the raw one; this skill passes the buffer to the server and displays that padded figure, so the day is planned against a number that holds. The server is the single source of truth for the padding, so a figure is never multiplied twice. The raw figures are still shown once, in the closing block, so nothing is hidden. (If you run an older server that does not return `padded_minutes`, the skill falls back to padding the raw estimate itself — still exactly once.)
 
 ## When it fires
 
@@ -13,8 +13,8 @@ Motor execution of a task routinely runs 30–50% longer than the raw cognitive 
 
 ## How it reads your profile
 
-- `chronometric.time_buffer_multiplier` — the padding factor. If it is unset, nothing is padded and no padding claim is made; you see the raw estimate.
-- `preferences.max_chunk_size` — how many steps are shown (4 in the preset). Extra steps are counted, not listed.
+- `chronometric.time_buffer_multiplier` — the padding factor, passed to the task-fractionator so the server pads. If it is unset, nothing is padded and no padding claim is made; you see the raw estimate.
+- `preferences.max_chunk_size` — how many steps are returned (4 in the preset), passed to the task-fractionator so the server caps the list. When the goal needs more steps, the server flags it and the skill says how many were left off — it never silently drops them.
 - `preferences.voice_input_preferred` — when true, any command is emitted as a single copy-pasteable block, value already in place, nothing to hand-edit.
 - `chronometric.motor_fatigue_aware` — when set, the closing break line factors the _kind of work_ in the list (typing, clicking) into the pacing, not just the clock. It never reads a movement as a signal.
 

--- a/packages/skills/dyspraxia-task-pacer/SKILL.md
+++ b/packages/skills/dyspraxia-task-pacer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dyspraxia-task-pacer
-version: 0.1.0
-description: Motor-aware pacing — decomposes a goal, pads each estimate by the profile buffer, names why.
+version: 0.2.0
+description: Motor-aware pacing — decomposes a goal, shows each estimate padded by the profile buffer, names why.
 neurotypes: ["dyspraxia"]
 status: stable
 triggers:
@@ -15,6 +15,16 @@ mcp_dependencies:
     tools: [get_time_context]
   - server: mcp-task-fractionator
     tools: [decompose, next_one]
+    inputs:
+      decompose:
+        [
+          goal,
+          time_budget,
+          max_chunk_size,
+          time_buffer_multiplier,
+          motor_fatigue_aware,
+        ]
+      next_one: [project]
 profile_dependencies:
   - identity.neurotypes
   - preferences.max_chunk_size
@@ -28,7 +38,7 @@ authors:
 
 # dyspraxia-task-pacer
 
-This skill decomposes a goal into atomic steps and presents each step's time estimate **padded** by the user's `chronometric.time_buffer_multiplier`, stating plainly that the figure is padded and why. Motor execution of a task routinely runs longer than the raw cognitive estimate predicts; the skill applies the buffer in its own output because the task-fractionator returns unpadded estimates. It uses absolute, source-order references throughout, keeps any command as one copy-pasteable block when the user dictates, and factors motor load into break pacing when the profile opts in.
+This skill decomposes a goal into atomic steps and presents each step's time estimate **padded** by the user's `chronometric.time_buffer_multiplier`, stating plainly that the figure is padded and why. Motor-heavy work routinely runs longer than the raw cognitive estimate predicts — the world underestimates that work, not the user — so the padded figure is the one the day should be planned against. The task-fractionator server is the single source of truth for the padding: the skill passes the buffer to `decompose` and displays the `padded_minutes` the server returns, never re-multiplying a figure that was already padded. It uses absolute, source-order references throughout, keeps any command as one copy-pasteable block when the user dictates, and factors motor load into break pacing when the profile opts in.
 
 ## Activation criteria
 
@@ -44,22 +54,38 @@ Do not activate when the user only wants the goal recorded (that is `record-fact
 
 Follow these steps in order. Do not skip steps. Do not improvise additional tool calls.
 
-1. **Read the pacing inputs.** Read `chronometric.time_buffer_multiplier`, `preferences.max_chunk_size`, `preferences.voice_input_preferred`, and `chronometric.motor_fatigue_aware` from the profile. If `time_buffer_multiplier` is absent or unset, treat it as **1.0** — no padding, and make no padding claim (see "Do not"). If `max_chunk_size` is absent, default to **4** for this neurotype.
+1. **Read the pacing inputs.** Read `chronometric.time_buffer_multiplier`, `preferences.max_chunk_size`, `preferences.voice_input_preferred`, and `chronometric.motor_fatigue_aware` from the profile. If `time_buffer_multiplier` is absent or unset, treat it as **1.0** — no buffer, no padding claim (see "Do not"). If `max_chunk_size` is absent, default to **4** for this neurotype.
 
 2. **Anchor the day for pacing only.** Call `mcp-chronometric.get_time_context()`. Read `current_session_length`, `energy_zone`, and — only when present — `motor_fatigue_aware`. Do not narrate the time; you need it for the break line at the end, not for the headline.
 
-3. **Decompose the goal.** Call `mcp-task-fractionator.decompose(goal=<the user's goal verbatim>)`. If the user supplied a time budget as an ISO 8601 duration (e.g. `PT3H`), pass it as `time_budget`; otherwise omit it. Use the returned `tasks[]` and `estimated_minutes` verbatim as the **raw** estimate. Do not paraphrase task titles.
+3. **Decompose the goal, passing the profile knobs.** Call `mcp-task-fractionator.decompose` with the goal verbatim and the profile knobs the server now understands:
+
+   - `goal` = the user's goal verbatim.
+   - `time_budget` = the user's ISO 8601 duration (e.g. `PT3H`) if they gave one, otherwise omit.
+   - `max_chunk_size` = `preferences.max_chunk_size` (default 4). **The server does the capping now** — do not cap the list yourself (see step 5).
+   - `time_buffer_multiplier` = `chronometric.time_buffer_multiplier`, but **only pass it when it is greater than 1.0**. When it is 1.0 or unset, omit it so the server returns the raw, unpadded shape.
+   - `motor_fatigue_aware` = `chronometric.motor_fatigue_aware` when it is `true`, otherwise omit.
+
+   Use the returned `tasks[]` verbatim. Do not paraphrase task titles.
 
    - On `BUDGET_INFEASIBLE`, say so plainly and stop: the budget cannot hold a credible list — do not truncate silently.
-   - On `GOAL_REQUIRED` / `GOAL_TOO_LONG`, surface the error and stop.
+   - On `GOAL_REQUIRED` / `GOAL_TOO_LONG` / `INPUT_INVALID`, surface the error and stop.
 
-4. **Pad every estimate.** For each task, compute `padded = round(estimated_minutes × time_buffer_multiplier)`. The padded figure is what the user sees. When the multiplier is greater than 1.0, the closing block must name the padding and its reason (step 7). When the multiplier is 1.0, show the raw figure with no padding claim.
+4. **Read the displayed estimate from the server (single source of truth).** For each task, the figure the user sees is:
 
-5. **Cap the list.** Keep the first `max_chunk_size` tasks in `sequence` order (lowest first). If the decomposition produced more, note the count of further steps in the closing block — do not list them. Each shown step is one atomic action.
+   - **When `padded_minutes` is present on the task** — show `padded_minutes`. The server already multiplied the raw estimate by the buffer; do **not** multiply again. The server also echoes `time_buffer_multiplier` at the top level and names the buffer in `rationale`; use the echoed multiplier for the closing line.
+   - **When `padded_minutes` is absent** — there is no server-side padding (the multiplier was 1.0/unset, or the server predates this field). Fall back to showing the raw `estimated_minutes`. **Only in this fallback, and only when the profile's `time_buffer_multiplier` is greater than 1.0**, compute the padding yourself as `round(estimated_minutes × time_buffer_multiplier)` and treat that as the displayed figure. If `padded_minutes` was present you have already padded once via the server, so the skill's own multiply must not run — this is how a double-pad is prevented.
 
-6. **Get the single next action.** Call `mcp-task-fractionator.next_one(project=<the goal's project, or the goal text trimmed to 120 chars>)` once.
+   In short: server `padded_minutes` wins when present; the skill's own arithmetic is a fallback that runs only when the server returned no padded figure.
 
-   - Success — quote the `task.title` and the padded estimate, and name the confidence to two decimal places.
+5. **Do not re-cap the list — the server already did.** Because `max_chunk_size` was passed to `decompose`, the returned `tasks[]` is already the capped prefix; show every task it contains, in `sequence` order. Capping is the server's responsibility now; surfacing the cut is the skill's.
+
+   - If the response carries `truncated: true`, the goal needed more steps than the cap. State this honestly in the closing block: name that further steps were left off and that they are still in the plan (you can lean on the server's `rationale`, which names the count and the recovery action — re-run without the cap to see them). Do not list the dropped steps and do not re-elide steps the server already returned.
+   - If `truncated` is absent, the list is complete for this cap; add no truncation line.
+
+6. **Get the single next action.** Call `mcp-task-fractionator.next_one(project=<the goal's project, or the goal text trimmed to 120 chars>)` once. `next_one` takes no knobs and its `task` carries **no** `padded_minutes` — so derive the displayed figure for the next action from the matching `decompose` task (match by `id`, falling back to `sequence`): show that task's `padded_minutes` when present, else the same raw/fallback figure rule as step 4. If no `decompose` task matches (e.g. the `next_one` task came from a saved project and was beyond this run's `max_chunk_size` cap), fall back to `next_one.task.estimated_minutes` with the step-4 fallback pad rule. Never multiply a `next_one` estimate a second time.
+
+   - Success — quote the `task.title` and the displayed (padded) estimate, and name the confidence to two decimal places.
    - Error `NO_TASKS_AVAILABLE` — the goal was not yet recorded as a project, so say "this plan is not saved yet; the steps above are the start-here list" and do not fabricate a task.
    - `ALL_TASKS_BLOCKED` or any other error — note the error code in the next-action line and move on.
 
@@ -72,29 +98,32 @@ Follow these steps in order. Do not skip steps. Do not improvise additional tool
 Strict "Answer First" structure. The first sentence must fit in 80 characters and must name the start-here step in plain prose.
 
 ```
-<One sentence, ≤ 80 chars: name the first step and its padded minutes. Plain prose.>
+<One sentence, ≤ 80 chars: name the first step and its displayed minutes. Plain prose.>
 
 Steps (source order, start at the top):
-1. <task.title> — <padded> min
-2. <task.title> — <padded> min
+1. <task.title> — <displayed> min
+2. <task.title> — <displayed> min
 ...
 
-Next one to pick up: <next_one.task.title> — <padded> min (conf <confidence>)
+Next one to pick up: <next_one.task.title> — <displayed> min (conf <confidence>)
 
 ---
-Estimates padded ×<time_buffer_multiplier> (≈+<percent>%): motor execution
+Estimates padded ×<time_buffer_multiplier> (≈+<percent>%): motor-heavy work
 runs longer than the raw estimate predicts. Raw figures were <raw1>, <raw2>, ... min.
-<Optional further-steps line.>
+<Optional truncation line — only when the server set truncated: true.>
 <Optional break line — only when motor_fatigue_aware is set.>
 ```
 
 Rules:
 
-- Steps are numbered top-to-bottom in `sequence` order. Never reorder. Never use "the one above" / "drag this" / relative spatial language — refer to a step by its number or its title.
-- Padded minutes are integers. Show the raw minutes once, in the closing block, so the user can see what was padded — never silently.
+- "Displayed minutes" is the server's `padded_minutes` when present, else the raw `estimated_minutes` (or the skill's fallback pad — step 4). Never the result of multiplying a `padded_minutes` again.
+- Steps are numbered top-to-bottom in `sequence` order. Never reorder. Never use "the one above" / "drag this" / relative spatial language — refer to a step by its number or title.
+- Displayed minutes are integers. Show the raw minutes once, in the closing block, so the user can see what was padded — never silently.
+- Use the server's echoed top-level `time_buffer_multiplier` for the `×` figure in the closing line. Do not invent a multiplier the server did not echo.
 - Confidence on the next-action line is always two decimal places.
+- The truncation line reports the server's `truncated` flag honestly: that there were more steps than the cap and they are still in the plan (re-run without the cap to see them). Count is fine; do not list dropped titles.
 - When `motor_fatigue_aware` is set, the break line factors motor load, not just clock time: e.g. `This list is mostly typing and clicking. That load builds faster than the minutes suggest, so a pause between step 2 and step 3 is worth taking.` Suggest, never demand. Never read a movement or a tic as a fatigue signal.
-- When `time_buffer_multiplier` is 1.0 (or unset), omit the padding line entirely and show the raw estimate inline. Do not claim anything was padded.
+- When `time_buffer_multiplier` is 1.0 (or unset) — and so the server returned no `padded_minutes` and echoed no multiplier — omit the padding line entirely and show the raw estimate inline. Do not claim anything was padded.
 
 ### Voice-input mode
 
@@ -120,12 +149,14 @@ budget entirely and I'll decompose without one.
 
 ## Distress signal handling
 
-If the invoking message contains overwhelm phrases — `I can't`, `too much`, `everything is urgent`, `I'm stuck`, `exhausted`, `burned out` — reduce the shown-step cap to **3** instead of `max_chunk_size`, drop the confidence number from the next-action line (state "this is a safe one to start with" instead), and append one sentence to the closing block: `If three is still too many, ask for "just the next one" and I'll show only that.` Do not lecture. Do not diagnose. Do not comment on the user's state.
+If the invoking message contains overwhelm phrases — `I can't`, `too much`, `everything is urgent`, `I'm stuck`, `exhausted`, `burned out` — pass a smaller `max_chunk_size` of **3** to `decompose` (instead of the profile value) so the server returns a shorter prefix, drop the confidence number from the next-action line (state "this is a safe one to start with" instead), and append one sentence to the closing block: `If three is still too many, ask for "just the next one" and I'll show only that.` Do not lecture. Do not diagnose. Do not comment on the user's state.
 
 ## Do not
 
-- Do not present a raw, unpadded estimate to a dyspraxia-tagged user as if it were the wall-clock cost. Padding is the point of this skill.
-- Do not claim an estimate was padded when `time_buffer_multiplier` is 1.0 or unset — that is a false statement about the number.
+- Do not present a raw, unpadded estimate to a dyspraxia-tagged user as if it were the wall-clock cost when a buffer is set. The padded figure is the point of this skill.
+- Do not pad twice. When the server returned `padded_minutes`, that figure is already padded — displaying it is enough. The skill's own `round(estimated_minutes × multiplier)` runs ONLY in the fallback where `padded_minutes` is absent. There is never a path where both the server and the skill multiply the same estimate.
+- Do not claim an estimate was padded when `time_buffer_multiplier` is 1.0 or unset (the server returns no `padded_minutes` and echoes no multiplier) — that is a false statement about the number.
+- Do not re-cap or re-elide the task list. `decompose` was given `max_chunk_size`, so the returned list is already the prefix; surface the server's `truncated` flag instead of trimming a second time.
 - Do not use relative spatial or temporal references: no "drag this there", "the step above", "move it up", "the one on the right", "recently". Refer to steps by number or title, top-to-bottom, in source order.
 - Do not scatter a command across inline edits when `voice_input_preferred` is true. One copy-pasteable block, value already in place.
 - Do not read a movement, a tic, or input cadence as a fatigue signal. Motor-load pacing is about the _kind of work_ in the list, not about watching the user.
@@ -136,7 +167,7 @@ If the invoking message contains overwhelm phrases — `I can't`, `too much`, `e
 
 ## What this skill is not
 
-It is not a productivity maximiser and it does not grade the user against the estimate. The padded number exists so the day is planned against a figure that holds, not so the user can be measured against a tighter one.
+It is not a productivity maximiser and it does not grade the user against the estimate. The padded number exists so the day is planned against a figure that holds, not so the user can be measured against a tighter one. The buffer reflects that motor-heavy work is routinely under-budgeted by everyone — it is not a measure of the user.
 
 ## Examples
 

--- a/packages/skills/dyspraxia-task-pacer/tests/01-pace-with-buffer.md
+++ b/packages/skills/dyspraxia-task-pacer/tests/01-pace-with-buffer.md
@@ -4,6 +4,8 @@
 
 It is Wednesday, 2026-05-20, 14:10 local time. The user has the `dyspraxia.yaml` preset installed: `identity.neurotypes: ["dyspraxia"]`, `preferences.max_chunk_size: 4`, `preferences.voice_input_preferred: true`, `chronometric.time_buffer_multiplier: 1.3`, `chronometric.motor_fatigue_aware: true`. They type `pace this for me: wire the new settings panel into the popup`. The goal is bigger than one step. There is no project recorded for it yet, so `next_one` will return `NO_TASKS_AVAILABLE`. The decomposition produces four atomic tasks, none of which involve a command to copy-paste.
 
+The buffer (1.3) and `motor_fatigue_aware` are now passed to `decompose`; the server is the source of truth for the padded figure. The skill displays the server's per-task `padded_minutes` and does NOT multiply again.
+
 ## Expected MCP tool sequence
 
 1. `mcp-chronometric.get_time_context()` →
@@ -17,7 +19,7 @@ It is Wednesday, 2026-05-20, 14:10 local time. The user has the `dyspraxia.yaml`
      "motor_fatigue_aware": true
    }
    ```
-2. `mcp-task-fractionator.decompose(goal="wire the new settings panel into the popup")` →
+2. `mcp-task-fractionator.decompose(goal="wire the new settings panel into the popup", max_chunk_size=4, time_buffer_multiplier=1.3, motor_fatigue_aware=true)` →
    ```json
    {
      "tasks": [
@@ -26,6 +28,7 @@ It is Wednesday, 2026-05-20, 14:10 local time. The user has the `dyspraxia.yaml`
          "title": "Add the SettingsPanel component file",
          "description": "Create the SettingsPanel.tsx component with the four reader fields, no wiring yet.",
          "estimated_minutes": 30,
+         "padded_minutes": 39,
          "acceptance_criteria": [
            "File exists at the named path",
            "Component renders the four fields"
@@ -39,6 +42,7 @@ It is Wednesday, 2026-05-20, 14:10 local time. The user has the `dyspraxia.yaml`
          "title": "Import SettingsPanel into the popup entrypoint",
          "description": "Add the import and render SettingsPanel under the existing Home view.",
          "estimated_minutes": 20,
+         "padded_minutes": 26,
          "acceptance_criteria": [
            "Popup mounts SettingsPanel",
            "No console errors on open"
@@ -52,6 +56,7 @@ It is Wednesday, 2026-05-20, 14:10 local time. The user has the `dyspraxia.yaml`
          "title": "Persist the four fields to local storage",
          "description": "Read and write the four field values via the existing storage helper.",
          "estimated_minutes": 40,
+         "padded_minutes": 52,
          "acceptance_criteria": ["Values survive a popup reopen"],
          "dependencies": ["a1b2c3d4-1111-4aaa-8bbb-000000000002"],
          "sequence": 3,
@@ -62,46 +67,55 @@ It is Wednesday, 2026-05-20, 14:10 local time. The user has the `dyspraxia.yaml`
          "title": "Add a regression test for the panel mount",
          "description": "Assert SettingsPanel renders the four fields in the popup test.",
          "estimated_minutes": 25,
+         "padded_minutes": 32,
          "acceptance_criteria": ["Test passes", "Covers the four-field render"],
          "dependencies": ["a1b2c3d4-1111-4aaa-8bbb-000000000003"],
          "sequence": 4,
          "tags": ["test"]
        }
      ],
-     "rationale": "Split into create, wire, persist, test so each step is startable cold."
+     "rationale": "Carved the goal into 4 task(s). Estimated total: 115 minutes across 4 tasks. Sequence is a total order; tasks at the same topological depth are tie-broken by estimated_minutes then id. padded_minutes is each raw estimate multiplied by your time_buffer_multiplier of 1.3; estimated_minutes stays raw so nothing is padded twice. motor_fatigue_aware is on: this server has no view of your actual motor activity, so it only flags the preference for the client to act on and does not infer fatigue.",
+     "time_buffer_multiplier": 1.3,
+     "motor_fatigue_aware": true
    }
    ```
 3. `mcp-task-fractionator.next_one(project="wire the new settings panel into the popup")` → error `NO_TASKS_AVAILABLE` (the goal was never recorded as a project; this is a fresh decomposition).
 
 (The skill MUST NOT call `decompose` more than once and MUST NOT retry `next_one`.)
 
-## Padding arithmetic (multiplier 1.3, round half-up to integer minutes)
+## Padding: server-computed, NOT recomputed by the skill
 
-| Step | Raw min | Padded min |
-| ---- | ------- | ---------- |
-| 1    | 30      | 39         |
-| 2    | 20      | 26         |
-| 3    | 40      | 52         |
-| 4    | 25      | 33         |
+The server returned `padded_minutes` per task using `round(estimated_minutes × 1.3)`. The skill DISPLAYS these and does not multiply again. Note the `.5` case: `round(25 × 1.3) = round(32.5) = 32` (Python round-half-to-even, the server's authority) — the skill must show `32`, not `33`.
+
+| Step | Raw min | Server `padded_minutes` (displayed) |
+| ---- | ------- | ----------------------------------- |
+| 1    | 30      | 39                                  |
+| 2    | 20      | 26                                  |
+| 3    | 40      | 52                                  |
+| 4    | 25      | 32                                  |
 
 ## Expected response shape
 
-- Opens with one sentence ≤ 80 characters that names step 1 (`Add the SettingsPanel component file`) and its padded figure `39 min`.
-- A numbered `Steps` list, in `sequence` order 1→4, each line `<title> — <padded> min`. Exactly four steps (equals `max_chunk_size`, none elided).
+- Opens with one sentence ≤ 80 characters that names step 1 (`Add the SettingsPanel component file`) and its displayed figure `39 min`.
+- A numbered `Steps` list, in `sequence` order 1→4, each line `<title> — <displayed> min`. Exactly four steps (the server already capped at `max_chunk_size = 4`; none elided by the skill).
 - A `Next one to pick up:` line. Because `next_one` returned `NO_TASKS_AVAILABLE`, it states the plan is not saved yet and that the steps above are the start-here list — it does NOT fabricate a task or a confidence number.
-- Closing block names the multiplier (`×1.3`), an approximate percentage (`+30%`), and the four raw figures (`30, 20, 40, 25`).
+- Closing block names the server's echoed multiplier (`×1.3`), an approximate percentage (`+30%`), and the four raw figures (`30, 20, 40, 25`).
 - Because `motor_fatigue_aware` is set, the closing block includes one suggestion-framed break line that refers to the _kind of work_ (frontend / typing-and-clicking), not to anything observed about the user, and refers to steps by number.
+- No `truncated` flag is present (the natural plan was four tasks), so there is no truncation line.
 - Total response length ≤ 1400 characters.
 
 ## Pass criteria
 
 - [ ] Tool sequence is exactly three calls in order: `get_time_context()`, one `decompose(...)`, one `next_one(...)`.
+- [ ] The `decompose` call passes `max_chunk_size=4`, `time_buffer_multiplier=1.3`, and `motor_fatigue_aware=true`.
 - [ ] First sentence is ≤ 80 characters and contains both the step-1 title and the number `39`.
-- [ ] Exactly four numbered steps appear, in sequence order, each showing the padded minute figure (`39`, `26`, `52`, `33`).
+- [ ] Exactly four numbered steps appear, in sequence order, each showing the server's `padded_minutes` figure (`39`, `26`, `52`, `32`).
+- [ ] The step-4 figure is `32` (the server's `round(32.5)`), NOT `33` — the skill consumed `padded_minutes` and did not re-multiply.
 - [ ] None of the raw figures (`30`, `20`, `40`, `25`) appears on a step line; the raw figures appear only in the closing block.
 - [ ] The next-action line contains `not saved yet` (or equivalent) and contains no fabricated task title and no `conf` number.
 - [ ] The closing block contains `×1.3`, `30%`, and all four raw figures.
 - [ ] A break line is present (motor_fatigue_aware is set) and contains no comment on the user's body, movement, or tics; it refers to a step by number.
+- [ ] No truncation line appears (the response carries no `truncated` flag).
 - [ ] No relative spatial language appears: none of `drag`, `the step above`, `move it up`, `on the right`, `recently`.
 - [ ] None of these substrings appear: `just`, `simply`, `quick`, `easy`, `superpower`, `crusher`, `smash`, `you got this`, `let's go`, `differently abled`, `clumsy`, `dyspraxia`, `dyspraxic`.
 - [ ] No `!` anywhere in the response.

--- a/packages/skills/dyspraxia-task-pacer/tests/02-no-buffer-no-padding-claim.md
+++ b/packages/skills/dyspraxia-task-pacer/tests/02-no-buffer-no-padding-claim.md
@@ -4,7 +4,7 @@
 
 It is Thursday, 2026-05-21, 10:00 local time. The user identifies with dyspraxia but is running a **hand-edited profile that does not set `chronometric.time_buffer_multiplier`** (the field is absent), and `chronometric.motor_fatigue_aware` is also absent. `identity.neurotypes: ["dyspraxia"]`, `preferences.max_chunk_size: 4`, `preferences.voice_input_preferred: false`. They type `/pace draft the release notes for 0.0.39`. The goal decomposes into two atomic tasks. A project for it exists, so `next_one` succeeds.
 
-This test guards the edge case: with no buffer, the skill must show **raw** estimates and must **not** claim anything was padded.
+This test guards the **no-buffer fallback path**: with no buffer, the skill omits `time_buffer_multiplier` (and `motor_fatigue_aware`) from the `decompose` call, the server returns **no** `padded_minutes` and echoes **no** multiplier, the skill shows the **raw** `estimated_minutes`, runs none of its own padding arithmetic, and claims nothing was padded.
 
 ## Expected MCP tool sequence
 
@@ -19,7 +19,7 @@ This test guards the edge case: with no buffer, the skill must show **raw** esti
    }
    ```
    (Note: no `motor_fatigue_aware` field — the profile did not opt in.)
-2. `mcp-task-fractionator.decompose(goal="draft the release notes for 0.0.39")` →
+2. `mcp-task-fractionator.decompose(goal="draft the release notes for 0.0.39", max_chunk_size=4)` — `time_buffer_multiplier` and `motor_fatigue_aware` are OMITTED because neither is set in the profile (multiplier unset ⇒ treat as 1.0 ⇒ do not pass it) →
    ```json
    {
      "tasks": [
@@ -47,9 +47,10 @@ This test guards the edge case: with no buffer, the skill must show **raw** esti
          "tags": ["writing"]
        }
      ],
-     "rationale": "Split into gather then write so the writing step starts from a fixed list."
+     "rationale": "Carved the goal into 2 task(s). Estimated total: 45 minutes across 2 tasks. Sequence is a total order; tasks at the same topological depth are tie-broken by estimated_minutes then id."
    }
    ```
+   (No `padded_minutes` on any task; no top-level `time_buffer_multiplier`, `motor_fatigue_aware`, or `truncated` — the server dumps `exclude_none=true` and no knob was active, so the wire shape is the pre-R2 `tasks` + `rationale` only.)
 3. `mcp-task-fractionator.next_one(project="draft the release notes for 0.0.39")` →
    ```json
    {
@@ -68,23 +69,30 @@ This test guards the edge case: with no buffer, the skill must show **raw** esti
    }
    ```
 
+## Padding: none in effect, none claimed
+
+There is no `padded_minutes` on any task and the server echoed no multiplier, so the skill shows the raw `estimated_minutes` (`15`, `30`) and runs none of its own padding arithmetic. (The skill's fallback multiply only runs when `padded_minutes` is absent AND the profile multiplier is greater than 1.0 — here the multiplier is unset, so even the fallback stays silent.)
+
 ## Expected response shape
 
 - Opens with one sentence ≤ 80 characters naming step 1 (`Collect the merged PRs since 0.0.38`) and `15 min` (raw, because there is no buffer).
 - Two numbered steps in sequence order, each showing the raw figure (`15`, `30`). No multiplier is applied.
 - A `Next one to pick up:` line quoting `Collect the merged PRs since 0.0.38`, `15 min`, and `conf 0.95`.
 - The closing block does NOT contain a padding line. It does NOT contain the strings `padded`, `×`, `buffer`, or any percentage. There is nothing to declare.
+- No truncation line (no `truncated` flag).
 - No break line, because `motor_fatigue_aware` is not set.
 - Total response length ≤ 900 characters.
 
 ## Pass criteria
 
 - [ ] Tool sequence is exactly three calls in order: `get_time_context()`, one `decompose(...)`, one `next_one(...)`.
+- [ ] The `decompose` call passes `max_chunk_size=4` and does NOT pass `time_buffer_multiplier` or `motor_fatigue_aware` (both unset in the profile).
 - [ ] First sentence is ≤ 80 characters and contains `15`.
 - [ ] Exactly two numbered steps; the figures shown are `15` and `30` (raw, unmodified).
 - [ ] The response does NOT contain a percentage-padding claim: none of `padded`, `pad`, `×1.`, `multiplier`, `buffer`, `30%`, `+%`, or the pattern `+<digits>%` (e.g. `+30%`). (A bare `+` is fine — it may legitimately appear in a task title such as `TypeScript + React`.)
 - [ ] The next-action line contains `conf 0.95`.
 - [ ] No break line appears (motor_fatigue_aware absent).
+- [ ] No truncation line appears (no `truncated` flag).
 - [ ] No relative spatial language: none of `drag`, `the step above`, `move it up`, `on the right`, `recently`.
 - [ ] None of these substrings appear: `just`, `simply`, `quick`, `easy`, `superpower`, `crusher`, `smash`, `you got this`, `differently abled`, `clumsy`, `dyspraxia`, `dyspraxic`.
 - [ ] No `!` anywhere in the response.

--- a/packages/skills/dyspraxia-task-pacer/tests/03-voice-input-single-block.md
+++ b/packages/skills/dyspraxia-task-pacer/tests/03-voice-input-single-block.md
@@ -1,10 +1,10 @@
-# Test: 03 — Voice-input mode, command as a single copy-pasteable block, with elision
+# Test: 03 — Voice-input mode, command as a single copy-pasteable block, with server-side truncation
 
 ## Scenario
 
-It is Friday, 2026-05-22, 09:30 local time. The user has the `dyspraxia.yaml` preset: `identity.neurotypes: ["dyspraxia"]`, `preferences.max_chunk_size: 4`, `preferences.voice_input_preferred: true`, `chronometric.time_buffer_multiplier: 1.3`, `chronometric.motor_fatigue_aware: true`. They dictate `break this down: set up the dyspraxia profile and run the first session`. The decomposition produces **six** atomic tasks (two more than `max_chunk_size`, so two must be elided with a count). The plan's first step is a shell command, so voice-input mode applies: the command must be one copy-pasteable block. `next_one` succeeds with a sequence-1 task.
+It is Friday, 2026-05-22, 09:30 local time. The user has the `dyspraxia.yaml` preset: `identity.neurotypes: ["dyspraxia"]`, `preferences.max_chunk_size: 4`, `preferences.voice_input_preferred: true`, `chronometric.time_buffer_multiplier: 1.3`, `chronometric.motor_fatigue_aware: true`. They dictate `break this down: set up the dyspraxia profile and run the first session`. The goal would naturally produce **six** atomic tasks, but the skill passes `max_chunk_size=4` to `decompose`, so the **server** returns the first four as a valid prefix and sets `truncated: true`. The plan's first step is a shell command, so voice-input mode applies: the command must be one copy-pasteable block. `next_one` succeeds with a sequence-1 task.
 
-This test guards two edges at once: list capping with an elision count, and the voice-input single-block rule.
+This test guards two edges at once: **server-side** capping with the `truncated` flag (the skill surfaces it, it does NOT re-elide), and the voice-input single-block rule.
 
 ## Expected MCP tool sequence
 
@@ -18,49 +18,52 @@ This test guards two edges at once: list capping with an elision count, and the 
      "motor_fatigue_aware": true
    }
    ```
-2. `mcp-task-fractionator.decompose(goal="set up the dyspraxia profile and run the first session")` → six tasks, `estimated_minutes` per sequence:
+2. `mcp-task-fractionator.decompose(goal="set up the dyspraxia profile and run the first session", max_chunk_size=4, time_buffer_multiplier=1.3, motor_fatigue_aware=true)` → the server caps at four tasks (the natural plan was six) and sets `truncated: true`. Each returned task carries server-computed `padded_minutes`:
 
-   | Sequence | Title                                         | Raw min |
-   | -------- | --------------------------------------------- | ------- |
-   | 1        | Copy the dyspraxia preset to the profile path | 5       |
-   | 2        | Open the profile and confirm the four fields  | 10      |
-   | 3        | Start the first session with a stated intent  | 5       |
-   | 4        | Decompose the first real goal                 | 15      |
-   | 5        | Pick the next single action                   | 5       |
-   | 6        | Mark the session end                          | 5       |
+   | Sequence | Title                                         | Raw min | Server `padded_minutes` |
+   | -------- | --------------------------------------------- | ------- | ----------------------- |
+   | 1        | Copy the dyspraxia preset to the profile path | 5       | 6                       |
+   | 2        | Open the profile and confirm the four fields  | 10      | 13                      |
+   | 3        | Start the first session with a stated intent  | 5       | 6                       |
+   | 4        | Decompose the first real goal                 | 15      | 20                      |
 
-   Step 1's `description` names the exact command `cp profiles/dyspraxia.yaml ~/.neurodock/profile.yaml`.
+   Step 1's `description` names the exact command `cp profiles/dyspraxia.yaml ~/.neurodock/profile.yaml`. The response also carries top-level `time_buffer_multiplier: 1.3`, `motor_fatigue_aware: true`, and `truncated: true`. The two further steps (sequences 5–6 in the natural plan) are NOT in the response — the server dropped them as part of the cap and named the truncation in the rationale (`Truncated to the first 4 of 6 tasks at your max_chunk_size; the dropped steps still need doing — re-run without the cap (or raise it) to see them.`).
 
-3. `mcp-task-fractionator.next_one(project="set up the dyspraxia profile and run the first session")` → task = sequence-1 (`Copy the dyspraxia preset to the profile path`), `confidence: 0.95`.
+3. `mcp-task-fractionator.next_one(project="set up the dyspraxia profile and run the first session")` → task = sequence-1 (`Copy the dyspraxia preset to the profile path`), raw `estimated_minutes: 5`, NO `padded_minutes` (next_one never pads), `confidence: 0.95`.
 
-## Padding arithmetic (multiplier 1.3, round half-up)
+## Padding: server-computed; note the `.5` rounding
 
-| Sequence | Raw | Padded |
-| -------- | --- | ------ |
-| 1        | 5   | 7      |
-| 2        | 10  | 13     |
-| 3        | 5   | 7      |
-| 4        | 15  | 20     |
+The server returned `padded_minutes` per task. Note `round(5 × 1.3) = round(6.5) = 6` (Python round-half-to-even, the server's authority) — the skill must show `6`, not `7`. The next-action figure for sequence-1 mirrors the matching `decompose` task's `padded_minutes` of `6` (the skill does not re-multiply the bare `next_one` estimate).
 
-(Sequences 5 and 6 are elided — only the first `max_chunk_size = 4` are shown.)
+| Sequence | Raw | Server `padded_minutes` (displayed) |
+| -------- | --- | ----------------------------------- |
+| 1        | 5   | 6                                   |
+| 2        | 10  | 13                                  |
+| 3        | 5   | 6                                   |
+| 4        | 15  | 20                                  |
+
+(Sequences 5 and 6 of the natural plan were dropped by the SERVER under the cap — the skill never sees them.)
 
 ## Expected response shape
 
-- Opens with one sentence ≤ 80 characters naming step 1 and its padded figure `7 min`.
-- Exactly four numbered steps (sequences 1–4), padded figures `7`, `13`, `7`, `20`.
+- Opens with one sentence ≤ 80 characters naming step 1 and its displayed figure `6 min`.
+- Exactly four numbered steps (the four the server returned), displayed figures `6`, `13`, `6`, `20`.
 - The step-1 command appears exactly once, as a single fenced code block containing the whole line `cp profiles/dyspraxia.yaml ~/.neurodock/profile.yaml` — value already in place, nothing to hand-edit. The command is NOT split across prose and is NOT presented as a fragment to insert into a larger file.
-- A `Next one to pick up:` line quoting `Copy the dyspraxia preset to the profile path`, `7 min`, `conf 0.95`.
-- The closing block names `×1.3`, `+30%`, the four shown raw figures (`5, 10, 5, 15`), an elision line stating `2 further steps` (count only, no titles for sequences 5–6), and one suggestion-framed break line referring to step numbers.
+- A `Next one to pick up:` line quoting `Copy the dyspraxia preset to the profile path`, `6 min`, `conf 0.95`.
+- The closing block names `×1.3`, `+30%`, the four shown raw figures (`5, 10, 5, 15`), a truncation line driven by the server's `truncated: true` flag stating that there were more steps than the cap (e.g. `2 further steps` / `4 of 6`) and that they still need doing — count only, no titles for the dropped steps — and one suggestion-framed break line referring to step numbers.
 - Total response length ≤ 1500 characters.
 
 ## Pass criteria
 
 - [ ] Tool sequence is exactly three calls in order: `get_time_context()`, one `decompose(...)`, one `next_one(...)`.
-- [ ] Exactly four numbered steps appear (sequences 1–4); sequences 5 and 6 are not shown.
-- [ ] The padded figures `7`, `13`, `7`, `20` appear on the step lines; the raw figures appear only in the closing block.
+- [ ] The `decompose` call passes `max_chunk_size=4`, `time_buffer_multiplier=1.3`, and `motor_fatigue_aware=true`.
+- [ ] Exactly four numbered steps appear (the four the server returned); no fifth or sixth step is shown.
+- [ ] The displayed figures `6`, `13`, `6`, `20` appear on the step lines; the raw figures appear only in the closing block.
+- [ ] The step-1 / step-3 figure is `6` (the server's `round(6.5)`), NOT `7` — the skill consumed `padded_minutes` and did not re-multiply.
 - [ ] The command `cp profiles/dyspraxia.yaml ~/.neurodock/profile.yaml` appears exactly once, inside a single fenced code block, as a complete line.
 - [ ] The command is not broken across two code blocks and not embedded in prose with an instruction to edit part of it.
-- [ ] The closing block contains `2 further steps` (or `Elided 2`) and does NOT contain the sequence-5 or sequence-6 titles (`Pick the next single action`, `Mark the session end`).
+- [ ] The closing block surfaces the server's truncation honestly: it contains a count of further steps (e.g. `2 further steps` or `4 of 6`) and does NOT contain any sequence-5 or sequence-6 title.
+- [ ] The skill does NOT re-elide: the four returned tasks are all shown; the truncation line reports the server's `truncated` flag, it does not trim a list the server already trimmed.
 - [ ] The closing block contains `×1.3` and `30%`.
 - [ ] A break line is present and contains no comment on the user's body, movement, or tics.
 - [ ] No relative spatial language: none of `drag`, `the step above`, `move it up`, `on the right`, `recently`.

--- a/uv.lock
+++ b/uv.lock
@@ -1446,7 +1446,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "neurodock-mcp-task-fractionator"
-version = "0.0.5"
+version = "0.1.0"
 source = { editable = "packages/mcp-task-fractionator" }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What

R2 (Phase B). The task-fractionator was fully neurotype-blind; this gives it optional,
additive neurotype hooks and aligns the dyspraxia skill to use them.

**Server** (`decompose`, knobs as call-time params — stays neurotype-blind, no enum branch):
- `max_chunk_size` — caps the atomic-task COUNT. Returns the lowest-sequence prefix (valid
  sub-DAG), renumbers `sequence` contiguously, filters dangling deps, sets `truncated` and
  names it in the rationale (existence framing, no shame — never a silent drop).
- `time_buffer_multiplier` — adds an OPTIONAL per-task `padded_minutes` (= round(raw × mult));
  **`estimated_minutes` stays RAW** (ADR-0011 — existing contract unchanged).
- `motor_fatigue_aware` — echoed honestly (the server has no activity stream; no fabrication).
- A no-knob `decompose` returns the **exact pre-R2 wire shape** (asserted). Decomposer enforces
  the 1–20 `max_chunk_size` bound and the 1.0–3.0 multiplier bound (rejects, never clamps).

**Skill** (`dyspraxia-task-pacer`): now passes the profile knobs to `decompose` and consumes the
server's `padded_minutes` as the single source of truth — the skill's own padding runs ONLY as a
fallback for an older server, so a double-pad is impossible. Surfaces `truncated` rather than
re-eliding. Server is bumped 0.0.5→0.1.0; `@neurodock/core` carrier changeset.

## Review

`mcp-task-fractionator-expert` (server) + `skill-author` (skill), TDD. Reviewed by `code-reviewer`
(APPROVE), `python-reviewer` (blocked on 2 — both fixed: incoherent truncation rationale; a test
asserting the wrong exception type), and `adhd-advocate` (no-block; "still need doing" → existence
framing applied in both server + skill). Fixes also added: multiplier out-of-range tests, the
decomposer upper-bound check, a `next_one` cap-edge note.

## Test plan

- [x] `ruff check` + `ruff format --check` clean; `mypy --strict src` no issues
- [x] `pytest -q` → 77 passed
- [x] back-compat: no-knob decompose byte-identical pre-R2; non-truncated rationale byte-identical
- [x] schema-conformance test passes (additive JSON schema in sync with Pydantic)
- [x] no double-pad: server `padded_minutes` and skill self-pad are mutually exclusive
- [x] `wrangler.jsonc` excluded