### PR TITLE
feat(mcp-translation): per-neurotype shaping for all mcp clients (r1 part b)

### DIFF
--- a/.changeset/translation-neurotype-shaping-server.md
+++ b/.changeset/translation-neurotype-shaping-server.md
@@ -1,0 +1,59 @@
+---
+"@neurodock/core": minor
+---
+
+server-side per-neurotype prompt shaping in mcp-translation (r1 part b, adr 0012)
+
+carrier changeset on `@neurodock/core` per the established convention for python
+package changes (mcp-translation is not in the pnpm workspace; its version is
+bumped in `packages/mcp-translation/pyproject.toml`, 0.2.2 -> 0.3.0).
+
+implements the server half of adr 0012 so EVERY mcp client — claude desktop,
+cursor, claude code, any mcp host — gets the same per-neurotype tailoring the
+browser extension already gets, not just the extension. the tailoring content
+stays the single source of truth in `@neurodock/core`
+(`data/neurotype-addenda/v1.json`); the server reads it through a python
+assembler and injects the addendum into the prompt it already returns. no llm
+sdk, no model call (adr 0005 intact).
+
+what landed in mcp-translation:
+
+- `addenda.py` — a direct port of core's `assembleNeurotypeAddendum` (fusion ->
+  priority -> per-tool block with generic fallback -> tourette/other specials ->
+  voice-input block -> 3+ conflict footer -> `{max_chunk_size}` / `{notes}`
+  interpolation -> wrapper), proven byte-identical to the typescript assembler.
+- artifact delivery: a byte-identical copy of `v1.json` ships inside the wheel as
+  package-data (`src/neurodock_mcp_translation/data/neurotype-addenda/v1.json`);
+  `importlib.resources` reads it with no monorepo filesystem dependency, so the
+  hosted-remote worker bundles cleanly. an import-time existence check degrades to
+  a logged safe default (generic/empty prompt) if the artifact is ever missing —
+  never a crash.
+- `profile.py` — a trimmed port of mcp-chronometric's profile reader, reading
+  `identity.neurotypes`, `identity.additional_notes`, `preferences.output_format`,
+  `preferences.max_chunk_size`, `preferences.voice_input_preferred`. same
+  `NEURODOCK_PROFILE_PATH` override / safe-default-on-absence / `profile_unreadable`
+  log / defensive-field-parsing discipline.
+- `reader_context` — one optional, additive input on all four tools
+  (`neurotypes?`, `output_format?`, `max_chunk_size?`, `voice_input_preferred?`,
+  `additional_notes?`), tolerant of unknown keys. resolution precedence is
+  field-by-field: `reader_context` per field, else the `profile.yaml` read, else
+  nothing. added to the pydantic input models and the four json schemas additively.
+- wiring: each tool appends the assembled addendum to
+  `prompt_for_llm_refinement.content` AFTER the schema block (the extension's
+  recency ordering). absent BOTH `reader_context` and a profile, the content is
+  byte-identical to today's — a load-bearing regression test asserts this. the
+  output shape is unchanged (no new required output field; adr 0011 holds).
+
+anti-drift control (the critical one): a committed parity fixture
+(`packages/core/data/neurotype-addenda/parity-fixtures.json`, 59 cases across the
+4 server tools x representative neurotype combos incl. adhd / asd / adhd+asd ->
+audhd fusion / explicit audhd / ocd / dyslexia / dyspraxia / tourette / other /
+3+ conflict, x voice on-off x chunk-size variants x notes present-absent) is
+generated FROM the typescript assembler (the source of truth). a TS test
+(`packages/core/src/neurotype-addenda.parity.test.ts`) guards the TS side and
+regenerates intentionally; a python test
+(`packages/mcp-translation/tests/test_addenda_parity.py`) asserts the python
+assembler produces the same strings. ts ≠ python is now a red ci build. a second
+guard asserts the wheel's artifact copy stays byte-identical to core's source.
+
+depends on `pyyaml` (added) for the profile read.

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,7 @@ __pycache__/
 pnpm-lock.yaml
 uv.lock
 .changeset/
+
+# Generated artifact: written by neurotype-addenda.parity.test.ts in
+# UPDATE_NEUROTYPE_PARITY_FIXTURES mode (JSON.stringify-formatted, not prettier).
+packages/core/data/neurotype-addenda/parity-fixtures.json

--- a/docs/src/content/docs/reference/mcp-servers/translation.mdx
+++ b/docs/src/content/docs/reference/mcp-servers/translation.mdx
@@ -7,10 +7,10 @@ description: Communication and translation as an MCP server. Four tools, four sc
 
 | Tool | What it takes | What it returns | Why your brain cares |
 |---|---|---|---|
-| `translate_incoming` | `{ text, channel?, thread_context?, target_language? }` | explicit ask, ranked subtext hypotheses, ambiguity spans, recommended next action | reads the "happy to discuss further" you've been staring at for ten minutes and tells you whether it's a soft no or a real opening — without you having to mask-rehearse seven interpretations |
-| `check_tone` | `{ text, baseline_messages?, target_register?, channel? }` | scores on directness, warmth, urgency; flagged phrases | shows you that your draft reads as 92/100 urgent when your usual baseline is 40 — useful when the social-meter in your head is offline |
-| `rewrite_outgoing` | `{ text, target_register, preserve_terms? }` | rewritten text, preserved/unpreserved terms, diff summary | lets you keep the ticket IDs and jargon verbatim while a tool handles the register shift you find exhausting |
-| `brief_meeting` | `{ transcript, me, project?, speakers? }` | my asks / others' asks / decisions / ambiguous items (with verbatim quotes) | turns ninety minutes of transcript into the four lists you actually need; ambiguous items are quoted character-for-character so nothing is invented |
+| `translate_incoming` | `{ text, channel?, thread_context?, target_language?, reader_context? }` | explicit ask, ranked subtext hypotheses, ambiguity spans, recommended next action | reads the "happy to discuss further" you've been staring at for ten minutes and tells you whether it's a soft no or a real opening — without you having to mask-rehearse seven interpretations |
+| `check_tone` | `{ text, baseline_messages?, target_register?, channel?, reader_context? }` | scores on directness, warmth, urgency; flagged phrases | shows you that your draft reads as 92/100 urgent when your usual baseline is 40 — useful when the social-meter in your head is offline |
+| `rewrite_outgoing` | `{ text, target_register, preserve_terms?, reader_context? }` | rewritten text, preserved/unpreserved terms, diff summary | lets you keep the ticket IDs and jargon verbatim while a tool handles the register shift you find exhausting |
+| `brief_meeting` | `{ transcript, me, project?, speakers?, reader_context? }` | my asks / others' asks / decisions / ambiguous items (with verbatim quotes) | turns ninety minutes of transcript into the four lists you actually need; ambiguous items are quoted character-for-character so nothing is invented |
 
 `mcp-translation` decodes corporate ambiguity. It is the substrate's communication-layer server: it scores tone, rewrites for register, decodes incoming subtext, and briefs meeting transcripts. The server itself contains **no LLM SDK** — every tool returns a deterministic baseline plus a structured prompt the caller's MCP client executes against its configured model.
 
@@ -42,10 +42,10 @@ The caller MAY use the deterministic analysis alone (no LLM required) or feed `p
 
 | Tool | Input | Output |
 |---|---|---|
-| `translate_incoming` | `{ text, channel?, thread_context?, target_language? }` | `{ explicit_ask, likely_subtext[], ambiguity, recommended_next_action, model_provenance, eval_corpus_slice }` |
-| `check_tone` | `{ text, baseline_messages?, target_register?, channel? }` | `{ axes, axes_target?, baseline_delta, flagged_phrases[], suggested_rewrite_hint, model_provenance, eval_corpus_slice }` |
-| `rewrite_outgoing` | `{ text, target_register, preserve_terms?, channel?, preserve_intent? }` | `{ rewritten, preserved_terms[], unpreserved_terms[], diff_summary, model_provenance, eval_corpus_slice }` |
-| `brief_meeting` | `{ transcript, me, project?, speakers? }` | `{ my_asks[], others_asks[], decisions[], ambiguous_items[], model_provenance, eval_corpus_slice }` |
+| `translate_incoming` | `{ text, channel?, thread_context?, target_language?, reader_context? }` | `{ explicit_ask, likely_subtext[], ambiguity, recommended_next_action, model_provenance, eval_corpus_slice }` |
+| `check_tone` | `{ text, baseline_messages?, target_register?, channel?, reader_context? }` | `{ axes, axes_target?, baseline_delta, flagged_phrases[], suggested_rewrite_hint, model_provenance, eval_corpus_slice }` |
+| `rewrite_outgoing` | `{ text, target_register, preserve_terms?, channel?, preserve_intent?, reader_context? }` | `{ rewritten, preserved_terms[], unpreserved_terms[], diff_summary, model_provenance, eval_corpus_slice }` |
+| `brief_meeting` | `{ transcript, me, project?, speakers?, reader_context? }` | `{ my_asks[], others_asks[], decisions[], ambiguous_items[], model_provenance, eval_corpus_slice }` |
 
 ### `translate_incoming`
 
@@ -77,6 +77,41 @@ Convert a transcript into a four-section brief: asks of the recipient, asks the 
 - `transcript` is 20–200,000 characters (roughly a 90-minute meeting). Longer transcripts MUST be chunked by the caller; the tool returns `TRANSCRIPT_TOO_LONG` otherwise.
 - `me` is required. Without a speaker label that identifies the recipient, the four-section partition is ill-defined; the tool returns `ME_REQUIRED` rather than guessing.
 - `ambiguous_items[].quoted_span.text` MUST equal `input.transcript[start_char:end_char]`. The server validates this on every response (including its own deterministic output) and raises `VERBATIM_ANCHOR_FAILED` if the model fabricates a span. This is anti-hallucination armour — a fabricated "ambiguous item" not in the transcript is worse than no brief at all.
+
+### `reader_context` (per-neurotype prompt shaping)
+
+All four tools accept an optional `reader_context` object that shapes the
+`prompt_for_llm_refinement.content` per the reader's neurotype preferences ([ADR 0012](/decisions/0012-shared-neurotype-shaping-layer/)). This is how a Claude Desktop / Cursor / generic-MCP user gets the same per-neurotype tailoring the browser extension already gets.
+
+```json
+{
+  "reader_context": {
+    "neurotypes": ["adhd", "asd"],
+    "output_format": "answer_first",
+    "max_chunk_size": 5,
+    "voice_input_preferred": true,
+    "additional_notes": "Please quote the source verbatim."
+  }
+}
+```
+
+- Every field is optional. When a field is absent, the server falls back to
+  `~/.neurodock/profile.yaml` (`identity.neurotypes`, `identity.additional_notes`,
+  `preferences.output_format`, `preferences.max_chunk_size`,
+  `preferences.voice_input_preferred`), and then to neutral absence. Precedence is
+  field-by-field: `reader_context` wins per field, the profile fills the rest.
+- **When both `reader_context` and the profile are absent, the prompt is
+  byte-identical to the un-shaped baseline.** Tailoring is something that gets
+  added, never something whose absence changes the baseline.
+- `neurotypes` uses the canonical self-ID enum (`adhd`, `asd`, `audhd`, `ocd`,
+  `dyslexia`, `dyspraxia`, `tourette`, `other`); `adhd` + `asd` (or explicit
+  `audhd`) fuses to the AuDHD block. The shaping content is the single source of
+  truth in `@neurodock/core` (`data/neurotype-addenda/v1.json`); the server reads
+  it through a pure assembler proven byte-identical to the extension's by a
+  cross-language parity test.
+- `reader_context` shapes **prompt text only**. The output shape is unchanged, and
+  the server still makes no LLM call ([ADR 0005](/decisions/0005-translation/)). Unknown keys are tolerated for
+  forward-compatibility.
 
 ## Error codes
 

--- a/packages/core/data/neurotype-addenda/parity-fixtures.json
+++ b/packages/core/data/neurotype-addenda/parity-fixtures.json
@@ -1,0 +1,672 @@
+{
+  "description": "Cross-language parity fixtures for the neurotype-addenda assembler (ADR 0012). Inputs use language-neutral snake_case keys so the TypeScript and Python parity tests read byte-identical inputs. The expected strings are generated FROM the TypeScript assembler (the source of truth) and asserted by BOTH packages/core/src/neurotype-addenda.parity.test.ts and packages/mcp-translation/tests/test_addenda_parity.py. Regenerate with UPDATE_NEUROTYPE_PARITY_FIXTURES=1.",
+  "artifact_version": "1.0.0",
+  "cases": [
+    {
+      "name": "empty/all-default/no-tool",
+      "neurotypes": [],
+      "output_format": "answer_first",
+      "max_chunk_size": 7,
+      "additional_notes": null,
+      "expected": ""
+    },
+    {
+      "name": "empty/all-default/translate_incoming",
+      "tool": "translate_incoming",
+      "neurotypes": [],
+      "output_format": "answer_first",
+      "max_chunk_size": 7,
+      "additional_notes": null,
+      "expected": ""
+    },
+    {
+      "name": "empty/non-default-format",
+      "tool": "check_tone",
+      "neurotypes": [],
+      "output_format": "bullet_first",
+      "max_chunk_size": 7,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: bullet_first — Lead with a short bullet list before any prose.\n---\n"
+    },
+    {
+      "name": "empty/voice-only",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [],
+      "output_format": "answer_first",
+      "max_chunk_size": 7,
+      "voice_input_preferred": true,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (voice input):\n- The reader dictates and cannot cheaply hand-edit fiddly punctuation.\n- Keep any example, draft, or snippet as a single, copy-pasteable block — do not scatter editable fragments across the response.\n---\n"
+    },
+    {
+      "name": "empty/notes-only",
+      "tool": "brief_meeting",
+      "neurotypes": [],
+      "output_format": "answer_first",
+      "max_chunk_size": 7,
+      "additional_notes": "Always quote the source verbatim.",
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (self-described):\n- Treat the notes below as a literal instruction set from the reader. Honour any 'please do' / 'please don't' requests.\n\nReader's own notes:\nAlways quote the source verbatim.\n---\n"
+    },
+    {
+      "name": "translate_incoming/adhd/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "adhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (ADHD) — translate_incoming:\n- 'explicit_ask': 1 sentence, lead with the verb ('Send the spec by Friday' not 'The sender would like…').\n- 'likely_subtext': cap at 5 items, highest-confidence first.\n- 'recommended_next_action.action': imperative verb-phrase, 6 words or fewer. 'Reply with the spec link' not 'It might be worth replying'.\n- 'recommended_next_action.reason': 1 sentence. No throat-clearing.\n- 'recommended_next_action.draft_reply': if drafted, keep it to 1-2 short sentences.\n---\n"
+    },
+    {
+      "name": "translate_incoming/asd/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (autism) — translate_incoming:\n- 'likely_subtext[].text': state subtext as commitments when evidence supports it ('The sender wants X by Friday'). Use guesses ('they might want X') ONLY when the message is genuinely ambiguous.\n- Decode any idiom in the source verbatim inside 'likely_subtext' (e.g. source 'circle back' -> subtext 'They will reply later'; source 'ping you' -> 'They will send a message').\n- 'ambiguity.spans[]': when a sentence depends on tone of voice or facial expression text cannot carry, mark it ambiguous with reason 'text alone cannot disambiguate tone'.\n- 'recommended_next_action.draft_reply': no idioms ('touch base', 'circle back', 'loop in', 'hop on a call', 'reach out'). Use literal verbs.\n- 'recommended_next_action.reason': quote the source verbatim in parentheses when paraphrasing the ask.\n---\n"
+    },
+    {
+      "name": "translate_incoming/audhd-fusion/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "adhd",
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (AuDHD) — translate_incoming:\n- 'explicit_ask': 1 sentence, lead with the verb. No throat-clearing.\n- 'likely_subtext': cap at 5; state as commitments when text supports it, as guesses only when genuinely ambiguous.\n- Decode source idioms verbatim in 'likely_subtext' ('ping you' -> 'send you a message').\n- 'recommended_next_action.action': imperative verb-phrase, 6 words or fewer, no idioms.\n- 'recommended_next_action.draft_reply': 1-2 short sentences, literal verbs only.\n- 'ambiguity.spans[]': flag tone-dependent sentences with reason 'text alone cannot disambiguate tone'.\n---\n"
+    },
+    {
+      "name": "translate_incoming/audhd-direct/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "audhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (AuDHD) — translate_incoming:\n- 'explicit_ask': 1 sentence, lead with the verb. No throat-clearing.\n- 'likely_subtext': cap at 5; state as commitments when text supports it, as guesses only when genuinely ambiguous.\n- Decode source idioms verbatim in 'likely_subtext' ('ping you' -> 'send you a message').\n- 'recommended_next_action.action': imperative verb-phrase, 6 words or fewer, no idioms.\n- 'recommended_next_action.draft_reply': 1-2 short sentences, literal verbs only.\n- 'ambiguity.spans[]': flag tone-dependent sentences with reason 'text alone cannot disambiguate tone'.\n---\n"
+    },
+    {
+      "name": "translate_incoming/ocd/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "ocd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (OCD) — translate_incoming:\n- 'recommended_next_action.action': low-pressure phrasing. Avoid 'urgent', 'must', 'immediately', 'ASAP', 'critical'. Prefer 'when you have a minute', 'consider', 'you may want to'.\n- 'recommended_next_action.reason': do not amplify time pressure. If the source said 'soon', don't paraphrase as 'urgently'.\n- 'ambiguity.detected': only flag ambiguity that's actually in the source. Don't invent ambiguity to be thorough.\n- 'likely_subtext': if the message has no actionable issue, return an empty array and say so plainly in 'recommended_next_action.reason' ('nothing here needs an answer today').\n- 'draft_reply': never say the reader's prior draft was 'wrong'. Use 'reads as' or 'may land as'.\n---\n"
+    },
+    {
+      "name": "translate_incoming/dyslexia/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "dyslexia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia) — translate_incoming:\n- 'explicit_ask': max 15 words. Plain language. 'They want X' not 'The sender is requesting X'.\n- 'likely_subtext[].text': 1 sentence each, max 15 words. Cap list at 5.\n- Replace 'paraphrased' with 'said plainly', 'ambiguous' with 'unclear', 'verbatim' with 'word-for-word', 'subtext' with 'what they really mean'.\n- 'recommended_next_action.reason': 1 short sentence. No semicolons. No em-dashes inside sentences.\n- 'recommended_next_action.draft_reply': short sentences. Common words ('use' not 'utilise', 'about' not 'regarding').\n---\n"
+    },
+    {
+      "name": "translate_incoming/dyspraxia/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "dyspraxia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyspraxia) — translate_incoming:\n- Use absolute dates in 'explicit_ask' and 'draft_reply' ('Wednesday 28 May', 'by end of this week') not relative ones ('next sprint', 'soon').\n- 'likely_subtext': cap at 5; if subtext references a prior thread message, name it explicitly rather than 'the above'.\n- 'recommended_next_action.action': single-step where possible. If multi-step, number the steps inside 'draft_reply', not inside 'action'.\n- Group related subtext items together — don't interleave 'they want X' with 'they're worried about Y'.\n---\n"
+    },
+    {
+      "name": "translate_incoming/tourette/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "tourette"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (Tourette):\n- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.\n- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.\n- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.\n- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.\n- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field.\n---\n"
+    },
+    {
+      "name": "translate_incoming/other/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "other"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": "Please use kelvin not celsius.",
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (self-described):\n- Treat the notes below as a literal instruction set from the reader. Honour any 'please do' / 'please don't' requests.\n\nReader's own notes:\nPlease use kelvin not celsius.\n---\n"
+    },
+    {
+      "name": "translate_incoming/conflict3/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "adhd",
+        "dyslexia",
+        "ocd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia) — translate_incoming:\n- 'explicit_ask': max 15 words. Plain language. 'They want X' not 'The sender is requesting X'.\n- 'likely_subtext[].text': 1 sentence each, max 15 words. Cap list at 5.\n- Replace 'paraphrased' with 'said plainly', 'ambiguous' with 'unclear', 'verbatim' with 'word-for-word', 'subtext' with 'what they really mean'.\n- 'recommended_next_action.reason': 1 short sentence. No semicolons. No em-dashes inside sentences.\n- 'recommended_next_action.draft_reply': short sentences. Common words ('use' not 'utilise', 'about' not 'regarding').\n\nReader preferences (OCD) — translate_incoming:\n- 'recommended_next_action.action': low-pressure phrasing. Avoid 'urgent', 'must', 'immediately', 'ASAP', 'critical'. Prefer 'when you have a minute', 'consider', 'you may want to'.\n- 'recommended_next_action.reason': do not amplify time pressure. If the source said 'soon', don't paraphrase as 'urgently'.\n- 'ambiguity.detected': only flag ambiguity that's actually in the source. Don't invent ambiguity to be thorough.\n- 'likely_subtext': if the message has no actionable issue, return an empty array and say so plainly in 'recommended_next_action.reason' ('nothing here needs an answer today').\n- 'draft_reply': never say the reader's prior draft was 'wrong'. Use 'reads as' or 'may land as'.\n\nReader preferences (ADHD) — translate_incoming:\n- 'explicit_ask': 1 sentence, lead with the verb ('Send the spec by Friday' not 'The sender would like…').\n- 'likely_subtext': cap at 5 items, highest-confidence first.\n- 'recommended_next_action.action': imperative verb-phrase, 6 words or fewer. 'Reply with the spec link' not 'It might be worth replying'.\n- 'recommended_next_action.reason': 1 sentence. No throat-clearing.\n- 'recommended_next_action.draft_reply': if drafted, keep it to 1-2 short sentences.\n\nWhen these preferences conflict (e.g. 'literal' vs 'soft'), prefer the more conservative reading: shorter, more concrete, less pressure.\n---\n"
+    },
+    {
+      "name": "translate_incoming/conflict-tourette-audhd/default",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "tourette",
+        "adhd",
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (Tourette):\n- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.\n- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.\n- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.\n- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.\n- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field.\n\nReader preferences (AuDHD) — translate_incoming:\n- 'explicit_ask': 1 sentence, lead with the verb. No throat-clearing.\n- 'likely_subtext': cap at 5; state as commitments when text supports it, as guesses only when genuinely ambiguous.\n- Decode source idioms verbatim in 'likely_subtext' ('ping you' -> 'send you a message').\n- 'recommended_next_action.action': imperative verb-phrase, 6 words or fewer, no idioms.\n- 'recommended_next_action.draft_reply': 1-2 short sentences, literal verbs only.\n- 'ambiguity.spans[]': flag tone-dependent sentences with reason 'text alone cannot disambiguate tone'.\n---\n"
+    },
+    {
+      "name": "check_tone/adhd/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "adhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (ADHD) — check_tone:\n- 'flagged_phrases': cap at 5, highest-impact first. Don't pad the list.\n- 'flagged_phrases[].reason': 1 short sentence per entry.\n- 'flagged_phrases[].suggestion': a concrete replacement, not advice. 'Replace with: \"by Friday\"' not 'Consider being more specific'.\n- 'suggested_rewrite_hint': 1-2 sentences, verb-led. 'Tighten the opener, drop the hedges' not 'You might want to consider tightening…'.\n---\n"
+    },
+    {
+      "name": "check_tone/asd/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (autism) — check_tone:\n- 'axes': state the score literally — don't soften with 'somewhat' or 'a bit'. 0.2 means 'low'; say so.\n- 'baseline_delta': when prior messages aren't available, return null rather than guessing a baseline.\n- 'flagged_phrases[].reason': explain WHY the phrase reads as it does ('reads as terse because it has no greeting and uses imperative mood'), not just 'sounds blunt'.\n- 'suggested_rewrite_hint': literal, no idioms ('touch base', 'soften the ask', 'warm up'). Use concrete edits ('add a greeting; replace \"send it\" with \"could you send it\"').\n- 'flagged_phrases[].suggestion': exact replacement string, not a description of the change.\n---\n"
+    },
+    {
+      "name": "check_tone/audhd-fusion/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "adhd",
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (AuDHD) — check_tone:\n- 'flagged_phrases': cap at 5, highest-impact first. Each 'suggestion' is a concrete replacement string, not advice.\n- 'flagged_phrases[].reason': 1 sentence; name the mechanism ('imperative mood, no greeting') not just the impression ('blunt').\n- 'suggested_rewrite_hint': verb-led, literal, no idioms. 'Add a greeting; soften the ask by changing \"send it\" to \"could you send it\".'\n- 'axes': state scores literally — don't hedge with 'somewhat'.\n- 'baseline_delta': null when no prior baseline; don't guess.\n---\n"
+    },
+    {
+      "name": "check_tone/audhd-direct/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "audhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (AuDHD) — check_tone:\n- 'flagged_phrases': cap at 5, highest-impact first. Each 'suggestion' is a concrete replacement string, not advice.\n- 'flagged_phrases[].reason': 1 sentence; name the mechanism ('imperative mood, no greeting') not just the impression ('blunt').\n- 'suggested_rewrite_hint': verb-led, literal, no idioms. 'Add a greeting; soften the ask by changing \"send it\" to \"could you send it\".'\n- 'axes': state scores literally — don't hedge with 'somewhat'.\n- 'baseline_delta': null when no prior baseline; don't guess.\n---\n"
+    },
+    {
+      "name": "check_tone/ocd/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "ocd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (OCD) — check_tone:\n- 'flagged_phrases[].reason': avoid 'wrong', 'mistake', 'error'. Use 'reads as' or 'may land as'.\n- 'suggested_rewrite_hint': low-pressure framing. 'You may want to add a greeting' not 'You must add a greeting'.\n- Do not flag a phrase as a problem if the only issue is that it could theoretically be misread. Flag actual tone issues, not hypothetical ones.\n- 'axes.urgency': if the source genuinely is urgent (deadline in source text), don't downgrade the score to seem 'calmer'. Report the tone the message actually has.\n---\n"
+    },
+    {
+      "name": "check_tone/dyslexia/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "dyslexia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia) — check_tone:\n- 'flagged_phrases': cap at 5. Each 'reason' max 15 words.\n- 'suggested_rewrite_hint': 1-2 short sentences. Plain words ('softer' not 'less assertive', 'shorter' not 'more concise').\n- One idea per sentence in every prose field. No semicolons.\n- 'flagged_phrases[].suggestion': a concrete replacement string, short.\n---\n"
+    },
+    {
+      "name": "check_tone/dyspraxia/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "dyspraxia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyspraxia) — check_tone:\n- 'flagged_phrases': 5 max, ordered as they appear in the source text (top to bottom) — not by severity.\n- 'suggested_rewrite_hint': if multi-step, write as a single continuous instruction rather than a numbered sequence.\n- Don't reference 'the above' or 'as mentioned'; name the specific phrase ('the opener \"hey\"', not 'the first issue').\n---\n"
+    },
+    {
+      "name": "check_tone/tourette/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "tourette"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (Tourette):\n- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.\n- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.\n- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.\n- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.\n- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field.\n---\n"
+    },
+    {
+      "name": "check_tone/other/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "other"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": "Please use kelvin not celsius.",
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (self-described):\n- Treat the notes below as a literal instruction set from the reader. Honour any 'please do' / 'please don't' requests.\n\nReader's own notes:\nPlease use kelvin not celsius.\n---\n"
+    },
+    {
+      "name": "check_tone/conflict3/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "adhd",
+        "dyslexia",
+        "ocd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia) — check_tone:\n- 'flagged_phrases': cap at 5. Each 'reason' max 15 words.\n- 'suggested_rewrite_hint': 1-2 short sentences. Plain words ('softer' not 'less assertive', 'shorter' not 'more concise').\n- One idea per sentence in every prose field. No semicolons.\n- 'flagged_phrases[].suggestion': a concrete replacement string, short.\n\nReader preferences (OCD) — check_tone:\n- 'flagged_phrases[].reason': avoid 'wrong', 'mistake', 'error'. Use 'reads as' or 'may land as'.\n- 'suggested_rewrite_hint': low-pressure framing. 'You may want to add a greeting' not 'You must add a greeting'.\n- Do not flag a phrase as a problem if the only issue is that it could theoretically be misread. Flag actual tone issues, not hypothetical ones.\n- 'axes.urgency': if the source genuinely is urgent (deadline in source text), don't downgrade the score to seem 'calmer'. Report the tone the message actually has.\n\nReader preferences (ADHD) — check_tone:\n- 'flagged_phrases': cap at 5, highest-impact first. Don't pad the list.\n- 'flagged_phrases[].reason': 1 short sentence per entry.\n- 'flagged_phrases[].suggestion': a concrete replacement, not advice. 'Replace with: \"by Friday\"' not 'Consider being more specific'.\n- 'suggested_rewrite_hint': 1-2 sentences, verb-led. 'Tighten the opener, drop the hedges' not 'You might want to consider tightening…'.\n\nWhen these preferences conflict (e.g. 'literal' vs 'soft'), prefer the more conservative reading: shorter, more concrete, less pressure.\n---\n"
+    },
+    {
+      "name": "check_tone/conflict-tourette-audhd/default",
+      "tool": "check_tone",
+      "neurotypes": [
+        "tourette",
+        "adhd",
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (Tourette):\n- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.\n- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.\n- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.\n- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.\n- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field.\n\nReader preferences (AuDHD) — check_tone:\n- 'flagged_phrases': cap at 5, highest-impact first. Each 'suggestion' is a concrete replacement string, not advice.\n- 'flagged_phrases[].reason': 1 sentence; name the mechanism ('imperative mood, no greeting') not just the impression ('blunt').\n- 'suggested_rewrite_hint': verb-led, literal, no idioms. 'Add a greeting; soften the ask by changing \"send it\" to \"could you send it\".'\n- 'axes': state scores literally — don't hedge with 'somewhat'.\n- 'baseline_delta': null when no prior baseline; don't guess.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/adhd/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "adhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (ADHD) — rewrite_outgoing:\n- 'rewritten': keep length within ~20% of the source. Don't pad to sound 'professional'.\n- 'diff_summary.structural_changes': cap at 5, highest-impact first.\n- 'diff_summary.tone_shift': 1 short sentence describing the shift verb-first ('Softened the ask; kept the deadline').\n- 'diff_summary.warnings': only include warnings the reader actually needs to act on. Skip 'minor style changes'.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/asd/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (autism) — rewrite_outgoing:\n- 'rewritten': preserve the literal ask. If the source says 'send the report by Friday', the rewrite still says that explicitly — don't bury it under softening.\n- 'rewritten': no idioms introduced. Banned in the rewrite: 'touch base', 'circle back', 'loop in', 'hop on', 'reach out', 'moving forward', 'low-hanging fruit'.\n- 'preserved_terms': include any technical term, name, or quoted phrase from the source that has a precise meaning.\n- 'diff_summary.tone_shift': name the mechanism ('added a greeting; replaced imperative with question form'), not the impression ('made it warmer').\n- 'diff_summary.warnings': flag if softening could obscure the deadline or quantity in the source.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/audhd-fusion/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "adhd",
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (AuDHD) — rewrite_outgoing:\n- 'rewritten': keep within ~20% of source length; preserve the literal ask verbatim; no introduced idioms.\n- 'diff_summary.structural_changes': cap at 5; name mechanisms not impressions.\n- 'diff_summary.tone_shift': 1 sentence, verb-led. 'Added greeting, replaced imperative with question form.'\n- 'preserved_terms': include technical terms, names, and quoted source phrases.\n- 'diff_summary.warnings': flag if softening would obscure the deadline or quantity.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/audhd-direct/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "audhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (AuDHD) — rewrite_outgoing:\n- 'rewritten': keep within ~20% of source length; preserve the literal ask verbatim; no introduced idioms.\n- 'diff_summary.structural_changes': cap at 5; name mechanisms not impressions.\n- 'diff_summary.tone_shift': 1 sentence, verb-led. 'Added greeting, replaced imperative with question form.'\n- 'preserved_terms': include technical terms, names, and quoted source phrases.\n- 'diff_summary.warnings': flag if softening would obscure the deadline or quantity.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/ocd/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "ocd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (OCD) — rewrite_outgoing:\n- 'rewritten': avoid 'urgent', 'must', 'ASAP', 'critical', 'don't forget' unless the source uses them. Don't amplify pressure beyond the source.\n- 'diff_summary.warnings': don't warn that the source was 'wrong' or 'aggressive'. Use 'the original could land as terse' instead.\n- 'diff_summary.tone_shift': avoid 'fixed', 'corrected', 'cleaned up'. Use 'shifted toward' or 'reduced'.\n- Don't add hedging the source didn't have unless the target_register asks for it.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/dyslexia/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "dyslexia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia) — rewrite_outgoing:\n- 'rewritten': short sentences, max 15 words each. Common words ('use' not 'utilise', 'help' not 'facilitate').\n- 'diff_summary.structural_changes': cap at 5; each item 1 short phrase, not a sentence.\n- 'diff_summary.tone_shift': 1 short sentence. Plain words.\n- Break compound sentences into two during the rewrite. No semicolons in 'rewritten'.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/dyspraxia/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "dyspraxia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyspraxia) — rewrite_outgoing:\n- 'rewritten': use absolute dates ('Wednesday 28 May'), not relative ones ('next week'), even if the source used relative.\n- 'diff_summary.structural_changes': 5 max, ordered by where they appear in the rewrite (top to bottom).\n- If the source asks for a sequence of actions, keep the sequence in source order in the rewrite; don't reorder for 'flow'.\n- 'diff_summary.warnings': flag if the rewrite introduces a forward-reference ('as mentioned above') that the source didn't have.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/tourette/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "tourette"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (Tourette):\n- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.\n- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.\n- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.\n- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.\n- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/other/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "other"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": "Please use kelvin not celsius.",
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (self-described):\n- Treat the notes below as a literal instruction set from the reader. Honour any 'please do' / 'please don't' requests.\n\nReader's own notes:\nPlease use kelvin not celsius.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/conflict3/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "adhd",
+        "dyslexia",
+        "ocd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia) — rewrite_outgoing:\n- 'rewritten': short sentences, max 15 words each. Common words ('use' not 'utilise', 'help' not 'facilitate').\n- 'diff_summary.structural_changes': cap at 5; each item 1 short phrase, not a sentence.\n- 'diff_summary.tone_shift': 1 short sentence. Plain words.\n- Break compound sentences into two during the rewrite. No semicolons in 'rewritten'.\n\nReader preferences (OCD) — rewrite_outgoing:\n- 'rewritten': avoid 'urgent', 'must', 'ASAP', 'critical', 'don't forget' unless the source uses them. Don't amplify pressure beyond the source.\n- 'diff_summary.warnings': don't warn that the source was 'wrong' or 'aggressive'. Use 'the original could land as terse' instead.\n- 'diff_summary.tone_shift': avoid 'fixed', 'corrected', 'cleaned up'. Use 'shifted toward' or 'reduced'.\n- Don't add hedging the source didn't have unless the target_register asks for it.\n\nReader preferences (ADHD) — rewrite_outgoing:\n- 'rewritten': keep length within ~20% of the source. Don't pad to sound 'professional'.\n- 'diff_summary.structural_changes': cap at 5, highest-impact first.\n- 'diff_summary.tone_shift': 1 short sentence describing the shift verb-first ('Softened the ask; kept the deadline').\n- 'diff_summary.warnings': only include warnings the reader actually needs to act on. Skip 'minor style changes'.\n\nWhen these preferences conflict (e.g. 'literal' vs 'soft'), prefer the more conservative reading: shorter, more concrete, less pressure.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/conflict-tourette-audhd/default",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "tourette",
+        "adhd",
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (Tourette):\n- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.\n- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.\n- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.\n- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.\n- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field.\n\nReader preferences (AuDHD) — rewrite_outgoing:\n- 'rewritten': keep within ~20% of source length; preserve the literal ask verbatim; no introduced idioms.\n- 'diff_summary.structural_changes': cap at 5; name mechanisms not impressions.\n- 'diff_summary.tone_shift': 1 sentence, verb-led. 'Added greeting, replaced imperative with question form.'\n- 'preserved_terms': include technical terms, names, and quoted source phrases.\n- 'diff_summary.warnings': flag if softening would obscure the deadline or quantity.\n---\n"
+    },
+    {
+      "name": "brief_meeting/adhd/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "adhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (ADHD) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: cap entries at 5; each facet verb-led and 8 words or fewer. Label each entry as 'my_asks[i]' / 'decisions[i]' so the reader can jump back to the verbatim quote.\n- 'my_asks': cap at 5, highest-priority first. Each ask is verb-led ('Send the spec to Bob') in 8 words or fewer.\n- 'others_asks': same cap and shape.\n- 'decisions[]': 1 short sentence each. State the decision, not the discussion.\n- 'ambiguous_items[]': include ONLY items the reader needs to chase. Skip 'minor topics raised'.\n---\n"
+    },
+    {
+      "name": "brief_meeting/asd/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (autism) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: each facet is a literal commitment. Decode source idioms inside facets ('circle back' → 'reply later'). Quote the source 'asker' speaker in the 'label' field.\n- 'my_asks[].text' and 'others_asks[].text': quote the original speaker verbatim in parentheses when paraphrasing ('Send the spec (\"can you ping me the spec by Fri?\")').\n- 'decisions[]': state the decision and the speaker who made it. Don't infer consensus that wasn't stated.\n- 'ambiguous_items[]': flag any item where the transcript depends on tone or shared context not in the text. Reason 'verbal agreement implied but not stated' is a legitimate ambiguity.\n- No idioms in any text field ('touch base', 'circle back', 'loop in').\n---\n"
+    },
+    {
+      "name": "brief_meeting/audhd-fusion/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "adhd",
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (AuDHD) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: cap at 5; verb-led, literal, 8 words or fewer, no idioms. Label each entry as 'my_asks[i]' / 'decisions[i]'.\n- 'my_asks' / 'others_asks': cap at 5, verb-led, 8 words or fewer. Quote source verbatim in parentheses when paraphrasing.\n- 'decisions[]': 1 sentence each, name the speaker; don't infer unstated consensus.\n- 'ambiguous_items[]': flag tone-dependent items with reason 'verbal agreement implied but not stated'. Skip 'minor topics raised'.\n- No idioms anywhere.\n---\n"
+    },
+    {
+      "name": "brief_meeting/audhd-direct/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "audhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (AuDHD) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: cap at 5; verb-led, literal, 8 words or fewer, no idioms. Label each entry as 'my_asks[i]' / 'decisions[i]'.\n- 'my_asks' / 'others_asks': cap at 5, verb-led, 8 words or fewer. Quote source verbatim in parentheses when paraphrasing.\n- 'decisions[]': 1 sentence each, name the speaker; don't infer unstated consensus.\n- 'ambiguous_items[]': flag tone-dependent items with reason 'verbal agreement implied but not stated'. Skip 'minor topics raised'.\n- No idioms anywhere.\n---\n"
+    },
+    {
+      "name": "brief_meeting/ocd/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "ocd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (OCD) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: in 'action' facets, avoid 'must', 'urgent', 'ASAP', 'critical' unless the source used them. Prefer 'when you have a minute'. Don't amplify pressure beyond the transcript.\n- 'my_asks[]': don't add asks that weren't actually assigned to the reader. If the transcript is ambiguous about who owns an action, put it in 'ambiguous_items[]' instead.\n- 'ambiguous_items[]': distinguish 'unclear who owns this' from 'this needs follow-up'. Reason field should name which kind of ambiguity.\n- No 'must', 'urgent', 'critical' in 'my_asks[].text' unless the speaker used those words.\n- 'decisions[]': don't flag a decision as 'final' unless the transcript explicitly closes it.\n---\n"
+    },
+    {
+      "name": "brief_meeting/dyslexia/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "dyslexia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: each facet text max 15 words, one idea per facet, common words, no semicolons. Cap entries at 5.\n- All list fields: cap at 5, each item max 15 words.\n- Plain language. 'Bob will send the spec' not 'Bob will action distribution of the specification'.\n- 'decisions[]': one decision per item. Don't combine two decisions into one sentence with 'and'.\n- 'ambiguous_items[].reason': 1 short sentence; no semicolons.\n---\n"
+    },
+    {
+      "name": "brief_meeting/dyspraxia/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "dyspraxia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyspraxia) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: order entries by transcript appearance, not priority. Absolute dates inside facets. Never 'as above' — name the prior label.\n- 'my_asks' / 'others_asks': ordered by when they appear in the transcript, not by priority. Cap at 5.\n- Use absolute dates in 'text' fields when the transcript implies a deadline ('Wednesday 28 May' rather than 'next week').\n- 'decisions[]': name the topic explicitly each time. Don't write 'as discussed above' or 'the prior point'.\n- Group related items together — don't interleave asks from different topics.\n---\n"
+    },
+    {
+      "name": "brief_meeting/tourette/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "tourette"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (Tourette):\n- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.\n- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.\n- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.\n- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.\n- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field.\n---\n"
+    },
+    {
+      "name": "brief_meeting/other/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "other"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": "Please use kelvin not celsius.",
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (self-described):\n- Treat the notes below as a literal instruction set from the reader. Honour any 'please do' / 'please don't' requests.\n\nReader's own notes:\nPlease use kelvin not celsius.\n---\n"
+    },
+    {
+      "name": "brief_meeting/conflict3/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "adhd",
+        "dyslexia",
+        "ocd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: each facet text max 15 words, one idea per facet, common words, no semicolons. Cap entries at 5.\n- All list fields: cap at 5, each item max 15 words.\n- Plain language. 'Bob will send the spec' not 'Bob will action distribution of the specification'.\n- 'decisions[]': one decision per item. Don't combine two decisions into one sentence with 'and'.\n- 'ambiguous_items[].reason': 1 short sentence; no semicolons.\n\nReader preferences (OCD) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: in 'action' facets, avoid 'must', 'urgent', 'ASAP', 'critical' unless the source used them. Prefer 'when you have a minute'. Don't amplify pressure beyond the transcript.\n- 'my_asks[]': don't add asks that weren't actually assigned to the reader. If the transcript is ambiguous about who owns an action, put it in 'ambiguous_items[]' instead.\n- 'ambiguous_items[]': distinguish 'unclear who owns this' from 'this needs follow-up'. Reason field should name which kind of ambiguity.\n- No 'must', 'urgent', 'critical' in 'my_asks[].text' unless the speaker used those words.\n- 'decisions[]': don't flag a decision as 'final' unless the transcript explicitly closes it.\n\nReader preferences (ADHD) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: cap entries at 5; each facet verb-led and 8 words or fewer. Label each entry as 'my_asks[i]' / 'decisions[i]' so the reader can jump back to the verbatim quote.\n- 'my_asks': cap at 5, highest-priority first. Each ask is verb-led ('Send the spec to Bob') in 8 words or fewer.\n- 'others_asks': same cap and shape.\n- 'decisions[]': 1 short sentence each. State the decision, not the discussion.\n- 'ambiguous_items[]': include ONLY items the reader needs to chase. Skip 'minor topics raised'.\n\nWhen these preferences conflict (e.g. 'literal' vs 'soft'), prefer the more conservative reading: shorter, more concrete, less pressure.\n---\n"
+    },
+    {
+      "name": "brief_meeting/conflict-tourette-audhd/default",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "tourette",
+        "adhd",
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (Tourette):\n- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.\n- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.\n- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.\n- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.\n- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field.\n\nReader preferences (AuDHD) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: cap at 5; verb-led, literal, 8 words or fewer, no idioms. Label each entry as 'my_asks[i]' / 'decisions[i]'.\n- 'my_asks' / 'others_asks': cap at 5, verb-led, 8 words or fewer. Quote source verbatim in parentheses when paraphrasing.\n- 'decisions[]': 1 sentence each, name the speaker; don't infer unstated consensus.\n- 'ambiguous_items[]': flag tone-dependent items with reason 'verbal agreement implied but not stated'. Skip 'minor topics raised'.\n- No idioms anywhere.\n---\n"
+    },
+    {
+      "name": "translate_incoming/adhd/voice-on",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "adhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "voice_input_preferred": true,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (voice input):\n- The reader dictates and cannot cheaply hand-edit fiddly punctuation.\n- Keep any example, draft, or snippet as a single, copy-pasteable block — do not scatter editable fragments across the response.\n\nReader preferences (ADHD) — translate_incoming:\n- 'explicit_ask': 1 sentence, lead with the verb ('Send the spec by Friday' not 'The sender would like…').\n- 'likely_subtext': cap at 5 items, highest-confidence first.\n- 'recommended_next_action.action': imperative verb-phrase, 6 words or fewer. 'Reply with the spec link' not 'It might be worth replying'.\n- 'recommended_next_action.reason': 1 sentence. No throat-clearing.\n- 'recommended_next_action.draft_reply': if drafted, keep it to 1-2 short sentences.\n---\n"
+    },
+    {
+      "name": "check_tone/audhd-fusion/voice-on",
+      "tool": "check_tone",
+      "neurotypes": [
+        "adhd",
+        "asd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "voice_input_preferred": true,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (voice input):\n- The reader dictates and cannot cheaply hand-edit fiddly punctuation.\n- Keep any example, draft, or snippet as a single, copy-pasteable block — do not scatter editable fragments across the response.\n\nReader preferences (AuDHD) — check_tone:\n- 'flagged_phrases': cap at 5, highest-impact first. Each 'suggestion' is a concrete replacement string, not advice.\n- 'flagged_phrases[].reason': 1 sentence; name the mechanism ('imperative mood, no greeting') not just the impression ('blunt').\n- 'suggested_rewrite_hint': verb-led, literal, no idioms. 'Add a greeting; soften the ask by changing \"send it\" to \"could you send it\".'\n- 'axes': state scores literally — don't hedge with 'somewhat'.\n- 'baseline_delta': null when no prior baseline; don't guess.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/dyslexia/chunk-3",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "dyslexia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 3,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia) — rewrite_outgoing:\n- 'rewritten': short sentences, max 15 words each. Common words ('use' not 'utilise', 'help' not 'facilitate').\n- 'diff_summary.structural_changes': cap at 3; each item 1 short phrase, not a sentence.\n- 'diff_summary.tone_shift': 1 short sentence. Plain words.\n- Break compound sentences into two during the rewrite. No semicolons in 'rewritten'.\n---\n"
+    },
+    {
+      "name": "brief_meeting/dyspraxia/chunk-12",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "dyspraxia"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 12,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyspraxia) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: order entries by transcript appearance, not priority. Absolute dates inside facets. Never 'as above' — name the prior label.\n- 'my_asks' / 'others_asks': ordered by when they appear in the transcript, not by priority. Cap at 12.\n- Use absolute dates in 'text' fields when the transcript implies a deadline ('Wednesday 28 May' rather than 'next week').\n- 'decisions[]': name the topic explicitly each time. Don't write 'as discussed above' or 'the prior point'.\n- Group related items together — don't interleave asks from different topics.\n---\n"
+    },
+    {
+      "name": "translate_incoming/adhd/notes-footer",
+      "tool": "translate_incoming",
+      "neurotypes": [
+        "adhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": "Use kelvin not celsius.",
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (ADHD) — translate_incoming:\n- 'explicit_ask': 1 sentence, lead with the verb ('Send the spec by Friday' not 'The sender would like…').\n- 'likely_subtext': cap at 5 items, highest-confidence first.\n- 'recommended_next_action.action': imperative verb-phrase, 6 words or fewer. 'Reply with the spec link' not 'It might be worth replying'.\n- 'recommended_next_action.reason': 1 sentence. No throat-clearing.\n- 'recommended_next_action.draft_reply': if drafted, keep it to 1-2 short sentences.\n\nReader preferences (self-described):\n- Treat the notes below as a literal instruction set from the reader. Honour any 'please do' / 'please don't' requests.\n\nReader's own notes:\nUse kelvin not celsius.\n---\n"
+    },
+    {
+      "name": "check_tone/ocd/conventional-format",
+      "tool": "check_tone",
+      "neurotypes": [
+        "ocd"
+      ],
+      "output_format": "conventional",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: conventional — Brief context first, then the verdict.\n\nReader preferences (OCD) — check_tone:\n- 'flagged_phrases[].reason': avoid 'wrong', 'mistake', 'error'. Use 'reads as' or 'may land as'.\n- 'suggested_rewrite_hint': low-pressure framing. 'You may want to add a greeting' not 'You must add a greeting'.\n- Do not flag a phrase as a problem if the only issue is that it could theoretically be misread. Flag actual tone issues, not hypothetical ones.\n- 'axes.urgency': if the source genuinely is urgent (deadline in source text), don't downgrade the score to seem 'calmer'. Report the tone the message actually has.\n---\n"
+    },
+    {
+      "name": "brief_meeting/conflict3/bullet-first-voice",
+      "tool": "brief_meeting",
+      "neurotypes": [
+        "adhd",
+        "dyslexia",
+        "ocd"
+      ],
+      "output_format": "bullet_first",
+      "max_chunk_size": 5,
+      "voice_input_preferred": true,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: bullet_first — Lead with a short bullet list before any prose.\n\nReader preferences (voice input):\n- The reader dictates and cannot cheaply hand-edit fiddly punctuation.\n- Keep any example, draft, or snippet as a single, copy-pasteable block — do not scatter editable fragments across the response.\n\nReader preferences (dyslexia) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: each facet text max 15 words, one idea per facet, common words, no semicolons. Cap entries at 5.\n- All list fields: cap at 5, each item max 15 words.\n- Plain language. 'Bob will send the spec' not 'Bob will action distribution of the specification'.\n- 'decisions[]': one decision per item. Don't combine two decisions into one sentence with 'and'.\n- 'ambiguous_items[].reason': 1 short sentence; no semicolons.\n\nReader preferences (OCD) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: in 'action' facets, avoid 'must', 'urgent', 'ASAP', 'critical' unless the source used them. Prefer 'when you have a minute'. Don't amplify pressure beyond the transcript.\n- 'my_asks[]': don't add asks that weren't actually assigned to the reader. If the transcript is ambiguous about who owns an action, put it in 'ambiguous_items[]' instead.\n- 'ambiguous_items[]': distinguish 'unclear who owns this' from 'this needs follow-up'. Reason field should name which kind of ambiguity.\n- No 'must', 'urgent', 'critical' in 'my_asks[].text' unless the speaker used those words.\n- 'decisions[]': don't flag a decision as 'final' unless the transcript explicitly closes it.\n\nReader preferences (ADHD) — brief_meeting:\n- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.\n- `content_translation`: cap entries at 5; each facet verb-led and 8 words or fewer. Label each entry as 'my_asks[i]' / 'decisions[i]' so the reader can jump back to the verbatim quote.\n- 'my_asks': cap at 5, highest-priority first. Each ask is verb-led ('Send the spec to Bob') in 8 words or fewer.\n- 'others_asks': same cap and shape.\n- 'decisions[]': 1 short sentence each. State the decision, not the discussion.\n- 'ambiguous_items[]': include ONLY items the reader needs to chase. Skip 'minor topics raised'.\n\nWhen these preferences conflict (e.g. 'literal' vs 'soft'), prefer the more conservative reading: shorter, more concrete, less pressure.\n---\n"
+    },
+    {
+      "name": "rewrite_outgoing/asd+other/notes",
+      "tool": "rewrite_outgoing",
+      "neurotypes": [
+        "asd",
+        "other"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": "Prefer British spelling.",
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (autism) — rewrite_outgoing:\n- 'rewritten': preserve the literal ask. If the source says 'send the report by Friday', the rewrite still says that explicitly — don't bury it under softening.\n- 'rewritten': no idioms introduced. Banned in the rewrite: 'touch base', 'circle back', 'loop in', 'hop on', 'reach out', 'moving forward', 'low-hanging fruit'.\n- 'preserved_terms': include any technical term, name, or quoted phrase from the source that has a precise meaning.\n- 'diff_summary.tone_shift': name the mechanism ('added a greeting; replaced imperative with question form'), not the impression ('made it warmer').\n- 'diff_summary.warnings': flag if softening could obscure the deadline or quantity in the source.\n\nReader preferences (self-described):\n- Treat the notes below as a literal instruction set from the reader. Honour any 'please do' / 'please don't' requests.\n\nReader's own notes:\nPrefer British spelling.\n---\n"
+    },
+    {
+      "name": "no-tool/adhd/generic",
+      "neurotypes": [
+        "adhd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (ADHD):\n- Lead with the verdict in the first phrase of any free-text field. No throat-clearing.\n- Keep prose fields to 1-2 short sentences. Cut qualifiers ('perhaps', 'it seems that', 'arguably').\n- Cap any list you return at 5 items even if more would fit the schema. Rank by importance and stop.\n- No nested clauses. One idea per sentence.\n- If you would say 'however' or 'that said', just start a new sentence.\n- Concrete verbs over abstract nouns. 'Send the spec' not 'completion of the spec distribution'.\n---\n"
+    },
+    {
+      "name": "no-tool/conflict3/generic",
+      "neurotypes": [
+        "adhd",
+        "dyslexia",
+        "ocd"
+      ],
+      "output_format": "answer_first",
+      "max_chunk_size": 5,
+      "additional_notes": null,
+      "expected": "\n\n---\n## Reader-specific overrides (apply LAST, after the schema)\n\nThe reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.\n\nOutput shape: answer_first — Lead every prose field with the headline conclusion. Reasoning afterwards if at all.\n\nReader preferences (dyslexia):\n- Short sentences. Maximum 15 words per sentence. Break compound sentences into two.\n- Plain words. Replace 'paraphrased' with 'said plainly', 'ambiguous' with 'unclear', 'verbatim' with 'word-for-word', 'register' with 'tone', 'subtext' with 'what they really mean'.\n- One idea per sentence. No semicolons. No em-dashes inside sentences.\n- Cap any list at 5 items.\n- Free-text prose fields: 1 sentence where the schema permits 2-3.\n- Common words over rare ones. 'Use' not 'utilise'. 'Help' not 'facilitate'. 'About' not 'regarding'.\n\nReader preferences (OCD):\n- Low-pressure phrasing in any 'what to do' field. Avoid: 'urgent', 'must', 'immediately', 'right away', 'ASAP', 'critical', 'before it's too late', 'don't forget', 'make sure'.\n- Prefer: 'when you have a minute', 'no rush — when ready', 'consider', 'you may want to'.\n- Do not invent ambiguity or risk that is not in the source. If the message has no actionable issue, say so plainly ('nothing here needs an answer today').\n- When ranking items, prefer the lowest-pressure framing first.\n- Do not amplify time pressure. If the sender said 'soon', do not paraphrase as 'urgently'.\n- Never use the word 'wrong' about the user's draft. Use 'reads as' or 'may land as'.\n\nReader preferences (ADHD):\n- Lead with the verdict in the first phrase of any free-text field. No throat-clearing.\n- Keep prose fields to 1-2 short sentences. Cut qualifiers ('perhaps', 'it seems that', 'arguably').\n- Cap any list you return at 5 items even if more would fit the schema. Rank by importance and stop.\n- No nested clauses. One idea per sentence.\n- If you would say 'however' or 'that said', just start a new sentence.\n- Concrete verbs over abstract nouns. 'Send the spec' not 'completion of the spec distribution'.\n\nWhen these preferences conflict (e.g. 'literal' vs 'soft'), prefer the more conservative reading: shorter, more concrete, less pressure.\n---\n"
+    }
+  ]
+}

--- a/packages/core/src/neurotype-addenda.parity.test.ts
+++ b/packages/core/src/neurotype-addenda.parity.test.ts
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * neurotype-addenda.parity.test.ts — the TypeScript half of the cross-language
+ * parity gate (ADR 0012 binding rule 2).
+ *
+ * The TypeScript assembler is the SOURCE OF TRUTH. This test asserts that the
+ * TS assembler still produces the exact strings committed in
+ * `data/neurotype-addenda/parity-fixtures.json`. The Python half
+ * (`packages/mcp-translation/tests/test_addenda_parity.py`) asserts the Python
+ * assembler produces the SAME strings. If TS and Python ever diverge, exactly
+ * one of the two halves goes red — drift becomes a failed build, not a user
+ * report.
+ *
+ * The fixture inputs (`cases`) live in the committed JSON so both runtimes read
+ * byte-identical inputs. The `expected` strings are generated FROM this
+ * assembler: run `UPDATE_NEUROTYPE_PARITY_FIXTURES=1 pnpm --filter @neurodock/core test`
+ * to intentionally regenerate them after a deliberate artifact edit, then
+ * re-run the Python half to confirm it still matches.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import {
+  assembleNeurotypeAddendum,
+  neurotypeAddendaV1,
+  type AssembleNeurotypeAddendumOptions,
+} from "./neurotype-addenda.js";
+
+const FIXTURES_URL = new URL(
+  "../data/neurotype-addenda/parity-fixtures.json",
+  import.meta.url,
+);
+const FIXTURES_PATH = fileURLToPath(FIXTURES_URL);
+
+/**
+ * One parity case. Inputs use language-neutral snake_case keys so the
+ * TypeScript and Python parity tests read byte-identical fixture inputs.
+ */
+interface ParityCase {
+  readonly name: string;
+  readonly tool?: string;
+  readonly neurotypes: readonly string[];
+  readonly output_format?: string;
+  readonly max_chunk_size: number;
+  readonly voice_input_preferred?: boolean;
+  readonly additional_notes?: string | null;
+  expected: string;
+}
+
+interface ParityFixtures {
+  readonly description: string;
+  readonly artifact_version: string;
+  readonly cases: ParityCase[];
+}
+
+function optionsForCase(c: ParityCase): AssembleNeurotypeAddendumOptions {
+  const options: {
+    tool?: string;
+    neurotypes: readonly string[];
+    outputFormat?: string;
+    maxChunkSize: number;
+    voiceInputPreferred?: boolean;
+    additionalNotes?: string | null;
+  } = {
+    neurotypes: c.neurotypes,
+    maxChunkSize: c.max_chunk_size,
+  };
+  if (c.tool !== undefined) options.tool = c.tool;
+  if (c.output_format !== undefined) options.outputFormat = c.output_format;
+  if (c.voice_input_preferred !== undefined)
+    options.voiceInputPreferred = c.voice_input_preferred;
+  if (c.additional_notes !== undefined)
+    options.additionalNotes = c.additional_notes;
+  return options as AssembleNeurotypeAddendumOptions;
+}
+
+const fixtures = JSON.parse(
+  readFileSync(FIXTURES_PATH, "utf-8"),
+) as ParityFixtures;
+
+describe("neurotype-addenda cross-language parity (TS source of truth)", () => {
+  if (process.env.UPDATE_NEUROTYPE_PARITY_FIXTURES === "1") {
+    test("regenerate parity fixtures from the TS assembler", () => {
+      for (const c of fixtures.cases) {
+        c.expected = assembleNeurotypeAddendum(
+          neurotypeAddendaV1,
+          optionsForCase(c),
+        );
+      }
+      const regenerated: ParityFixtures = {
+        ...fixtures,
+        artifact_version: neurotypeAddendaV1.artifact_version,
+      };
+      writeFileSync(
+        FIXTURES_PATH,
+        JSON.stringify(regenerated, null, 2) + "\n",
+        "utf-8",
+      );
+      expect(fixtures.cases.length).toBeGreaterThan(0);
+    });
+    return;
+  }
+
+  test("the fixture corpus is non-trivial and pinned to the shipped artifact", () => {
+    // 59 cases exist; a floor of 55 catches accidental truncation of the corpus.
+    expect(fixtures.cases.length).toBeGreaterThanOrEqual(55);
+    expect(fixtures.artifact_version).toBe(neurotypeAddendaV1.artifact_version);
+  });
+
+  test.each(fixtures.cases.map((c) => [c.name, c] as const))(
+    "TS assembler reproduces fixture %s",
+    (_name, c) => {
+      expect(
+        assembleNeurotypeAddendum(neurotypeAddendaV1, optionsForCase(c)),
+      ).toBe(c.expected);
+    },
+  );
+});

--- a/packages/mcp-translation/CHANGELOG.md
+++ b/packages/mcp-translation/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to `neurodock-mcp-translation` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This package follows semantic versioning per .
 
+## [0.3.0] - 2026-06-19 — server-side per-neurotype prompt shaping (ADR 0012, R1 part B)
+
+Closes the R1 gap: per-neurotype prompt tailoring now reaches **every** MCP
+client (Claude Desktop, Cursor, Claude Code, any MCP host), not just the browser
+extension. The tailoring content stays the single source of truth in
+`@neurodock/core` (`data/neurotype-addenda/v1.json`); the server reads it through a
+Python assembler and injects the per-(tool × neurotype) addendum into the prompt it
+already returns. **No LLM SDK, no model call — ADR 0005 vendor-neutrality intact.**
+
+### Added
+
+- **Python assembler** (`addenda.py`): a direct port of core's
+  `assembleNeurotypeAddendum` (fusion → priority → per-tool block with generic
+  fallback → tourette/other specials → voice-input block → 3+ conflict footer →
+  `{max_chunk_size}`/`{notes}` interpolation → wrapper), proven byte-identical to
+  the TypeScript assembler by a cross-language parity test.
+- **Bundled artifact**: a byte-identical copy of `v1.json` ships inside the wheel
+  as package-data and is read via `importlib.resources` (no monorepo filesystem
+  dependency; the hosted-remote Worker bundles cleanly). An import-time existence
+  check degrades to a logged safe default if the artifact is ever missing — never
+  a crash.
+- **Profile reader** (`profile.py`): a trimmed port of mcp-chronometric's reader,
+  reading `identity.neurotypes`, `identity.additional_notes`,
+  `preferences.output_format`, `preferences.max_chunk_size`,
+  `preferences.voice_input_preferred`, with the same `NEURODOCK_PROFILE_PATH`
+  override, safe-default-on-absence, `profile_unreadable` log, and defensive
+  field parsing.
+- **`reader_context`** — one optional, additive input on all four tools
+  (`neurotypes?`, `output_format?`, `max_chunk_size?`, `voice_input_preferred?`,
+  `additional_notes?`), tolerant of unknown keys. Added to the Pydantic input
+  models and the four JSON schemas additively (a new `ReaderContext` `$def`).
+
+### Changed
+
+- Each tool appends the assembled addendum to `prompt_for_llm_refinement.content`
+  **after** the schema block (the extension's recency ordering). Resolution
+  precedence is field-by-field: `reader_context` per field, else the `profile.yaml`
+  read, else nothing. **Absent both, the content is byte-identical to 0.2.2's** —
+  a regression test asserts this. The output shape is unchanged (no new required
+  output field; ADR 0011 holds).
+- Adds a `pyyaml` runtime dependency (for the profile read).
+
+### Anti-drift control
+
+A committed parity fixture (`packages/core/data/neurotype-addenda/parity-fixtures.json`,
+59 cases across the four server tools × representative neurotype combos × voice
+on/off × chunk-size variants × notes present/absent) is generated from the
+TypeScript assembler (source of truth). A TS test guards the TS side; the Python
+test `tests/test_addenda_parity.py` asserts the Python assembler produces the same
+strings — so TS ≠ Python is a red CI build. A second guard
+(`tests/test_artifact_parity.py`) asserts the wheel's artifact copy stays
+byte-identical to core's source.
+
 ## [0.2.2] - 2026-06-11
 
 ### Changed

--- a/packages/mcp-translation/pyproject.toml
+++ b/packages/mcp-translation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neurodock-mcp-translation"
-version = "0.2.2"
+version = "0.3.0"
 description = "NeuroDock translation MCP server — deterministic baseline analysis plus structured LLM-refinement prompts for incoming/outgoing message decoding and meeting briefing."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -9,6 +9,7 @@ authors = [{ name = "NeuroDock contributors" }]
 dependencies = [
     "fastmcp>=3.3.0",
     "pydantic>=2.7",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]
@@ -33,9 +34,11 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-# `prompts/` is a subpackage (it has __init__.py), so `packages` already bundles
-# it AND its .prompt.md data files. A force-include of the same dir would add
-# every file twice and fail the wheel build on newer hatchling
+# `prompts/` and `data/` are subpackages (each has __init__.py), so `packages`
+# already bundles them AND their data files: the `.prompt.md` prompt sources and
+# the load-bearing `data/neurotype-addenda/v1.json` shaping artifact (ADR 0012),
+# which the addenda assembler loads at runtime. A force-include of the same dir
+# would add every file twice and fail the wheel build on newer hatchling
 # ("a second file is being added to the wheel archive at the same path").
 packages = ["src/neurodock_mcp_translation"]
 

--- a/packages/mcp-translation/schemas/brief_meeting.schema.json
+++ b/packages/mcp-translation/schemas/brief_meeting.schema.json
@@ -45,6 +45,10 @@
             "maxLength": 200
           },
           "examples": [["Priya", "Thomas", "Roberto"]]
+        },
+        "reader_context": {
+          "$ref": "#/$defs/ReaderContext",
+          "description": "Optional per-neurotype prompt-shaping context (ADR 0012). When present, the server appends a per-(tool x neurotype) addendum to prompt_for_llm_refinement.content AFTER the schema block; when absent, the server falls back to ~/.neurodock/profile.yaml, and when both are absent the prompt is byte-identical to the un-shaped baseline. Shapes ONLY the prompt text — the output shape is unchanged. The server makes no LLM call (ADR 0005)."
         }
       }
     },
@@ -251,6 +255,51 @@
     "privacy": "local-only-by-default. The server itself does not call any provider. Meeting transcripts are highly sensitive (third-party speakers, internal strategy); cloud-mode for brief_meeting SHOULD surface a stronger consent prompt than other tools — that is the extension's responsibility, not this server's."
   },
   "$defs": {
+    "ReaderContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional, additive per-neurotype prompt-shaping context (ADR 0012). Every field is optional; an absent field falls back to ~/.neurodock/profile.yaml, then to neutral absence. additionalProperties is true so a newer client may send extra keys without rejection. This input shapes prompt text only; it adds no field to the output and is never logged or stored.",
+      "properties": {
+        "neurotypes": {
+          "type": "array",
+          "maxItems": 8,
+          "items": {
+            "type": "string",
+            "enum": [
+              "adhd",
+              "asd",
+              "audhd",
+              "ocd",
+              "dyslexia",
+              "dyspraxia",
+              "tourette",
+              "other"
+            ]
+          },
+          "description": "Self-identified neurotypes. Self-ID is sufficient; never a diagnosis. adhd+asd (or explicit audhd) fuses to the AuDHD block."
+        },
+        "output_format": {
+          "type": "string",
+          "enum": ["answer_first", "conventional", "bullet_first"],
+          "description": "How the reader wants prose structured. Mirrors preferences.output_format."
+        },
+        "max_chunk_size": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Per-list item cap interpolated into the shaping blocks. Mirrors preferences.max_chunk_size."
+        },
+        "voice_input_preferred": {
+          "type": "boolean",
+          "description": "True when the reader predominantly dictates input; emits the cross-cutting voice-input block. Mirrors preferences.voice_input_preferred."
+        },
+        "additional_notes": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Free-form reader notes, surfaced verbatim in the self-described block. Mirrors identity.additional_notes."
+        }
+      }
+    },
     "TranslatedEntry": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/mcp-translation/schemas/check_tone.schema.json
+++ b/packages/mcp-translation/schemas/check_tone.schema.json
@@ -46,6 +46,10 @@
         "channel": {
           "$ref": "#/$defs/Channel",
           "description": "Optional channel hint. Influences register expectations (slack is informal, email is formal, github lean technical/blunt). When absent the prompt assumes 'generic'."
+        },
+        "reader_context": {
+          "$ref": "#/$defs/ReaderContext",
+          "description": "Optional per-neurotype prompt-shaping context (ADR 0012). When present, the server appends a per-(tool x neurotype) addendum to prompt_for_llm_refinement.content AFTER the schema block; when absent, the server falls back to ~/.neurodock/profile.yaml, and when both are absent the prompt is byte-identical to the un-shaped baseline. Shapes ONLY the prompt text — the output shape is unchanged. The server makes no LLM call (ADR 0005)."
         }
       }
     },
@@ -203,6 +207,51 @@
     "privacy": "local-only-by-default. The server itself does not call any provider. Cloud-mode is selected by the caller's MCP client and the user's profile; this server is provider-agnostic."
   },
   "$defs": {
+    "ReaderContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional, additive per-neurotype prompt-shaping context (ADR 0012). Every field is optional; an absent field falls back to ~/.neurodock/profile.yaml, then to neutral absence. additionalProperties is true so a newer client may send extra keys without rejection. This input shapes prompt text only; it adds no field to the output and is never logged or stored.",
+      "properties": {
+        "neurotypes": {
+          "type": "array",
+          "maxItems": 8,
+          "items": {
+            "type": "string",
+            "enum": [
+              "adhd",
+              "asd",
+              "audhd",
+              "ocd",
+              "dyslexia",
+              "dyspraxia",
+              "tourette",
+              "other"
+            ]
+          },
+          "description": "Self-identified neurotypes. Self-ID is sufficient; never a diagnosis. adhd+asd (or explicit audhd) fuses to the AuDHD block."
+        },
+        "output_format": {
+          "type": "string",
+          "enum": ["answer_first", "conventional", "bullet_first"],
+          "description": "How the reader wants prose structured. Mirrors preferences.output_format."
+        },
+        "max_chunk_size": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Per-list item cap interpolated into the shaping blocks. Mirrors preferences.max_chunk_size."
+        },
+        "voice_input_preferred": {
+          "type": "boolean",
+          "description": "True when the reader predominantly dictates input; emits the cross-cutting voice-input block. Mirrors preferences.voice_input_preferred."
+        },
+        "additional_notes": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Free-form reader notes, surfaced verbatim in the self-described block. Mirrors identity.additional_notes."
+        }
+      }
+    },
     "Channel": {
       "type": "string",
       "enum": [

--- a/packages/mcp-translation/schemas/rewrite_outgoing.schema.json
+++ b/packages/mcp-translation/schemas/rewrite_outgoing.schema.json
@@ -48,6 +48,10 @@
           "type": "boolean",
           "default": true,
           "description": "When true (default), the rewrite preserves the message's underlying ask or position even if surface phrasing softens. When false, the caller is explicitly allowing semantic shift; rarely needed and SHOULD be left at the default."
+        },
+        "reader_context": {
+          "$ref": "#/$defs/ReaderContext",
+          "description": "Optional per-neurotype prompt-shaping context (ADR 0012). When present, the server appends a per-(tool x neurotype) addendum to prompt_for_llm_refinement.content AFTER the schema block; when absent, the server falls back to ~/.neurodock/profile.yaml, and when both are absent the prompt is byte-identical to the un-shaped baseline. Shapes ONLY the prompt text — the output shape is unchanged. The server makes no LLM call (ADR 0005)."
         }
       }
     },
@@ -216,6 +220,51 @@
     "privacy": "local-only-by-default. The server itself does not call any provider. Cloud-mode is selected by the caller's MCP client and the user's profile."
   },
   "$defs": {
+    "ReaderContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional, additive per-neurotype prompt-shaping context (ADR 0012). Every field is optional; an absent field falls back to ~/.neurodock/profile.yaml, then to neutral absence. additionalProperties is true so a newer client may send extra keys without rejection. This input shapes prompt text only; it adds no field to the output and is never logged or stored.",
+      "properties": {
+        "neurotypes": {
+          "type": "array",
+          "maxItems": 8,
+          "items": {
+            "type": "string",
+            "enum": [
+              "adhd",
+              "asd",
+              "audhd",
+              "ocd",
+              "dyslexia",
+              "dyspraxia",
+              "tourette",
+              "other"
+            ]
+          },
+          "description": "Self-identified neurotypes. Self-ID is sufficient; never a diagnosis. adhd+asd (or explicit audhd) fuses to the AuDHD block."
+        },
+        "output_format": {
+          "type": "string",
+          "enum": ["answer_first", "conventional", "bullet_first"],
+          "description": "How the reader wants prose structured. Mirrors preferences.output_format."
+        },
+        "max_chunk_size": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Per-list item cap interpolated into the shaping blocks. Mirrors preferences.max_chunk_size."
+        },
+        "voice_input_preferred": {
+          "type": "boolean",
+          "description": "True when the reader predominantly dictates input; emits the cross-cutting voice-input block. Mirrors preferences.voice_input_preferred."
+        },
+        "additional_notes": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Free-form reader notes, surfaced verbatim in the self-described block. Mirrors identity.additional_notes."
+        }
+      }
+    },
     "Channel": {
       "type": "string",
       "enum": [

--- a/packages/mcp-translation/schemas/translate_incoming.schema.json
+++ b/packages/mcp-translation/schemas/translate_incoming.schema.json
@@ -46,6 +46,10 @@
           "type": "string",
           "description": "Optional BCP-47 language tag of the message. Defaults to 'en' when absent. Used to select a language pack when one is registered (e.g. 'en-IE' for Hiberno-English, 'de' for German directness norms, 'ja' for Japanese keigo).",
           "examples": ["en", "en-IE", "de", "ja"]
+        },
+        "reader_context": {
+          "$ref": "#/$defs/ReaderContext",
+          "description": "Optional per-neurotype prompt-shaping context (ADR 0012). When present, the server appends a per-(tool x neurotype) addendum to prompt_for_llm_refinement.content AFTER the schema block; when absent, the server falls back to ~/.neurodock/profile.yaml, and when both are absent the prompt is byte-identical to the un-shaped baseline. Shapes ONLY the prompt text — the output shape is unchanged. The server makes no LLM call (ADR 0005)."
         }
       }
     },
@@ -224,6 +228,51 @@
     "privacy": "local-only-by-default. The server itself does not call any provider. Cloud-mode is selected by the caller's MCP client and the user's profile; this server is provider-agnostic. PII redaction is upstream — the server analyses whatever text it is given and never logs it."
   },
   "$defs": {
+    "ReaderContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional, additive per-neurotype prompt-shaping context (ADR 0012). Every field is optional; an absent field falls back to ~/.neurodock/profile.yaml, then to neutral absence. additionalProperties is true so a newer client may send extra keys without rejection. This input shapes prompt text only; it adds no field to the output and is never logged or stored.",
+      "properties": {
+        "neurotypes": {
+          "type": "array",
+          "maxItems": 8,
+          "items": {
+            "type": "string",
+            "enum": [
+              "adhd",
+              "asd",
+              "audhd",
+              "ocd",
+              "dyslexia",
+              "dyspraxia",
+              "tourette",
+              "other"
+            ]
+          },
+          "description": "Self-identified neurotypes. Self-ID is sufficient; never a diagnosis. adhd+asd (or explicit audhd) fuses to the AuDHD block."
+        },
+        "output_format": {
+          "type": "string",
+          "enum": ["answer_first", "conventional", "bullet_first"],
+          "description": "How the reader wants prose structured. Mirrors preferences.output_format."
+        },
+        "max_chunk_size": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Per-list item cap interpolated into the shaping blocks. Mirrors preferences.max_chunk_size."
+        },
+        "voice_input_preferred": {
+          "type": "boolean",
+          "description": "True when the reader predominantly dictates input; emits the cross-cutting voice-input block. Mirrors preferences.voice_input_preferred."
+        },
+        "additional_notes": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Free-form reader notes, surfaced verbatim in the self-described block. Mirrors identity.additional_notes."
+        }
+      }
+    },
     "Channel": {
       "type": "string",
       "enum": [

--- a/packages/mcp-translation/src/neurodock_mcp_translation/addenda.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/addenda.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Python port of the shared, language-neutral neurotype-addenda assembler.
+
+This is the Python half of ADR 0012: the per-(tool x neurotype) prompt-shaping
+content lives once, as a language-neutral JSON artifact in ``@neurodock/core``
+(``data/neurotype-addenda/v1.json``). A byte-identical copy ships inside this
+package as package-data; :func:`assemble_neurotype_addendum` reproduces the
+TypeScript ``assembleNeurotypeAddendum`` exactly (fusion -> priority order ->
+per-tool block with generic fallback -> tourette/other specials -> voice-input
+cross-cutting block -> conflict footer -> ``{max_chunk_size}`` / ``{notes}``
+interpolation -> wrapper).
+
+Vendor-neutrality (ADR 0005): this module only assembles prompt *text*. It
+imports no LLM SDK and makes no model call.
+
+Defensiveness: if the bundled artifact is missing or unreadable, the loader logs
+``addenda_artifact_unavailable`` and serves a minimal safe-default artifact whose
+only behaviour is the "all-default => empty string" gate, so a packaging mishap
+degrades to today's un-shaped prompt rather than crashing a tool call.
+
+The cross-language parity test (``tests/test_addenda_parity.py``) and the
+divergence guard (``tests/test_artifact_parity.py``) are the authorities that the
+Python output equals the TypeScript output and that the bundled artifact has not
+drifted from core's source of truth.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any
+
+_LOG = logging.getLogger("neurodock_mcp_translation.addenda")
+
+# Relative resource path within ``neurodock_mcp_translation`` (a copy of core's
+# ``data/neurotype-addenda/v1.json``, kept byte-identical by the divergence guard).
+ARTIFACT_RESOURCE = "neurotype-addenda/v1.json"
+# Derived from this module's own package so a package rename can't silently break
+# artifact loading: ``neurodock_mcp_translation.addenda`` -> ``...mcp_translation.data``.
+_ARTIFACT_SUBPACKAGE = f"{__name__.rsplit('.', 1)[0]}.data"
+
+# A minimal artifact used only when the bundled file is missing/unreadable. It
+# carries no content blocks, so every neurotype renders nothing; with no header
+# either, the assembler's gate returns "" for the all-default case and the
+# wrapper for any non-default knob — never a crash, never fabricated content.
+_SAFE_DEFAULT_ARTIFACT: dict[str, Any] = {
+    "artifact_version": "0.0.0-safe-default",
+    "fusion": {"result": "audhd", "all_of": ["adhd", "asd"], "remove": ["adhd", "asd"]},
+    "priority": [],
+    "framing": {
+        "wrapper_prefix": "",
+        "wrapper_suffix": "",
+        "section_separator": "\n",
+        "block_line_separator": "\n",
+        "header": [],
+        "footer": [],
+        "conflict_footer_min_neurotypes": 3,
+        "conflict_footer": "",
+    },
+    "output_format": {
+        "prefix": "Output shape: ",
+        "separator": " — ",
+        "descriptions": {},
+        "default": "answer_first",
+    },
+    "voice_input": {"block": [""]},
+    "tourette": {"block": [""]},
+    "other": {"block": ["{notes}"]},
+    "generic": {},
+    "tools": {},
+}
+
+
+def load_artifact_text() -> str:
+    """Return the raw text of the bundled artifact.
+
+    Raises the underlying I/O error; callers that want the safe default go
+    through :func:`load_artifact`.
+    """
+
+    return (
+        resources.files(_ARTIFACT_SUBPACKAGE)
+        .joinpath(ARTIFACT_RESOURCE)
+        .read_text(encoding="utf-8")
+    )
+
+
+def load_artifact() -> dict[str, Any]:
+    """Load and parse the bundled neurotype-addenda artifact.
+
+    On any failure (missing file, unreadable, malformed JSON, wrong top-level
+    type) logs ``addenda_artifact_unavailable`` and returns the safe-default
+    artifact, so a packaging mishap degrades to an un-shaped prompt rather than
+    crashing.
+    """
+
+    try:
+        data = json.loads(load_artifact_text())
+    except (OSError, FileNotFoundError, ValueError, ModuleNotFoundError) as exc:
+        _LOG.warning(
+            "addenda_artifact_unavailable",
+            extra={
+                "event": "addenda_artifact_unavailable",
+                "error_type": type(exc).__name__,
+            },
+        )
+        # Deep-copy so a caller can never mutate the shared nested dicts of the
+        # module-level template (a shallow ``dict(...)`` would alias them).
+        return copy.deepcopy(_SAFE_DEFAULT_ARTIFACT)
+    if not isinstance(data, dict):
+        _LOG.warning(
+            "addenda_artifact_unavailable",
+            extra={"event": "addenda_artifact_unavailable", "error_type": "NotAMapping"},
+        )
+        return copy.deepcopy(_SAFE_DEFAULT_ARTIFACT)
+    return data
+
+
+# Import-time existence check: surface a missing artifact at module import, never
+# silently. The result is cached and reused by the tools.
+_ARTIFACT: dict[str, Any] = load_artifact()
+
+
+def default_artifact() -> dict[str, Any]:
+    """Return the import-time-cached artifact (or the safe default on failure)."""
+
+    return _ARTIFACT
+
+
+@dataclass(frozen=True)
+class AssembleOptions:
+    """Inputs to :func:`assemble_neurotype_addendum` (mirrors the TS options).
+
+    ``tool`` is the tool being shaped; when ``None`` every neurotype falls back
+    to its generic block. ``output_format`` defaults to the artifact's declared
+    default when ``None``.
+    """
+
+    neurotypes: list[str]
+    max_chunk_size: int
+    tool: str | None = None
+    output_format: str | None = None
+    voice_input_preferred: bool | None = None
+    additional_notes: str | None = None
+
+
+def _framing(artifact: dict[str, Any]) -> dict[str, Any]:
+    framing = artifact.get("framing")
+    return framing if isinstance(framing, dict) else {}
+
+
+def _str(value: Any, default: str = "") -> str:
+    return value if isinstance(value, str) else default
+
+
+def _block_lines(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [line for line in value if isinstance(line, str)]
+
+
+def _effective_neurotypes(artifact: dict[str, Any], input_types: list[str]) -> list[str]:
+    """Apply the fusion (AuDHD substitution) rule; preserve set-union order.
+
+    Mirrors the TS ``effectiveNeurotypes`` / ``Set`` semantics: insertion order
+    is first-seen order, the fusion ``result`` is appended at the end if newly
+    added, and ``remove`` members are dropped. Python ``dict`` preserves
+    insertion order, matching JS ``Set``.
+    """
+
+    fusion = artifact.get("fusion")
+    fusion = fusion if isinstance(fusion, dict) else {}
+    result = _str(fusion.get("result"))
+    all_of = fusion.get("all_of")
+    all_of = [n for n in all_of if isinstance(n, str)] if isinstance(all_of, list) else []
+    remove = fusion.get("remove")
+    remove = [n for n in remove if isinstance(n, str)] if isinstance(remove, list) else []
+
+    # Ordered set via dict keys (matches JS Set insertion-order iteration).
+    ordered: dict[str, None] = {}
+    for n in input_types:
+        ordered.setdefault(n, None)
+
+    has_result = result in ordered if result else False
+    has_all = bool(all_of) and all(n in ordered for n in all_of)
+    if has_result or has_all:
+        if result:
+            ordered.setdefault(result, None)
+        for n in remove:
+            ordered.pop(n, None)
+    return list(ordered.keys())
+
+
+def _order_by_priority(artifact: dict[str, Any], neurotypes: list[str]) -> list[str]:
+    """Sort by the artifact's priority ordering (recency: higher index = later).
+
+    Mirrors the TS ``orderByPriority``: ``priority.indexOf(x)`` returns ``-1``
+    for an unlisted neurotype, which sorts it first. Python's ``list.sort`` is
+    stable, matching ``Array.prototype.sort`` for equal keys.
+    """
+
+    priority = artifact.get("priority")
+    priority = [p for p in priority if isinstance(p, str)] if isinstance(priority, list) else []
+
+    def index_of(value: str) -> int:
+        try:
+            return priority.index(value)
+        except ValueError:
+            return -1
+
+    return sorted(neurotypes, key=index_of)
+
+
+def _interpolate_max_chunk_size(line: str, max_chunk_size: int) -> str:
+    return line.replace("{max_chunk_size}", str(max_chunk_size))
+
+
+def _render_output_format_block(artifact: dict[str, Any], fmt: str) -> str:
+    output_format = artifact.get("output_format")
+    output_format = output_format if isinstance(output_format, dict) else {}
+    descriptions = output_format.get("descriptions")
+    descriptions = descriptions if isinstance(descriptions, dict) else {}
+    description = _str(descriptions.get(fmt))
+    prefix = _str(output_format.get("prefix"))
+    separator = _str(output_format.get("separator"))
+    return prefix + fmt + separator + description
+
+
+def _render_other_block(artifact: dict[str, Any], notes: str) -> str:
+    other = artifact.get("other")
+    other = other if isinstance(other, dict) else {}
+    sep = _str(_framing(artifact).get("block_line_separator"), "\n")
+    lines = _block_lines(other.get("block"))
+    return sep.join(line.replace("{notes}", notes) for line in lines)
+
+
+def _render_neurotype_block(
+    artifact: dict[str, Any],
+    neurotype: str,
+    max_chunk_size: int,
+    additional_notes: str | None,
+    tool: str | None,
+) -> str:
+    """Render a single neurotype's block (mirrors the TS ``renderNeurotypeBlock``)."""
+
+    sep = _str(_framing(artifact).get("block_line_separator"), "\n")
+
+    if neurotype == "tourette":
+        tourette = artifact.get("tourette")
+        tourette = tourette if isinstance(tourette, dict) else {}
+        return sep.join(_block_lines(tourette.get("block")))
+
+    if neurotype == "other":
+        if additional_notes is None or len(additional_notes) == 0:
+            return ""
+        return _render_other_block(artifact, additional_notes)
+
+    block: list[str] | None = None
+    if tool is not None:
+        tools = artifact.get("tools")
+        matrix = tools.get(tool) if isinstance(tools, dict) else None
+        if isinstance(matrix, dict):
+            candidate = matrix.get(neurotype)
+            if isinstance(candidate, list):
+                block = _block_lines(candidate)
+    if block is None:
+        generic = artifact.get("generic")
+        candidate = generic.get(neurotype) if isinstance(generic, dict) else None
+        if isinstance(candidate, list):
+            block = _block_lines(candidate)
+    if block is None:
+        return ""
+    return sep.join(_interpolate_max_chunk_size(line, max_chunk_size) for line in block)
+
+
+def assemble_neurotype_addendum(artifact: dict[str, Any], options: AssembleOptions) -> str:
+    """Assemble the per-neurotype prompt addendum from the artifact.
+
+    Pure function: deterministic, no I/O, no mutation of inputs. A direct port of
+    the TypeScript ``assembleNeurotypeAddendum`` (proven byte-identical by
+    ``tests/test_addenda_parity.py``).
+
+    Returns ``""`` when there are no effective neurotypes, no notes, a default
+    output format, AND no voice-input hint — so the all-default case stays
+    byte-identical to an un-shaped prompt.
+    """
+
+    framing = _framing(artifact)
+    output_format = artifact.get("output_format")
+    output_format = output_format if isinstance(output_format, dict) else {}
+    default_format = _str(output_format.get("default"), "answer_first")
+    fmt = options.output_format if options.output_format is not None else default_format
+
+    effective = _effective_neurotypes(artifact, list(options.neurotypes))
+    additional_notes = options.additional_notes
+    has_notes = additional_notes is not None and len(additional_notes) > 0
+    has_non_default_format = fmt != default_format
+    wants_voice_input = options.voice_input_preferred is True
+
+    if (
+        len(effective) == 0
+        and not has_notes
+        and not has_non_default_format
+        and not wants_voice_input
+    ):
+        return ""
+
+    # The TS source joins SECTIONS with framing.section_separator and joins the
+    # lines WITHIN a block with framing.block_line_separator; keep that split.
+    section_sep = _str(framing.get("section_separator"), "\n")
+
+    sections: list[str] = []
+    for line in _block_lines(framing.get("header")):
+        sections.append(line)
+    sections.append(_render_output_format_block(artifact, fmt))
+
+    if wants_voice_input:
+        voice = artifact.get("voice_input")
+        voice = voice if isinstance(voice, dict) else {}
+        sep = _str(framing.get("block_line_separator"), "\n")
+        sections.append("")
+        sections.append(sep.join(_block_lines(voice.get("block"))))
+
+    ordered = _order_by_priority(artifact, effective)
+    for neurotype in ordered:
+        block = _render_neurotype_block(
+            artifact,
+            neurotype,
+            options.max_chunk_size,
+            additional_notes,
+            options.tool,
+        )
+        if len(block) > 0:
+            sections.append("")
+            sections.append(block)
+
+    if has_notes and "other" not in ordered:
+        sections.append("")
+        sections.append(_render_other_block(artifact, additional_notes or ""))
+
+    min_conflict = framing.get("conflict_footer_min_neurotypes")
+    min_conflict = min_conflict if isinstance(min_conflict, int) else 3
+    if len(ordered) >= min_conflict:
+        sections.append("")
+        sections.append(_str(framing.get("conflict_footer")))
+
+    for line in _block_lines(framing.get("footer")):
+        sections.append(line)
+
+    wrapper_prefix = _str(framing.get("wrapper_prefix"))
+    wrapper_suffix = _str(framing.get("wrapper_suffix"))
+    return wrapper_prefix + section_sep.join(sections) + wrapper_suffix
+
+
+# Cross-cutting helpers reused by the tools ----------------------------------
+
+# Default per-list item cap when neither reader_context nor the profile sets one.
+# Matches the canonical NeuroDock profile default (preferences.max_chunk_size).
+DEFAULT_MAX_CHUNK_SIZE = 7
+
+
+__all__ = [
+    "ARTIFACT_RESOURCE",
+    "DEFAULT_MAX_CHUNK_SIZE",
+    "AssembleOptions",
+    "assemble_neurotype_addendum",
+    "default_artifact",
+    "load_artifact",
+    "load_artifact_text",
+]

--- a/packages/mcp-translation/src/neurodock_mcp_translation/data/__init__.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/data/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Bundled, language-neutral package-data.
+
+Currently holds a byte-identical copy of ``@neurodock/core``'s
+``data/neurotype-addenda/v1.json`` (ADR 0012), kept in sync by the divergence
+guard in ``tests/test_artifact_parity.py``. The copy lives inside the wheel so
+the assembler never needs a filesystem read of the monorepo (this also makes the
+hosted-remote Worker bundling straightforward).
+"""

--- a/packages/mcp-translation/src/neurodock_mcp_translation/data/neurotype-addenda/v1.json
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/data/neurotype-addenda/v1.json
@@ -1,0 +1,389 @@
+{
+  "$schema": "https://schemas.neurodock.org/neurotype-addenda/v1/neurotype-addenda.schema.json",
+  "artifact_version": "1.0.0",
+  "description": "Language-neutral, enum-keyed prompt-shaping content for per-neurotype response tailoring. Single source of truth shared by the NeuroDock browser extension and (in a later PR) the mcp-translation server. This artifact is CONTENT, not schema shape (ADR 0011): it carries no field constraints, only the prose blocks that get appended to a model prompt. The only interpolation tokens are {max_chunk_size} and {notes}.",
+  "tokens": ["{max_chunk_size}", "{notes}"],
+  "fusion": {
+    "description": "AuDHD substitution rule. When the input set lists `audhd` directly, OR lists both `adhd` and `asd`, the fused `audhd` block is substituted: `audhd` is added and `adhd` + `asd` are removed. De-duplication is implied by set semantics.",
+    "result": "audhd",
+    "any_of": ["audhd"],
+    "all_of": ["adhd", "asd"],
+    "remove": ["adhd", "asd"]
+  },
+  "priority": [
+    "tourette",
+    "dyspraxia",
+    "dyslexia",
+    "ocd",
+    "asd",
+    "adhd",
+    "audhd",
+    "other"
+  ],
+  "framing": {
+    "wrapper_prefix": "\n\n",
+    "wrapper_suffix": "\n",
+    "section_separator": "\n",
+    "block_line_separator": "\n",
+    "header": [
+      "---",
+      "## Reader-specific overrides (apply LAST, after the schema)",
+      "",
+      "The reader has these preferences. Honor them inside the schema-shaped JSON you're about to write. If a preference conflicts with the schema, the schema wins — but apply every preference that's compatible.",
+      ""
+    ],
+    "footer": ["---"],
+    "conflict_footer_min_neurotypes": 3,
+    "conflict_footer": "When these preferences conflict (e.g. 'literal' vs 'soft'), prefer the more conservative reading: shorter, more concrete, less pressure."
+  },
+  "output_format": {
+    "prefix": "Output shape: ",
+    "separator": " — ",
+    "descriptions": {
+      "answer_first": "Lead every prose field with the headline conclusion. Reasoning afterwards if at all.",
+      "conventional": "Brief context first, then the verdict.",
+      "bullet_first": "Lead with a short bullet list before any prose."
+    },
+    "default": "answer_first"
+  },
+  "voice_input": {
+    "block": [
+      "Reader preferences (voice input):",
+      "- The reader dictates and cannot cheaply hand-edit fiddly punctuation.",
+      "- Keep any example, draft, or snippet as a single, copy-pasteable block — do not scatter editable fragments across the response."
+    ]
+  },
+  "tourette": {
+    "block": [
+      "Reader preferences (Tourette):",
+      "- Be concise. Lead with the answer first; keep prose to the fewest sentences that still carry the meaning.",
+      "- Cut throat-clearing, recap, and padding. Shorter responses hold the reader's attention for less time.",
+      "- Plain, low-pressure phrasing. Avoid manufactured urgency the source did not have.",
+      "- Keep a neutral register. Do not add reassurance, soothing language, or motivational pep — it is not wanted here.",
+      "- Do not comment on, notice, or reference the reader's behaviour, composure, or movement anywhere in any field."
+    ]
+  },
+  "other": {
+    "block": [
+      "Reader preferences (self-described):",
+      "- Treat the notes below as a literal instruction set from the reader. Honour any 'please do' / 'please don't' requests.",
+      "",
+      "Reader's own notes:",
+      "{notes}"
+    ]
+  },
+  "generic": {
+    "adhd": [
+      "Reader preferences (ADHD):",
+      "- Lead with the verdict in the first phrase of any free-text field. No throat-clearing.",
+      "- Keep prose fields to 1-2 short sentences. Cut qualifiers ('perhaps', 'it seems that', 'arguably').",
+      "- Cap any list you return at {max_chunk_size} items even if more would fit the schema. Rank by importance and stop.",
+      "- No nested clauses. One idea per sentence.",
+      "- If you would say 'however' or 'that said', just start a new sentence.",
+      "- Concrete verbs over abstract nouns. 'Send the spec' not 'completion of the spec distribution'."
+    ],
+    "asd": [
+      "Reader preferences (autism):",
+      "- State subtext literally. Do not soften with 'perhaps' or 'they might' if the evidence in the text is concrete enough to commit. Use 'the sender wants X' when the text supports it.",
+      "- No idioms. Banned phrases include: 'touch base', 'circle back', 'loop in', 'ping you', 'moving forward', 'low-hanging fruit', 'ducks in a row', 'reach out', 'hop on a call', 'in the loop', 'out of pocket'.",
+      "- If the input message contains an idiom, decode it literally in your prose ('ping you' -> 'send you a message').",
+      "- If a sentence depends on tone of voice or facial expression that text cannot carry, flag that explicitly ('text alone is ambiguous — could be sincere or sarcastic').",
+      "- Quote the source verbatim in parentheses when you paraphrase a decision or ask.",
+      "- No metaphor. No analogies. No 'kind of' / 'sort of' hedges."
+    ],
+    "audhd": [
+      "Reader preferences (AuDHD):",
+      "- Lead with the verdict in the first phrase. Literal first sentence, no throat-clearing.",
+      "- One idea per sentence; cap list fields at {max_chunk_size} items.",
+      "- No idioms. Banned phrases include: 'touch base', 'circle back', 'loop in', 'ping', 'moving forward', 'low-hanging fruit', 'reach out', 'hop on a call'.",
+      "- State subtext as commitments when the text supports it ('the sender wants X'), not as guesses ('they might want X') — but when the text is genuinely ambiguous, say so explicitly rather than picking one reading.",
+      "- Concrete verbs over abstract nouns; quote the source verbatim in parentheses when paraphrasing a decision.",
+      "- If a sentence depends on tone of voice the text cannot carry, flag that explicitly."
+    ],
+    "ocd": [
+      "Reader preferences (OCD):",
+      "- Low-pressure phrasing in any 'what to do' field. Avoid: 'urgent', 'must', 'immediately', 'right away', 'ASAP', 'critical', 'before it's too late', 'don't forget', 'make sure'.",
+      "- Prefer: 'when you have a minute', 'no rush — when ready', 'consider', 'you may want to'.",
+      "- Do not invent ambiguity or risk that is not in the source. If the message has no actionable issue, say so plainly ('nothing here needs an answer today').",
+      "- When ranking items, prefer the lowest-pressure framing first.",
+      "- Do not amplify time pressure. If the sender said 'soon', do not paraphrase as 'urgently'.",
+      "- Never use the word 'wrong' about the user's draft. Use 'reads as' or 'may land as'."
+    ],
+    "dyslexia": [
+      "Reader preferences (dyslexia):",
+      "- Short sentences. Maximum 15 words per sentence. Break compound sentences into two.",
+      "- Plain words. Replace 'paraphrased' with 'said plainly', 'ambiguous' with 'unclear', 'verbatim' with 'word-for-word', 'register' with 'tone', 'subtext' with 'what they really mean'.",
+      "- One idea per sentence. No semicolons. No em-dashes inside sentences.",
+      "- Cap any list at {max_chunk_size} items.",
+      "- Free-text prose fields: 1 sentence where the schema permits 2-3.",
+      "- Common words over rare ones. 'Use' not 'utilise'. 'Help' not 'facilitate'. 'About' not 'regarding'."
+    ],
+    "dyspraxia": [
+      "Reader preferences (dyspraxia):",
+      "- Minimise sequencing burden. Give absolute time markers ('Wednesday 28 May', 'by end of this week') rather than relative ones ('next sprint', 'soon').",
+      "- For meeting briefs: if an ask references another ask or decision, name it explicitly rather than saying 'the above' or 'as mentioned earlier'.",
+      "- For rewrites: prefer one continuous instruction over a numbered sequence when the action is single-step.",
+      "- Cap any list at {max_chunk_size} items.",
+      "- Group related items together; do not interleave asks from different topics."
+    ]
+  },
+  "tools": {
+    "describe_image": {
+      "adhd": [
+        "Reader preferences (ADHD) — describe_image:",
+        "- INVARIANT: Always populate `content_translation` with one entry per logical item in the image (numbered points, bullets, framework slots, chart series, document sections). Use null ONLY if the image is a decorative avatar/logo/icon with no readable instructional content.",
+        "- `content_translation`: cap entries at {max_chunk_size}. Each facet text is verb-led and 8 words or fewer ('Wait 5 seconds.', not 'It might be advisable to wait roughly five seconds'). Prefer `action` + `goal` facets — those are what the ADHD reader scans for.",
+        "- 'description': 1 sentence (metadata field). Lead with the inferred purpose in 4-7 words, then what's visually shown.",
+        "- 'key_elements': cap at {max_chunk_size}. Most prominent first. Stop ranking when you'd be reaching.",
+        "- 'inferred_purpose': a noun phrase, not a sentence. 'Promotional slide' not 'This is a promotional slide that…'.",
+        "- No qualifiers ('perhaps', 'appears to', 'seems'). Commit, or flag the uncertainty in 'accessibility_notes'.",
+        "- 'accessibility_notes': 1 sentence max. Skip if there is nothing assistive-tech-relevant to add."
+      ],
+      "asd": [
+        "Reader preferences (autism) — describe_image:",
+        "- INVARIANT: Always populate `content_translation` with one entry per logical item in the image (numbered points, bullets, framework slots, chart series, document sections). Use null ONLY if the image is a decorative avatar/logo/icon with no readable instructional content.",
+        "- `content_translation`: each facet text is a literal commitment, no idioms. Quote the source label verbatim in the 'label' field (e.g. label = '1. Emotional Control (The \"Pause\" Strategy)' exactly as the image renders it). Decode any source idiom literally inside facets ('touch base' → 'send a follow-up message').",
+        "- Build 'key_elements' (literal nouns + adjectives) BEFORE writing 'description'. The description then references those elements in visual-prominence order, without inferring meaning.",
+        "- 'inferred_purpose': if text + visual evidence doesn't make purpose unambiguous, write 'I can't tell from the image alone' and explain in 'accessibility_notes' what would resolve it (e.g. the surrounding page text).",
+        "- Banned soft hedges in 'description': 'kind of', 'sort of', 'looks like'. Use 'shows' or 'contains' instead.",
+        "- 'transcribed_text': exact verbatim. If partially obscured, transcribe what's visible and mark the cut with '[…]'.",
+        "- No metaphor anywhere. 'Speech-bubble shape' not 'a thought floating above her head'."
+      ],
+      "audhd": [
+        "Reader preferences (AuDHD) — describe_image:",
+        "- INVARIANT: Always populate `content_translation` with one entry per logical item in the image (numbered points, bullets, framework slots, chart series, document sections). Use null ONLY if the image is a decorative avatar/logo/icon with no readable instructional content.",
+        "- `content_translation`: cap entries at {max_chunk_size}; each facet is verb-led, literal, 8 words or fewer, no idioms. Quote source labels verbatim.",
+        "- 'description': 1 sentence (metadata). Lead with the literal subject in 4-7 words, then the inferred purpose.",
+        "- 'key_elements': cap at {max_chunk_size}. Literal nouns + adjectives, visual-prominence order, no meaning-inference.",
+        "- 'inferred_purpose': noun phrase, not sentence. When unambiguous, commit ('Promotional slide'). When not, write 'I can't tell from the image alone'.",
+        "- Banned: 'perhaps', 'appears to', 'kind of', 'sort of', 'looks like'. Use 'shows' or 'contains'; flag genuine uncertainty in 'accessibility_notes'.",
+        "- 'transcribed_text': exact verbatim. Mark obscured portions with '[…]'."
+      ],
+      "ocd": [
+        "Reader preferences (OCD) — describe_image:",
+        "- INVARIANT: Always populate `content_translation` with one entry per logical item in the image (numbered points, bullets, framework slots, chart series, document sections). Use null ONLY if the image is a decorative avatar/logo/icon with no readable instructional content.",
+        "- `content_translation`: in 'action' and 'rule' facets, avoid 'must', 'urgent', 'critical', 'don't forget' unless the source uses those exact words. Prefer 'consider', 'you may want to', 'when ready'. Don't amplify pressure beyond the source.",
+        "- In 'description' and 'inferred_purpose', don't say a slide is 'missing' something or 'incomplete' unless the image literally shows that. Slides are point-in-time snapshots; absence of an element is not a defect.",
+        "- Avoid 'error', 'wrong', 'broken', 'mistake', 'should' in 'description'.",
+        "- 'accessibility_notes': low-pressure framing. 'Consider adding alt-text describing X' not 'Alt-text is missing and must be added'.",
+        "- If text is obscured in 'transcribed_text', describe what's visible without amplifying the concern."
+      ],
+      "dyslexia": [
+        "Reader preferences (dyslexia) — describe_image:",
+        "- INVARIANT: Always populate `content_translation` with one entry per logical item in the image (numbered points, bullets, framework slots, chart series, document sections). Use null ONLY if the image is a decorative avatar/logo/icon with no readable instructional content.",
+        "- `content_translation`: each facet text max 15 words, one idea per facet, common words ('use' not 'utilise'), no semicolons. Cap entries at {max_chunk_size}.",
+        "- 'description': 1 sentence, max 15 words. Replace 'depicted' with 'shown', 'inferred' with 'guessed', 'transcribed' with 'copied'.",
+        "- 'key_elements': simple nouns, cap at {max_chunk_size}. 'Logo' not 'Brand identity element'. 'Person' not 'Individual subject'.",
+        "- 'inferred_purpose': 5 words or fewer. 'Promotional banner', 'Bar chart', 'UI screenshot'.",
+        "- One idea per sentence everywhere. No semicolons. No em-dashes inside sentences.",
+        "- 'accessibility_notes': plain words. 'Hard to read' not 'low legibility'."
+      ],
+      "dyspraxia": [
+        "Reader preferences (dyspraxia) — describe_image:",
+        "- INVARIANT: Always populate `content_translation` with one entry per logical item in the image (numbered points, bullets, framework slots, chart series, document sections). Use null ONLY if the image is a decorative avatar/logo/icon with no readable instructional content.",
+        "- `content_translation`: order entries top-to-bottom / left-to-right as they appear in the image, not by importance. Use absolute dates inside facets when the source uses any date ('Wednesday 28 May', not 'next week'). Never write 'as above' inside a facet — name the prior label.",
+        "- For sequenced visuals (numbered steps, flowcharts, timelines), describe in the order they appear in the image. Don't reorder by importance.",
+        "- 'key_elements': ordered top-to-bottom / left-to-right, not by prominence. Cap at {max_chunk_size}.",
+        "- 'description': name spatial relationships explicitly ('logo top-left, headline centre, CTA button bottom-right') rather than 'the above'.",
+        "- 'transcribed_text': preserve original order even if visually scattered; use line breaks between disjoint blocks."
+      ]
+    },
+    "translate_incoming": {
+      "adhd": [
+        "Reader preferences (ADHD) — translate_incoming:",
+        "- 'explicit_ask': 1 sentence, lead with the verb ('Send the spec by Friday' not 'The sender would like…').",
+        "- 'likely_subtext': cap at {max_chunk_size} items, highest-confidence first.",
+        "- 'recommended_next_action.action': imperative verb-phrase, 6 words or fewer. 'Reply with the spec link' not 'It might be worth replying'.",
+        "- 'recommended_next_action.reason': 1 sentence. No throat-clearing.",
+        "- 'recommended_next_action.draft_reply': if drafted, keep it to 1-2 short sentences."
+      ],
+      "asd": [
+        "Reader preferences (autism) — translate_incoming:",
+        "- 'likely_subtext[].text': state subtext as commitments when evidence supports it ('The sender wants X by Friday'). Use guesses ('they might want X') ONLY when the message is genuinely ambiguous.",
+        "- Decode any idiom in the source verbatim inside 'likely_subtext' (e.g. source 'circle back' -> subtext 'They will reply later'; source 'ping you' -> 'They will send a message').",
+        "- 'ambiguity.spans[]': when a sentence depends on tone of voice or facial expression text cannot carry, mark it ambiguous with reason 'text alone cannot disambiguate tone'.",
+        "- 'recommended_next_action.draft_reply': no idioms ('touch base', 'circle back', 'loop in', 'hop on a call', 'reach out'). Use literal verbs.",
+        "- 'recommended_next_action.reason': quote the source verbatim in parentheses when paraphrasing the ask."
+      ],
+      "audhd": [
+        "Reader preferences (AuDHD) — translate_incoming:",
+        "- 'explicit_ask': 1 sentence, lead with the verb. No throat-clearing.",
+        "- 'likely_subtext': cap at {max_chunk_size}; state as commitments when text supports it, as guesses only when genuinely ambiguous.",
+        "- Decode source idioms verbatim in 'likely_subtext' ('ping you' -> 'send you a message').",
+        "- 'recommended_next_action.action': imperative verb-phrase, 6 words or fewer, no idioms.",
+        "- 'recommended_next_action.draft_reply': 1-2 short sentences, literal verbs only.",
+        "- 'ambiguity.spans[]': flag tone-dependent sentences with reason 'text alone cannot disambiguate tone'."
+      ],
+      "ocd": [
+        "Reader preferences (OCD) — translate_incoming:",
+        "- 'recommended_next_action.action': low-pressure phrasing. Avoid 'urgent', 'must', 'immediately', 'ASAP', 'critical'. Prefer 'when you have a minute', 'consider', 'you may want to'.",
+        "- 'recommended_next_action.reason': do not amplify time pressure. If the source said 'soon', don't paraphrase as 'urgently'.",
+        "- 'ambiguity.detected': only flag ambiguity that's actually in the source. Don't invent ambiguity to be thorough.",
+        "- 'likely_subtext': if the message has no actionable issue, return an empty array and say so plainly in 'recommended_next_action.reason' ('nothing here needs an answer today').",
+        "- 'draft_reply': never say the reader's prior draft was 'wrong'. Use 'reads as' or 'may land as'."
+      ],
+      "dyslexia": [
+        "Reader preferences (dyslexia) — translate_incoming:",
+        "- 'explicit_ask': max 15 words. Plain language. 'They want X' not 'The sender is requesting X'.",
+        "- 'likely_subtext[].text': 1 sentence each, max 15 words. Cap list at {max_chunk_size}.",
+        "- Replace 'paraphrased' with 'said plainly', 'ambiguous' with 'unclear', 'verbatim' with 'word-for-word', 'subtext' with 'what they really mean'.",
+        "- 'recommended_next_action.reason': 1 short sentence. No semicolons. No em-dashes inside sentences.",
+        "- 'recommended_next_action.draft_reply': short sentences. Common words ('use' not 'utilise', 'about' not 'regarding')."
+      ],
+      "dyspraxia": [
+        "Reader preferences (dyspraxia) — translate_incoming:",
+        "- Use absolute dates in 'explicit_ask' and 'draft_reply' ('Wednesday 28 May', 'by end of this week') not relative ones ('next sprint', 'soon').",
+        "- 'likely_subtext': cap at {max_chunk_size}; if subtext references a prior thread message, name it explicitly rather than 'the above'.",
+        "- 'recommended_next_action.action': single-step where possible. If multi-step, number the steps inside 'draft_reply', not inside 'action'.",
+        "- Group related subtext items together — don't interleave 'they want X' with 'they're worried about Y'."
+      ]
+    },
+    "check_tone": {
+      "adhd": [
+        "Reader preferences (ADHD) — check_tone:",
+        "- 'flagged_phrases': cap at {max_chunk_size}, highest-impact first. Don't pad the list.",
+        "- 'flagged_phrases[].reason': 1 short sentence per entry.",
+        "- 'flagged_phrases[].suggestion': a concrete replacement, not advice. 'Replace with: \"by Friday\"' not 'Consider being more specific'.",
+        "- 'suggested_rewrite_hint': 1-2 sentences, verb-led. 'Tighten the opener, drop the hedges' not 'You might want to consider tightening…'."
+      ],
+      "asd": [
+        "Reader preferences (autism) — check_tone:",
+        "- 'axes': state the score literally — don't soften with 'somewhat' or 'a bit'. 0.2 means 'low'; say so.",
+        "- 'baseline_delta': when prior messages aren't available, return null rather than guessing a baseline.",
+        "- 'flagged_phrases[].reason': explain WHY the phrase reads as it does ('reads as terse because it has no greeting and uses imperative mood'), not just 'sounds blunt'.",
+        "- 'suggested_rewrite_hint': literal, no idioms ('touch base', 'soften the ask', 'warm up'). Use concrete edits ('add a greeting; replace \"send it\" with \"could you send it\"').",
+        "- 'flagged_phrases[].suggestion': exact replacement string, not a description of the change."
+      ],
+      "audhd": [
+        "Reader preferences (AuDHD) — check_tone:",
+        "- 'flagged_phrases': cap at {max_chunk_size}, highest-impact first. Each 'suggestion' is a concrete replacement string, not advice.",
+        "- 'flagged_phrases[].reason': 1 sentence; name the mechanism ('imperative mood, no greeting') not just the impression ('blunt').",
+        "- 'suggested_rewrite_hint': verb-led, literal, no idioms. 'Add a greeting; soften the ask by changing \"send it\" to \"could you send it\".'",
+        "- 'axes': state scores literally — don't hedge with 'somewhat'.",
+        "- 'baseline_delta': null when no prior baseline; don't guess."
+      ],
+      "ocd": [
+        "Reader preferences (OCD) — check_tone:",
+        "- 'flagged_phrases[].reason': avoid 'wrong', 'mistake', 'error'. Use 'reads as' or 'may land as'.",
+        "- 'suggested_rewrite_hint': low-pressure framing. 'You may want to add a greeting' not 'You must add a greeting'.",
+        "- Do not flag a phrase as a problem if the only issue is that it could theoretically be misread. Flag actual tone issues, not hypothetical ones.",
+        "- 'axes.urgency': if the source genuinely is urgent (deadline in source text), don't downgrade the score to seem 'calmer'. Report the tone the message actually has."
+      ],
+      "dyslexia": [
+        "Reader preferences (dyslexia) — check_tone:",
+        "- 'flagged_phrases': cap at {max_chunk_size}. Each 'reason' max 15 words.",
+        "- 'suggested_rewrite_hint': 1-2 short sentences. Plain words ('softer' not 'less assertive', 'shorter' not 'more concise').",
+        "- One idea per sentence in every prose field. No semicolons.",
+        "- 'flagged_phrases[].suggestion': a concrete replacement string, short."
+      ],
+      "dyspraxia": [
+        "Reader preferences (dyspraxia) — check_tone:",
+        "- 'flagged_phrases': {max_chunk_size} max, ordered as they appear in the source text (top to bottom) — not by severity.",
+        "- 'suggested_rewrite_hint': if multi-step, write as a single continuous instruction rather than a numbered sequence.",
+        "- Don't reference 'the above' or 'as mentioned'; name the specific phrase ('the opener \"hey\"', not 'the first issue')."
+      ]
+    },
+    "rewrite_outgoing": {
+      "adhd": [
+        "Reader preferences (ADHD) — rewrite_outgoing:",
+        "- 'rewritten': keep length within ~20% of the source. Don't pad to sound 'professional'.",
+        "- 'diff_summary.structural_changes': cap at {max_chunk_size}, highest-impact first.",
+        "- 'diff_summary.tone_shift': 1 short sentence describing the shift verb-first ('Softened the ask; kept the deadline').",
+        "- 'diff_summary.warnings': only include warnings the reader actually needs to act on. Skip 'minor style changes'."
+      ],
+      "asd": [
+        "Reader preferences (autism) — rewrite_outgoing:",
+        "- 'rewritten': preserve the literal ask. If the source says 'send the report by Friday', the rewrite still says that explicitly — don't bury it under softening.",
+        "- 'rewritten': no idioms introduced. Banned in the rewrite: 'touch base', 'circle back', 'loop in', 'hop on', 'reach out', 'moving forward', 'low-hanging fruit'.",
+        "- 'preserved_terms': include any technical term, name, or quoted phrase from the source that has a precise meaning.",
+        "- 'diff_summary.tone_shift': name the mechanism ('added a greeting; replaced imperative with question form'), not the impression ('made it warmer').",
+        "- 'diff_summary.warnings': flag if softening could obscure the deadline or quantity in the source."
+      ],
+      "audhd": [
+        "Reader preferences (AuDHD) — rewrite_outgoing:",
+        "- 'rewritten': keep within ~20% of source length; preserve the literal ask verbatim; no introduced idioms.",
+        "- 'diff_summary.structural_changes': cap at {max_chunk_size}; name mechanisms not impressions.",
+        "- 'diff_summary.tone_shift': 1 sentence, verb-led. 'Added greeting, replaced imperative with question form.'",
+        "- 'preserved_terms': include technical terms, names, and quoted source phrases.",
+        "- 'diff_summary.warnings': flag if softening would obscure the deadline or quantity."
+      ],
+      "ocd": [
+        "Reader preferences (OCD) — rewrite_outgoing:",
+        "- 'rewritten': avoid 'urgent', 'must', 'ASAP', 'critical', 'don't forget' unless the source uses them. Don't amplify pressure beyond the source.",
+        "- 'diff_summary.warnings': don't warn that the source was 'wrong' or 'aggressive'. Use 'the original could land as terse' instead.",
+        "- 'diff_summary.tone_shift': avoid 'fixed', 'corrected', 'cleaned up'. Use 'shifted toward' or 'reduced'.",
+        "- Don't add hedging the source didn't have unless the target_register asks for it."
+      ],
+      "dyslexia": [
+        "Reader preferences (dyslexia) — rewrite_outgoing:",
+        "- 'rewritten': short sentences, max 15 words each. Common words ('use' not 'utilise', 'help' not 'facilitate').",
+        "- 'diff_summary.structural_changes': cap at {max_chunk_size}; each item 1 short phrase, not a sentence.",
+        "- 'diff_summary.tone_shift': 1 short sentence. Plain words.",
+        "- Break compound sentences into two during the rewrite. No semicolons in 'rewritten'."
+      ],
+      "dyspraxia": [
+        "Reader preferences (dyspraxia) — rewrite_outgoing:",
+        "- 'rewritten': use absolute dates ('Wednesday 28 May'), not relative ones ('next week'), even if the source used relative.",
+        "- 'diff_summary.structural_changes': {max_chunk_size} max, ordered by where they appear in the rewrite (top to bottom).",
+        "- If the source asks for a sequence of actions, keep the sequence in source order in the rewrite; don't reorder for 'flow'.",
+        "- 'diff_summary.warnings': flag if the rewrite introduces a forward-reference ('as mentioned above') that the source didn't have."
+      ]
+    },
+    "brief_meeting": {
+      "adhd": [
+        "Reader preferences (ADHD) — brief_meeting:",
+        "- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.",
+        "- `content_translation`: cap entries at {max_chunk_size}; each facet verb-led and 8 words or fewer. Label each entry as 'my_asks[i]' / 'decisions[i]' so the reader can jump back to the verbatim quote.",
+        "- 'my_asks': cap at {max_chunk_size}, highest-priority first. Each ask is verb-led ('Send the spec to Bob') in 8 words or fewer.",
+        "- 'others_asks': same cap and shape.",
+        "- 'decisions[]': 1 short sentence each. State the decision, not the discussion.",
+        "- 'ambiguous_items[]': include ONLY items the reader needs to chase. Skip 'minor topics raised'."
+      ],
+      "asd": [
+        "Reader preferences (autism) — brief_meeting:",
+        "- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.",
+        "- `content_translation`: each facet is a literal commitment. Decode source idioms inside facets ('circle back' → 'reply later'). Quote the source 'asker' speaker in the 'label' field.",
+        "- 'my_asks[].text' and 'others_asks[].text': quote the original speaker verbatim in parentheses when paraphrasing ('Send the spec (\"can you ping me the spec by Fri?\")').",
+        "- 'decisions[]': state the decision and the speaker who made it. Don't infer consensus that wasn't stated.",
+        "- 'ambiguous_items[]': flag any item where the transcript depends on tone or shared context not in the text. Reason 'verbal agreement implied but not stated' is a legitimate ambiguity.",
+        "- No idioms in any text field ('touch base', 'circle back', 'loop in')."
+      ],
+      "audhd": [
+        "Reader preferences (AuDHD) — brief_meeting:",
+        "- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.",
+        "- `content_translation`: cap at {max_chunk_size}; verb-led, literal, 8 words or fewer, no idioms. Label each entry as 'my_asks[i]' / 'decisions[i]'.",
+        "- 'my_asks' / 'others_asks': cap at {max_chunk_size}, verb-led, 8 words or fewer. Quote source verbatim in parentheses when paraphrasing.",
+        "- 'decisions[]': 1 sentence each, name the speaker; don't infer unstated consensus.",
+        "- 'ambiguous_items[]': flag tone-dependent items with reason 'verbal agreement implied but not stated'. Skip 'minor topics raised'.",
+        "- No idioms anywhere."
+      ],
+      "ocd": [
+        "Reader preferences (OCD) — brief_meeting:",
+        "- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.",
+        "- `content_translation`: in 'action' facets, avoid 'must', 'urgent', 'ASAP', 'critical' unless the source used them. Prefer 'when you have a minute'. Don't amplify pressure beyond the transcript.",
+        "- 'my_asks[]': don't add asks that weren't actually assigned to the reader. If the transcript is ambiguous about who owns an action, put it in 'ambiguous_items[]' instead.",
+        "- 'ambiguous_items[]': distinguish 'unclear who owns this' from 'this needs follow-up'. Reason field should name which kind of ambiguity.",
+        "- No 'must', 'urgent', 'critical' in 'my_asks[].text' unless the speaker used those words.",
+        "- 'decisions[]': don't flag a decision as 'final' unless the transcript explicitly closes it."
+      ],
+      "dyslexia": [
+        "Reader preferences (dyslexia) — brief_meeting:",
+        "- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.",
+        "- `content_translation`: each facet text max 15 words, one idea per facet, common words, no semicolons. Cap entries at {max_chunk_size}.",
+        "- All list fields: cap at {max_chunk_size}, each item max 15 words.",
+        "- Plain language. 'Bob will send the spec' not 'Bob will action distribution of the specification'.",
+        "- 'decisions[]': one decision per item. Don't combine two decisions into one sentence with 'and'.",
+        "- 'ambiguous_items[].reason': 1 short sentence; no semicolons."
+      ],
+      "dyspraxia": [
+        "Reader preferences (dyspraxia) — brief_meeting:",
+        "- INVARIANT: Always populate `content_translation` with one entry per ask, decision, or actionable ambiguous item in the transcript. Use null ONLY if the meeting is chat-only and all four legacy sections (my_asks/others_asks/decisions/ambiguous_items) are empty.",
+        "- `content_translation`: order entries by transcript appearance, not priority. Absolute dates inside facets. Never 'as above' — name the prior label.",
+        "- 'my_asks' / 'others_asks': ordered by when they appear in the transcript, not by priority. Cap at {max_chunk_size}.",
+        "- Use absolute dates in 'text' fields when the transcript implies a deadline ('Wednesday 28 May' rather than 'next week').",
+        "- 'decisions[]': name the topic explicitly each time. Don't write 'as discussed above' or 'the prior point'.",
+        "- Group related items together — don't interleave asks from different topics."
+      ]
+    }
+  }
+}

--- a/packages/mcp-translation/src/neurodock_mcp_translation/profile.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/profile.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Trimmed loader for ``~/.neurodock/profile.yaml`` (translation subset).
+
+Ported from ``mcp-chronometric``'s proven profile reader (ADR 0012, R1 part B).
+The translation server reads only the five fields that feed the per-neurotype
+prompt-shaping addendum:
+
+* ``identity.neurotypes``            — the reader's self-identified neurotypes.
+* ``identity.additional_notes``      — free-form notes (the ``{notes}`` token).
+* ``preferences.output_format``      — answer_first / conventional / bullet_first.
+* ``preferences.max_chunk_size``     — per-list item cap (1..20).
+* ``preferences.voice_input_preferred`` — R5 cross-cutting voice-input hint.
+
+Discipline (identical to chronometric):
+
+* A ``NEURODOCK_PROFILE_PATH`` env var overrides the default path so tests stay
+  isolated from the user's filesystem.
+* A missing or unparseable file degrades to a neutral safe default; the
+  unparseable case logs ``profile_unreadable`` so the omission is visible.
+* Every field is defensively parsed; a malformed value drops to ``None`` (or an
+  empty list) rather than propagating.
+
+The server stores nothing and emits no telemetry — this loader only *reads*.
+Hosted-remote (``packages/remote``) has no home dir; ``load_profile`` simply
+returns the safe default there, and shaping rides on ``reader_context`` instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_LOG = logging.getLogger("neurodock_mcp_translation.profile")
+
+DEFAULT_PROFILE_PATH = Path.home() / ".neurodock" / "profile.yaml"
+PROFILE_PATH_ENV_VAR = "NEURODOCK_PROFILE_PATH"
+
+# Canonical enums (mirror ``@neurodock/core``'s profile.ts). Self-ID only.
+NEUROTYPES: frozenset[str] = frozenset(
+    {"adhd", "asd", "audhd", "ocd", "dyslexia", "dyspraxia", "tourette", "other"}
+)
+OUTPUT_FORMATS: frozenset[str] = frozenset({"answer_first", "conventional", "bullet_first"})
+
+# Profile-schema bounds for preferences.max_chunk_size.
+_CHUNK_MIN = 1
+_CHUNK_MAX = 20
+
+
+@dataclass(frozen=True)
+class TranslationProfile:
+    """Subset of the user's profile relevant to translation prompt-shaping.
+
+    All fields default to "absent"; an absent field means the corresponding
+    ``reader_context`` field (or neutral absence) decides, so a profile carrying
+    none of them yields today's un-shaped prompt.
+    """
+
+    neurotypes: list[str] = field(default_factory=list)
+    output_format: str | None = None
+    max_chunk_size: int | None = None
+    voice_input_preferred: bool | None = None
+    additional_notes: str | None = None
+
+
+def profile_path() -> Path:
+    override = os.environ.get(PROFILE_PATH_ENV_VAR)
+    if override:
+        return Path(override)
+    return DEFAULT_PROFILE_PATH
+
+
+def _safe_default() -> TranslationProfile:
+    return TranslationProfile()
+
+
+def _parse_neurotypes(value: Any) -> list[str]:
+    """Keep only recognised neurotype enum members, in declaration order."""
+
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value:
+        if isinstance(item, str) and item in NEUROTYPES:
+            out.append(item)
+    return out
+
+
+def _parse_output_format(value: Any) -> str | None:
+    if isinstance(value, str) and value in OUTPUT_FORMATS:
+        return value
+    return None
+
+
+def _parse_chunk_size(value: Any) -> int | None:
+    # bool is a subclass of int; reject it explicitly so True/False never leak.
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and _CHUNK_MIN <= value <= _CHUNK_MAX:
+        return value
+    return None
+
+
+def _parse_voice_input(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _parse_notes(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def load_profile() -> TranslationProfile:
+    """Load the translation subset of the user profile.
+
+    Returns a neutral safe default when the file is missing or unparseable. A
+    structured warning is logged in the unparseable case so the omission is
+    visible — never silent.
+    """
+
+    path = profile_path()
+    if not path.exists():
+        return _safe_default()
+
+    try:
+        with path.open("r", encoding="utf-8") as fp:
+            data = yaml.safe_load(fp) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        _LOG.warning(
+            "profile_unreadable",
+            extra={"event": "profile_unreadable", "error_type": type(exc).__name__},
+        )
+        return _safe_default()
+
+    if not isinstance(data, dict):
+        return _safe_default()
+
+    identity = data.get("identity")
+    identity = identity if isinstance(identity, dict) else {}
+    preferences = data.get("preferences")
+    preferences = preferences if isinstance(preferences, dict) else {}
+
+    return TranslationProfile(
+        neurotypes=_parse_neurotypes(identity.get("neurotypes")),
+        output_format=_parse_output_format(preferences.get("output_format")),
+        max_chunk_size=_parse_chunk_size(preferences.get("max_chunk_size")),
+        voice_input_preferred=_parse_voice_input(preferences.get("voice_input_preferred")),
+        additional_notes=_parse_notes(identity.get("additional_notes")),
+    )

--- a/packages/mcp-translation/src/neurodock_mcp_translation/server.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/server.py
@@ -101,6 +101,7 @@ def build_server() -> FastMCP[Any]:
         channel: str | None = None,
         thread_context: list[str] | None = None,
         target_language: str | None = None,
+        reader_context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "translate_incoming"})
         try:
@@ -109,6 +110,7 @@ def build_server() -> FastMCP[Any]:
                 channel=channel,  # type: ignore[arg-type]
                 thread_context=thread_context,
                 target_language=target_language,
+                reader_context=reader_context,  # type: ignore[arg-type]
             )
         except ValidationError as exc:
             raise _ToolError(_validation_error_code(exc, "TEXT_REQUIRED"), str(exc)) from exc
@@ -136,6 +138,7 @@ def build_server() -> FastMCP[Any]:
         baseline_messages: list[str] | None = None,
         target_register: TargetRegister | None = None,
         channel: str | None = None,
+        reader_context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "check_tone"})
         try:
@@ -144,6 +147,7 @@ def build_server() -> FastMCP[Any]:
                 baseline_messages=baseline_messages,
                 target_register=target_register,
                 channel=channel,  # type: ignore[arg-type]
+                reader_context=reader_context,  # type: ignore[arg-type]
             )
         except ValidationError as exc:
             raise _ToolError(_validation_error_code(exc, "TEXT_REQUIRED"), str(exc)) from exc
@@ -172,6 +176,7 @@ def build_server() -> FastMCP[Any]:
         preserve_terms: list[str] | None = None,
         channel: str | None = None,
         preserve_intent: bool = True,
+        reader_context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "rewrite_outgoing"})
         try:
@@ -181,6 +186,7 @@ def build_server() -> FastMCP[Any]:
                 preserve_terms=preserve_terms,
                 channel=channel,  # type: ignore[arg-type]
                 preserve_intent=preserve_intent,
+                reader_context=reader_context,  # type: ignore[arg-type]
             )
         except ValidationError as exc:
             raise _ToolError(
@@ -209,6 +215,7 @@ def build_server() -> FastMCP[Any]:
         me: str,
         project: str | None = None,
         speakers: list[str] | None = None,
+        reader_context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         _LOG.info("tool_invoked", extra={"tool": "brief_meeting"})
         try:
@@ -217,6 +224,7 @@ def build_server() -> FastMCP[Any]:
                 me=me,
                 project=project,
                 speakers=speakers,
+                reader_context=reader_context,  # type: ignore[arg-type]
             )
         except ValidationError as exc:
             raise _ToolError(_validation_error_code(exc, "TRANSCRIPT_REQUIRED"), str(exc)) from exc

--- a/packages/mcp-translation/src/neurodock_mcp_translation/shaping.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/shaping.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Resolve reader preferences and assemble the per-neurotype prompt addendum.
+
+This is the single seam (ADR 0012) that every tool calls after it renders its
+base prompt. It resolves the shaping inputs with field-by-field precedence —
+``reader_context`` per field, else the ``profile.yaml`` read, else neutral
+absence — assembles the addendum via the pure :func:`assemble_neurotype_addendum`
+port, and appends it to the existing prompt content AFTER the schema block (the
+extension's recency ordering).
+
+When neither ``reader_context`` nor the profile contributes anything that would
+shape the prompt, the assembler returns ``""`` and the content is byte-identical
+to today's un-shaped prompt.
+
+Vendor-neutrality (ADR 0005): pure string assembly. No LLM SDK, no model call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from neurodock_mcp_translation.addenda import (
+    DEFAULT_MAX_CHUNK_SIZE,
+    AssembleOptions,
+    assemble_neurotype_addendum,
+    default_artifact,
+)
+from neurodock_mcp_translation.profile import TranslationProfile, load_profile
+from neurodock_mcp_translation.types import ReaderContext
+
+
+def _resolve(
+    reader_context: ReaderContext | None,
+    profile: TranslationProfile,
+) -> AssembleOptions | None:
+    """Merge ``reader_context`` over the profile, field-by-field.
+
+    Returns ``None`` when neither source supplies any shaping signal, so the
+    caller can skip assembly entirely and keep the prompt byte-identical.
+    """
+
+    ctx_neurotypes = reader_context.neurotypes if reader_context is not None else None
+    neurotypes = ctx_neurotypes if ctx_neurotypes is not None else profile.neurotypes
+
+    ctx_format = reader_context.output_format if reader_context is not None else None
+    output_format = ctx_format if ctx_format is not None else profile.output_format
+
+    ctx_chunk = reader_context.max_chunk_size if reader_context is not None else None
+    max_chunk_size = ctx_chunk if ctx_chunk is not None else profile.max_chunk_size
+
+    ctx_voice = reader_context.voice_input_preferred if reader_context is not None else None
+    voice = ctx_voice if ctx_voice is not None else profile.voice_input_preferred
+
+    ctx_notes = reader_context.additional_notes if reader_context is not None else None
+    notes = ctx_notes if ctx_notes is not None else profile.additional_notes
+
+    # No shaping signal at all -> let the caller short-circuit. An explicit
+    # voice-input opt-out (``False``) emits no instruction (the assembler gates
+    # on ``is True``), so it is NOT a signal — only ``True`` is.
+    has_signal = (
+        bool(neurotypes)
+        or output_format is not None
+        or voice is True
+        or (notes is not None and len(notes) > 0)
+    )
+    if not has_signal:
+        return None
+
+    return AssembleOptions(
+        neurotypes=list(neurotypes),
+        max_chunk_size=(max_chunk_size if max_chunk_size is not None else DEFAULT_MAX_CHUNK_SIZE),
+        output_format=output_format,
+        voice_input_preferred=voice,
+        additional_notes=notes,
+    )
+
+
+def build_addendum(tool: str, reader_context: ReaderContext | None) -> str:
+    """Assemble the per-neurotype addendum for ``tool``.
+
+    Resolves ``reader_context`` over the ``profile.yaml`` fallback, then runs the
+    pure assembler. Returns ``""`` when nothing shapes the prompt (the
+    byte-identical baseline case).
+    """
+
+    profile = load_profile()
+    options = _resolve(reader_context, profile)
+    if options is None:
+        return ""
+    # ``replace`` carries every existing field forward, so a future
+    # AssembleOptions field can never be silently dropped here.
+    shaped = replace(options, tool=tool)
+    return assemble_neurotype_addendum(default_artifact(), shaped)
+
+
+def apply_shaping(content: str, tool: str, reader_context: ReaderContext | None) -> str:
+    """Append the assembled addendum to ``content`` AFTER the schema block.
+
+    Matches the extension's recency ordering: the schema is concrete and small
+    models anchor on it, so the per-neurotype overrides are placed last to be the
+    final instruction the model reads. When the addendum is ``""`` (nothing to
+    shape), ``content`` is returned unchanged — byte-identical to today.
+    """
+
+    return content + build_addendum(tool, reader_context)

--- a/packages/mcp-translation/src/neurodock_mcp_translation/tools/brief_meeting.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/tools/brief_meeting.py
@@ -30,6 +30,7 @@ from neurodock_mcp_translation.heuristics.quote_extractor import (
     find_ambiguities as find_transcript_ambiguities,
 )
 from neurodock_mcp_translation.prompts import render_prompt
+from neurodock_mcp_translation.shaping import apply_shaping
 from neurodock_mcp_translation.types import (
     AmbiguousItem,
     AmbiguousReason,
@@ -230,6 +231,10 @@ def brief_meeting(payload: BriefMeetingInput) -> BriefMeetingEnvelope:
         speakers=speakers_block,
         deterministic_summary=_deterministic_summary(my_asks, others_asks, decisions, ambiguous),
     )
+
+    # ADR 0012: append the per-neurotype addendum AFTER the schema block. Absent
+    # both reader_context and a profile, this is a no-op (byte-identical content).
+    prompt_content = apply_shaping(prompt_content, "brief_meeting", payload.reader_context)
 
     return BriefMeetingEnvelope(
         deterministic_analysis=analysis,

--- a/packages/mcp-translation/src/neurodock_mcp_translation/tools/check_tone.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/tools/check_tone.py
@@ -18,6 +18,7 @@ from neurodock_mcp_translation.heuristics.tone import (
     target_axes,
 )
 from neurodock_mcp_translation.prompts import render_prompt
+from neurodock_mcp_translation.shaping import apply_shaping
 from neurodock_mcp_translation.types import (
     BaselineDelta,
     CheckToneAnalysis,
@@ -197,6 +198,10 @@ def check_tone(payload: CheckToneInput) -> CheckToneEnvelope:
             axes_score, axes_target_score, baseline_delta, flagged_hits
         ),
     )
+
+    # ADR 0012: append the per-neurotype addendum AFTER the schema block. Absent
+    # both reader_context and a profile, this is a no-op (byte-identical content).
+    prompt_content = apply_shaping(prompt_content, "check_tone", payload.reader_context)
 
     return CheckToneEnvelope(
         deterministic_analysis=analysis,

--- a/packages/mcp-translation/src/neurodock_mcp_translation/tools/rewrite_outgoing.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/tools/rewrite_outgoing.py
@@ -13,6 +13,7 @@ rewrite while keeping the same preservation contract.
 from __future__ import annotations
 
 from neurodock_mcp_translation.prompts import render_prompt
+from neurodock_mcp_translation.shaping import apply_shaping
 from neurodock_mcp_translation.types import (
     DiffSummary,
     ModelProvenance,
@@ -171,6 +172,10 @@ def rewrite_outgoing(payload: RewriteOutgoingInput) -> RewriteOutgoingEnvelope:
             f"unpreserved_terms = {unpreserved!r}"
         ),
     )
+
+    # ADR 0012: append the per-neurotype addendum AFTER the schema block. Absent
+    # both reader_context and a profile, this is a no-op (byte-identical content).
+    prompt_content = apply_shaping(prompt_content, "rewrite_outgoing", payload.reader_context)
 
     return RewriteOutgoingEnvelope(
         deterministic_analysis=analysis,

--- a/packages/mcp-translation/src/neurodock_mcp_translation/tools/translate_incoming.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/tools/translate_incoming.py
@@ -13,6 +13,7 @@ from neurodock_mcp_translation.heuristics.ambiguity import (
     find_ambiguities,
 )
 from neurodock_mcp_translation.prompts import render_prompt
+from neurodock_mcp_translation.shaping import apply_shaping
 from neurodock_mcp_translation.types import (
     AmbiguityReport,
     AmbiguitySpan,
@@ -214,6 +215,10 @@ def translate_incoming(payload: TranslateIncomingInput) -> TranslateIncomingEnve
         thread_context=thread_context_lines,
         deterministic_summary=_deterministic_summary(explicit_ask, subtext, ambiguities, action),
     )
+
+    # ADR 0012: append the per-neurotype addendum AFTER the schema block. Absent
+    # both reader_context and a profile, this is a no-op (byte-identical content).
+    prompt_content = apply_shaping(prompt_content, "translate_incoming", payload.reader_context)
 
     return TranslateIncomingEnvelope(
         deterministic_analysis=analysis,

--- a/packages/mcp-translation/src/neurodock_mcp_translation/types.py
+++ b/packages/mcp-translation/src/neurodock_mcp_translation/types.py
@@ -11,9 +11,9 @@ caller's MCP client MAY execute against its configured LLM.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # ---------------------------------------------------------------------------
 # Shared enums (mirror schemas)
@@ -56,6 +56,21 @@ NextActionEnum = Literal[
 ToneAxisName = Literal["directness", "warmth", "urgency"]
 
 ProvenanceMode = Literal["local", "cloud", "unknown"]
+
+# R1 (ADR 0012): self-identified neurotypes + output-format enums. Mirrors
+# @neurodock/core's profile.ts. Self-ID only; never a diagnosis.
+Neurotype = Literal[
+    "adhd",
+    "asd",
+    "audhd",
+    "ocd",
+    "dyslexia",
+    "dyspraxia",
+    "tourette",
+    "other",
+]
+
+OutputFormat = Literal["answer_first", "conventional", "bullet_first"]
 
 AmbiguousReason = Literal[
     "vague_timeline",
@@ -107,6 +122,41 @@ class PromptForLLMRefinement(_Base):
 
 
 # ---------------------------------------------------------------------------
+# reader_context (ADR 0012): optional, additive, per-neurotype prompt shaping.
+
+
+class ReaderContext(BaseModel):
+    """Optional reader preferences that shape the LLM-refinement prompt.
+
+    Additive and absence-tolerant (ADR 0012 binding rule 3). Every field is
+    optional; an absent field falls back to the ``profile.yaml`` read, and then
+    to neutral absence. ``extra="ignore"`` keeps the input forward-compatible:
+    an unknown key from a newer client is tolerated, never rejected.
+
+    This carries NO output contract — it only feeds prompt assembly. The tool
+    output shape is unchanged.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    neurotypes: list[Neurotype] | None = Field(default=None, max_length=8)
+    output_format: OutputFormat | None = None
+    max_chunk_size: int | None = Field(default=None, ge=1, le=20)
+    voice_input_preferred: bool | None = None
+    additional_notes: str | None = Field(default=None, max_length=2000)
+
+    @field_validator("max_chunk_size", mode="before")
+    @classmethod
+    def _reject_bool_max_chunk_size(cls, value: Any) -> Any:
+        # ``bool`` is an ``int`` subclass; Pydantic would otherwise coerce
+        # ``True``/``False`` to ``1``/``0``. Reject it explicitly so the wire
+        # contract stays a true integer and matches profile.py:_parse_chunk_size.
+        if isinstance(value, bool):
+            raise ValueError("max_chunk_size must be an integer, not a boolean")
+        return value
+
+
+# ---------------------------------------------------------------------------
 # translate_incoming
 
 
@@ -115,6 +165,7 @@ class TranslateIncomingInput(_Base):
     channel: Channel | None = None
     thread_context: list[str] | None = Field(default=None, max_length=20)
     target_language: str | None = None
+    reader_context: ReaderContext | None = None
 
 
 class SubtextHypothesis(_Base):
@@ -164,6 +215,7 @@ class CheckToneInput(_Base):
     baseline_messages: list[str] | None = Field(default=None, max_length=20)
     target_register: TargetRegister | None = None
     channel: Channel | None = None
+    reader_context: ReaderContext | None = None
 
 
 class ToneAxes(_Base):
@@ -213,6 +265,7 @@ class RewriteOutgoingInput(_Base):
     preserve_terms: list[str] | None = Field(default=None, max_length=100)
     channel: Channel | None = None
     preserve_intent: bool = True
+    reader_context: ReaderContext | None = None
 
 
 class DiffSummary(_Base):
@@ -245,6 +298,7 @@ class BriefMeetingInput(_Base):
     me: str = Field(min_length=1, max_length=200)
     project: str | None = Field(default=None, min_length=1, max_length=200)
     speakers: list[str] | None = Field(default=None, max_length=30)
+    reader_context: ReaderContext | None = None
 
 
 class QuotedSpan(_Base):

--- a/packages/mcp-translation/tests/test_addenda.py
+++ b/packages/mcp-translation/tests/test_addenda.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Unit tests for the Python neurotype-addenda assembler.
+
+These mirror the TypeScript assembler's unit tests
+(``packages/core/src/neurotype-addenda.test.ts``) so the two ports stay aligned
+at the unit level. The byte-for-byte cross-language guarantee is proven
+separately by ``test_addenda_parity.py``.
+"""
+
+from __future__ import annotations
+
+from neurodock_mcp_translation.addenda import (
+    AssembleOptions,
+    assemble_neurotype_addendum,
+    load_artifact,
+)
+
+
+def _assemble(
+    *,
+    neurotypes: list[str] | None = None,
+    output_format: str | None = "answer_first",
+    max_chunk_size: int = 5,
+    tool: str | None = None,
+    voice_input_preferred: bool | None = None,
+    additional_notes: str | None = None,
+) -> str:
+    options = AssembleOptions(
+        neurotypes=neurotypes if neurotypes is not None else [],
+        max_chunk_size=max_chunk_size,
+        tool=tool,
+        output_format=output_format,
+        voice_input_preferred=voice_input_preferred,
+        additional_notes=additional_notes,
+    )
+    return assemble_neurotype_addendum(load_artifact(), options)
+
+
+# ---------------------------------------------------------------------------
+# Empty gate
+
+
+def test_empty_all_default_returns_empty_string() -> None:
+    assert _assemble() == ""
+
+
+def test_non_default_output_format_alone_triggers_addendum() -> None:
+    assert _assemble(output_format="bullet_first") != ""
+
+
+def test_voice_input_flag_alone_triggers_addendum() -> None:
+    assert _assemble(voice_input_preferred=True) != ""
+
+
+def test_notes_alone_trigger_addendum() -> None:
+    assert _assemble(additional_notes="always quote the source") != ""
+
+
+# ---------------------------------------------------------------------------
+# Fusion (AuDHD)
+
+
+def test_adhd_plus_asd_fuse_to_audhd() -> None:
+    out = _assemble(neurotypes=["adhd", "asd"])
+    assert "Reader preferences (AuDHD)" in out
+    assert "Reader preferences (ADHD)" not in out
+    assert "Reader preferences (autism)" not in out
+
+
+def test_audhd_declared_directly_uses_audhd_block() -> None:
+    out = _assemble(neurotypes=["audhd"])
+    assert "Reader preferences (AuDHD)" in out
+
+
+def test_tourette_plus_audhd_keeps_tourette_drops_raw_adhd() -> None:
+    out = _assemble(neurotypes=["tourette", "adhd", "asd"])
+    assert "Reader preferences (Tourette)" in out
+    assert "Reader preferences (AuDHD)" in out
+    assert "Reader preferences (ADHD):" not in out
+
+
+# ---------------------------------------------------------------------------
+# Priority ordering
+
+
+def test_dyslexia_is_placed_before_adhd() -> None:
+    out = _assemble(neurotypes=["adhd", "dyslexia"])
+    dyslexia_idx = out.index("Reader preferences (dyslexia)")
+    adhd_idx = out.index("Reader preferences (ADHD)")
+    assert dyslexia_idx < adhd_idx
+
+
+def test_other_is_always_last() -> None:
+    out = _assemble(
+        neurotypes=["adhd", "other"],
+        additional_notes="Always start with 'Heads up:'",
+    )
+    adhd_idx = out.index("Reader preferences (ADHD)")
+    other_idx = out.index("Reader preferences (self-described)")
+    assert adhd_idx < other_idx
+
+
+# ---------------------------------------------------------------------------
+# Per-tool vs generic fallback
+
+
+def test_per_tool_block_used_when_tool_supplied() -> None:
+    out = _assemble(neurotypes=["adhd"], tool="translate_incoming")
+    assert "Reader preferences (ADHD) — translate_incoming:" in out
+
+
+def test_generic_fallback_used_without_tool() -> None:
+    out = _assemble(neurotypes=["adhd"])
+    assert "Reader preferences (ADHD):" in out
+    assert "first phrase" in out
+
+
+def test_unknown_tool_falls_back_to_generic() -> None:
+    out = _assemble(neurotypes=["adhd"], tool="no_such_tool")
+    assert "Reader preferences (ADHD):" in out
+
+
+# ---------------------------------------------------------------------------
+# Token interpolation
+
+
+def test_max_chunk_size_interpolated_into_generic_block() -> None:
+    out = _assemble(neurotypes=["adhd"], max_chunk_size=3)
+    assert "Cap any list you return at 3 items" in out
+    assert "{max_chunk_size}" not in out
+
+
+def test_max_chunk_size_interpolated_into_per_tool_block() -> None:
+    out = _assemble(neurotypes=["adhd"], tool="translate_incoming", max_chunk_size=7)
+    assert "'likely_subtext': cap at 7 items" in out
+    assert "{max_chunk_size}" not in out
+
+
+def test_notes_interpolated_into_self_described_block() -> None:
+    out = _assemble(
+        neurotypes=["other"],
+        additional_notes="Please always quote the source verbatim.",
+    )
+    assert "Reader preferences (self-described)" in out
+    assert "Please always quote the source verbatim." in out
+    assert "{notes}" not in out
+
+
+def test_notes_appended_as_footer_when_other_not_selected() -> None:
+    out = _assemble(
+        neurotypes=["adhd"],
+        additional_notes="Use kelvin not celsius for temperatures.",
+    )
+    assert "Reader preferences (ADHD)" in out
+    assert "Use kelvin not celsius for temperatures." in out
+
+
+# ---------------------------------------------------------------------------
+# Voice-input gating
+
+
+def test_voice_input_emits_single_block_instruction() -> None:
+    out = _assemble(output_format="bullet_first", voice_input_preferred=True)
+    assert "single, copy-pasteable block" in out
+
+
+def test_voice_input_not_emitted_when_false() -> None:
+    out = _assemble(neurotypes=["adhd"], voice_input_preferred=False)
+    assert "Reader preferences (ADHD)" in out
+    assert "copy-pasteable block" not in out
+
+
+def test_voice_input_not_emitted_when_unset() -> None:
+    out = _assemble(neurotypes=["adhd"])
+    assert "copy-pasteable block" not in out
+
+
+# ---------------------------------------------------------------------------
+# Conflict footer
+
+
+def test_conflict_footer_appended_for_three_plus() -> None:
+    out = _assemble(neurotypes=["adhd", "dyslexia", "ocd"])
+    assert "prefer the more conservative reading: shorter, more concrete" in out
+
+
+def test_conflict_footer_not_appended_for_fewer_than_three() -> None:
+    out = _assemble(neurotypes=["adhd", "dyslexia"])
+    assert "prefer the more conservative reading" not in out
+
+
+# ---------------------------------------------------------------------------
+# Purity / defensiveness
+
+
+def test_does_not_mutate_input_neurotypes() -> None:
+    neurotypes = ["adhd", "asd"]
+    _assemble(neurotypes=neurotypes)
+    assert neurotypes == ["adhd", "asd"]
+
+
+def test_unknown_neurotype_is_skipped_not_crashed() -> None:
+    # A neurotype with no block (and not tourette/other) renders nothing.
+    out = _assemble(neurotypes=["adhd", "not_a_real_type"])
+    assert "Reader preferences (ADHD)" in out

--- a/packages/mcp-translation/tests/test_addenda_parity.py
+++ b/packages/mcp-translation/tests/test_addenda_parity.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""The Python half of the cross-language parity gate (ADR 0012 binding rule 2).
+
+The TypeScript assembler is the source of truth; it generates the ``expected``
+strings in ``packages/core/data/neurotype-addenda/parity-fixtures.json`` and the
+TS test (``packages/core/src/neurotype-addenda.parity.test.ts``) guards them. THIS
+test asserts the Python assembler reproduces those same strings byte-for-byte.
+
+If TS and Python ever diverge, exactly one of the two halves goes red — drift is
+a failed build, not a user report. The TS test runs in the TypeScript CI job; this
+test runs in the Python/eval CI job, so the cross-product is checked on both
+toolchains.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from neurodock_mcp_translation.addenda import (
+    AssembleOptions,
+    assemble_neurotype_addendum,
+    load_artifact,
+)
+
+# packages/mcp-translation/tests/ -> repo root is parents[3].
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_FIXTURES = _REPO_ROOT / "packages" / "core" / "data" / "neurotype-addenda" / "parity-fixtures.json"
+
+
+def _load_fixtures() -> dict[str, Any]:
+    data: dict[str, Any] = json.loads(_FIXTURES.read_text(encoding="utf-8"))
+    return data
+
+
+_FIXTURE_DATA = _load_fixtures()
+_CASES: list[dict[str, Any]] = _FIXTURE_DATA["cases"]
+
+
+def _options_for(case: dict[str, Any]) -> AssembleOptions:
+    # Fixture inputs use language-neutral snake_case keys (same as the Python
+    # options field names), so this maps one-to-one.
+    return AssembleOptions(
+        tool=case.get("tool"),
+        neurotypes=list(case["neurotypes"]),
+        output_format=case.get("output_format"),
+        max_chunk_size=case["max_chunk_size"],
+        voice_input_preferred=case.get("voice_input_preferred"),
+        additional_notes=case.get("additional_notes"),
+    )
+
+
+def test_fixture_corpus_is_non_trivial_and_pinned() -> None:
+    artifact = load_artifact()
+    # 59 cases exist; a floor of 55 catches accidental truncation of the corpus.
+    assert len(_CASES) >= 55
+    assert _FIXTURE_DATA["artifact_version"] == artifact["artifact_version"]
+
+
+@pytest.mark.parametrize("case", _CASES, ids=[c["name"] for c in _CASES])
+def test_python_assembler_matches_ts_fixture(case: dict[str, Any]) -> None:
+    artifact = load_artifact()
+    produced = assemble_neurotype_addendum(artifact, _options_for(case))
+    assert produced == case["expected"], (
+        f"Python assembler diverged from the TS source of truth for case {case['name']!r}."
+    )

--- a/packages/mcp-translation/tests/test_artifact_parity.py
+++ b/packages/mcp-translation/tests/test_artifact_parity.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Divergence guard: the artifact copy shipped inside the Python wheel MUST be
+byte-identical to the canonical artifact in ``@neurodock/core``.
+
+The Python assembler reads a copy of ``v1.json`` bundled as package-data (so the
+wheel and the hosted-remote Worker both have it without a filesystem read of the
+monorepo). That copy is only safe if it never drifts from core's source of
+truth. This test fails the build the moment the two diverge — e.g. someone edits
+core's artifact but forgets to re-copy it into the package.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from neurodock_mcp_translation.addenda import (
+    ARTIFACT_RESOURCE,
+    load_artifact,
+    load_artifact_text,
+)
+
+# packages/mcp-translation/tests/ -> repo root is parents[3].
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CORE_ARTIFACT = _REPO_ROOT / "packages" / "core" / "data" / "neurotype-addenda" / "v1.json"
+
+
+def test_packaged_artifact_is_byte_identical_to_core() -> None:
+    core_text = _CORE_ARTIFACT.read_text(encoding="utf-8")
+    packaged_text = load_artifact_text()
+    assert packaged_text == core_text, (
+        "The artifact copy bundled in mcp-translation has drifted from "
+        f"{_CORE_ARTIFACT}. Re-copy core's v1.json into "
+        f"src/neurodock_mcp_translation/data/{ARTIFACT_RESOURCE}."
+    )
+
+
+def test_packaged_artifact_parses_to_same_object_as_core() -> None:
+    core_obj = json.loads(_CORE_ARTIFACT.read_text(encoding="utf-8"))
+    assert load_artifact() == core_obj

--- a/packages/mcp-translation/tests/test_no_llm_sdk.py
+++ b/packages/mcp-translation/tests/test_no_llm_sdk.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Structural guard (ADR 0005 §2): the server imports NO LLM vendor SDK.
+
+This is the substrate-server doctrine made executable. The translation server
+only ASSEMBLES prompt text (now including the ADR 0012 neurotype addendum); it
+must never gain a model client. A grep over the package source keeps that
+boundary honest as the package grows.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "neurodock_mcp_translation"
+
+# Match an actual import statement for a vendor LLM SDK, not a mention in a
+# docstring/comment (those legitimately name the SDKs we DON'T import).
+_FORBIDDEN = re.compile(
+    r"^\s*(?:import|from)\s+"
+    r"(anthropic|openai|ollama|cohere|google\.generativeai|google\.genai|mistralai|groq)\b",
+    re.MULTILINE,
+)
+
+
+def test_server_source_imports_no_llm_sdk() -> None:
+    offenders: list[str] = []
+    for path in _SRC.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        if _FORBIDDEN.search(text):
+            offenders.append(str(path))
+    assert not offenders, f"LLM SDK import found in: {offenders}"

--- a/packages/mcp-translation/tests/test_profile.py
+++ b/packages/mcp-translation/tests/test_profile.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""Tests for the trimmed profile reader (ported from mcp-chronometric)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from neurodock_mcp_translation.profile import (
+    PROFILE_PATH_ENV_VAR,
+    TranslationProfile,
+    load_profile,
+    profile_path,
+)
+
+
+def _write_profile(tmp_path: Path, body: str, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "profile.yaml"
+    path.write_text(body, encoding="utf-8")
+    monkeypatch.setenv(PROFILE_PATH_ENV_VAR, str(path))
+    return path
+
+
+def test_missing_file_returns_safe_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(PROFILE_PATH_ENV_VAR, str(tmp_path / "nope.yaml"))
+    profile = load_profile()
+    assert profile == TranslationProfile()
+    assert profile.neurotypes == []
+    assert profile.output_format is None
+    assert profile.max_chunk_size is None
+    assert profile.voice_input_preferred is None
+    assert profile.additional_notes is None
+
+
+def test_env_var_overrides_default_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(PROFILE_PATH_ENV_VAR, "/tmp/elsewhere/profile.yaml")
+    assert profile_path() == Path("/tmp/elsewhere/profile.yaml")
+
+
+def test_reads_all_relevant_fields(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_profile(
+        tmp_path,
+        """
+identity:
+  display_name: Thomas
+  neurotypes: [adhd, asd]
+  additional_notes: Please quote the source.
+preferences:
+  output_format: bullet_first
+  max_chunk_size: 3
+  voice_input_preferred: true
+""",
+        monkeypatch,
+    )
+    profile = load_profile()
+    assert profile.neurotypes == ["adhd", "asd"]
+    assert profile.additional_notes == "Please quote the source."
+    assert profile.output_format == "bullet_first"
+    assert profile.max_chunk_size == 3
+    assert profile.voice_input_preferred is True
+
+
+def test_unparseable_yaml_returns_safe_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_profile(tmp_path, "identity: [unbalanced\n", monkeypatch)
+    assert load_profile() == TranslationProfile()
+
+
+def test_unknown_neurotypes_are_dropped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_profile(
+        tmp_path,
+        """
+identity:
+  neurotypes: [adhd, not_a_type, "", 5, asd]
+""",
+        monkeypatch,
+    )
+    profile = load_profile()
+    assert profile.neurotypes == ["adhd", "asd"]
+
+
+def test_unknown_output_format_is_ignored(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_profile(
+        tmp_path,
+        """
+preferences:
+  output_format: rainbow
+""",
+        monkeypatch,
+    )
+    assert load_profile().output_format is None
+
+
+def test_out_of_range_chunk_size_is_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_profile(
+        tmp_path,
+        """
+preferences:
+  max_chunk_size: 99
+""",
+        monkeypatch,
+    )
+    assert load_profile().max_chunk_size is None
+
+
+def test_chunk_size_bool_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_profile(
+        tmp_path,
+        """
+preferences:
+  max_chunk_size: true
+""",
+        monkeypatch,
+    )
+    assert load_profile().max_chunk_size is None
+
+
+def test_voice_input_non_bool_is_ignored(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_profile(
+        tmp_path,
+        """
+preferences:
+  voice_input_preferred: "yes"
+""",
+        monkeypatch,
+    )
+    assert load_profile().voice_input_preferred is None
+
+
+def test_non_mapping_top_level_returns_safe_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_profile(tmp_path, "- just\n- a\n- list\n", monkeypatch)
+    assert load_profile() == TranslationProfile()
+
+
+def test_empty_additional_notes_becomes_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_profile(
+        tmp_path,
+        """
+identity:
+  additional_notes: ""
+""",
+        monkeypatch,
+    )
+    assert load_profile().additional_notes is None

--- a/packages/mcp-translation/tests/test_reader_context.py
+++ b/packages/mcp-translation/tests/test_reader_context.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""``reader_context`` wiring + the byte-identical-when-absent regression gate.
+
+ADR 0012 binding rule 3: the server gains exactly one optional, additive input.
+ADR 0012 decision-driver 5: absence is identity — a call with no reader_context
+against a profile with no neurotypes must yield a BYTE-IDENTICAL prompt to
+today's.
+
+These tests drive the four tools through their Python entrypoints (not the MCP
+boundary) so they can compare ``prompt_for_llm_refinement.content`` directly
+against the un-shaped baseline.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from neurodock_mcp_translation.profile import PROFILE_PATH_ENV_VAR
+from neurodock_mcp_translation.tools.brief_meeting import brief_meeting
+from neurodock_mcp_translation.tools.check_tone import check_tone
+from neurodock_mcp_translation.tools.rewrite_outgoing import rewrite_outgoing
+from neurodock_mcp_translation.tools.translate_incoming import translate_incoming
+from neurodock_mcp_translation.types import (
+    BriefMeetingInput,
+    CheckToneInput,
+    ReaderContext,
+    RewriteOutgoingInput,
+    TranslateIncomingInput,
+)
+from pydantic import ValidationError
+
+_ADDENDUM_HEADER = "## Reader-specific overrides (apply LAST, after the schema)"
+
+_TRANSCRIPT = (
+    "Priya: Let's get the rollout date on the calendar. Thomas, can you own the migration script?\n"
+    "Thomas: Yes — I'll have it ready by Wednesday.\n"
+    "Roberto: We should also think about rollback. Can someone draft the runbook?\n"
+    "Priya: We can circle back on that next week.\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_profile_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the profile reader at a nonexistent path for every test here.
+
+    This isolates the suite from any real ``~/.neurodock/profile.yaml`` so the
+    "absent both" baseline is genuinely absent.
+    """
+
+    monkeypatch.setenv(PROFILE_PATH_ENV_VAR, str(tmp_path / "absent.yaml"))
+
+
+def _write_profile(tmp_path: Path, body: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "profile.yaml"
+    path.write_text(body, encoding="utf-8")
+    monkeypatch.setenv(PROFILE_PATH_ENV_VAR, str(path))
+
+
+# ---------------------------------------------------------------------------
+# max_chunk_size type discipline: bool must NOT coerce to int
+
+
+def test_reader_context_rejects_boolean_max_chunk_size() -> None:
+    """``max_chunk_size: True`` must be rejected, not silently coerced to 1.
+
+    ``bool`` is an ``int`` subclass, so Pydantic would otherwise accept ``True``
+    as ``1``. That contradicts ``profile.py:_parse_chunk_size`` (which rejects
+    bools) and the documented integer contract. A ``@field_validator`` raises so
+    the boundary fails fast.
+    """
+
+    with pytest.raises(ValidationError):
+        ReaderContext.model_validate({"max_chunk_size": True})
+    with pytest.raises(ValidationError):
+        ReaderContext.model_validate({"max_chunk_size": False})
+
+
+def test_reader_context_still_accepts_integer_max_chunk_size() -> None:
+    ctx = ReaderContext.model_validate({"max_chunk_size": 3})
+    assert ctx.max_chunk_size == 3
+
+
+# ---------------------------------------------------------------------------
+# Byte-identical-when-absent regression (the load-bearing gate)
+
+
+def test_translate_incoming_byte_identical_when_absent() -> None:
+    payload = TranslateIncomingInput(text="Hey — can we revisit the rollout timeline?")
+    with_field = translate_incoming(payload)
+    # Re-run with reader_context explicitly None to prove None == absent.
+    assert (
+        with_field.prompt_for_llm_refinement.content
+        == translate_incoming(
+            TranslateIncomingInput(
+                text="Hey — can we revisit the rollout timeline?", reader_context=None
+            )
+        ).prompt_for_llm_refinement.content
+    )
+    assert _ADDENDUM_HEADER not in with_field.prompt_for_llm_refinement.content
+
+
+def test_all_four_tools_byte_identical_when_absent() -> None:
+    contents = [
+        translate_incoming(
+            TranslateIncomingInput(text="Quick one: I'll loop back next week.")
+        ).prompt_for_llm_refinement.content,
+        check_tone(
+            CheckToneInput(text="This is broken. Please fix before EOD.")
+        ).prompt_for_llm_refinement.content,
+        rewrite_outgoing(
+            RewriteOutgoingInput(text="Strong nack. This will not scale.", target_register="warm")
+        ).prompt_for_llm_refinement.content,
+        brief_meeting(
+            BriefMeetingInput(transcript=_TRANSCRIPT, me="Thomas")
+        ).prompt_for_llm_refinement.content,
+    ]
+    for content in contents:
+        assert _ADDENDUM_HEADER not in content
+
+
+# ---------------------------------------------------------------------------
+# reader_context shapes + appends after the existing content
+
+
+def test_reader_context_appends_addendum_after_existing_content() -> None:
+    base = translate_incoming(
+        TranslateIncomingInput(text="Hey — can we revisit the rollout timeline?")
+    ).prompt_for_llm_refinement.content
+    shaped = translate_incoming(
+        TranslateIncomingInput(
+            text="Hey — can we revisit the rollout timeline?",
+            reader_context=ReaderContext(neurotypes=["adhd"]),
+        )
+    ).prompt_for_llm_refinement.content
+    # The shaped content is the baseline followed by the addendum (recency order).
+    assert shaped.startswith(base)
+    assert _ADDENDUM_HEADER in shaped
+    assert "Reader preferences (ADHD) — translate_incoming:" in shaped
+
+
+def test_reader_context_uses_per_tool_block_for_each_tool() -> None:
+    shaped = check_tone(
+        CheckToneInput(
+            text="This is broken. Fix it.",
+            reader_context=ReaderContext(neurotypes=["asd"]),
+        )
+    ).prompt_for_llm_refinement.content
+    assert "Reader preferences (autism) — check_tone:" in shaped
+
+
+def test_reader_context_max_chunk_size_interpolated() -> None:
+    shaped = translate_incoming(
+        TranslateIncomingInput(
+            text="Please review the doc and reply.",
+            reader_context=ReaderContext(neurotypes=["adhd"], max_chunk_size=3),
+        )
+    ).prompt_for_llm_refinement.content
+    assert "'likely_subtext': cap at 3 items" in shaped
+
+
+def test_reader_context_empty_neurotypes_default_knobs_stays_byte_identical() -> None:
+    base = translate_incoming(
+        TranslateIncomingInput(text="Status update only.")
+    ).prompt_for_llm_refinement.content
+    shaped = translate_incoming(
+        TranslateIncomingInput(
+            text="Status update only.",
+            reader_context=ReaderContext(neurotypes=[]),
+        )
+    ).prompt_for_llm_refinement.content
+    assert shaped == base
+
+
+def test_reader_context_voice_input_false_alone_stays_byte_identical() -> None:
+    """An explicit voice-input opt-out is NOT a shaping signal.
+
+    ``voice_input_preferred=False`` carries no instruction, so it must not
+    trigger a profile read + assembler call; the prompt stays byte-identical to
+    the un-shaped baseline.
+    """
+
+    base = translate_incoming(
+        TranslateIncomingInput(text="Status update only.")
+    ).prompt_for_llm_refinement.content
+    shaped = translate_incoming(
+        TranslateIncomingInput(
+            text="Status update only.",
+            reader_context=ReaderContext(voice_input_preferred=False),
+        )
+    ).prompt_for_llm_refinement.content
+    assert shaped == base
+
+
+# ---------------------------------------------------------------------------
+# Resolution precedence: reader_context per-field, else profile, else nothing
+
+
+def test_profile_fallback_shapes_when_no_reader_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_profile(
+        tmp_path,
+        """
+identity:
+  neurotypes: [dyslexia]
+""",
+        monkeypatch,
+    )
+    shaped = rewrite_outgoing(
+        RewriteOutgoingInput(text="This is broken.", target_register="warm")
+    ).prompt_for_llm_refinement.content
+    assert "Reader preferences (dyslexia) — rewrite_outgoing:" in shaped
+
+
+def test_reader_context_field_overrides_profile_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_profile(
+        tmp_path,
+        """
+identity:
+  neurotypes: [dyslexia]
+preferences:
+  max_chunk_size: 9
+""",
+        monkeypatch,
+    )
+    # reader_context overrides neurotypes -> adhd; max_chunk_size NOT given in
+    # reader_context, so the profile's 9 fills it (field-by-field precedence).
+    shaped = translate_incoming(
+        TranslateIncomingInput(
+            text="Please review and reply.",
+            reader_context=ReaderContext(neurotypes=["adhd"]),
+        )
+    ).prompt_for_llm_refinement.content
+    assert "Reader preferences (ADHD) — translate_incoming:" in shaped
+    assert "Reader preferences (dyslexia)" not in shaped
+    assert "'likely_subtext': cap at 9 items" in shaped
+
+
+def test_reader_context_tolerates_unknown_keys() -> None:
+    # additionalProperties tolerant: an unknown key does not crash the call.
+    ctx = ReaderContext.model_validate({"neurotypes": ["adhd"], "future_knob": 42})
+    shaped = translate_incoming(
+        TranslateIncomingInput(text="Please review.", reader_context=ctx)
+    ).prompt_for_llm_refinement.content
+    assert "Reader preferences (ADHD) — translate_incoming:" in shaped
+
+
+def test_output_shape_unchanged_no_new_required_field() -> None:
+    # The analysis (output shape) must not gain a reader_context field.
+    envelope = translate_incoming(
+        TranslateIncomingInput(
+            text="Please review.",
+            reader_context=ReaderContext(neurotypes=["adhd"]),
+        )
+    )
+    dumped = envelope.deterministic_analysis.model_dump()
+    assert "reader_context" not in dumped
+    assert set(dumped) == {
+        "explicit_ask",
+        "likely_subtext",
+        "ambiguity",
+        "recommended_next_action",
+        "eval_corpus_slice",
+        "model_provenance",
+    }

--- a/packages/mcp-translation/tests/test_reader_context_schema.py
+++ b/packages/mcp-translation/tests/test_reader_context_schema.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 NeuroDock contributors.
+"""The ``reader_context`` input is additive: it validates against every tool's
+``input`` sub-schema, and existing inputs (no reader_context) still validate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+_TOOLS = ("translate_incoming", "check_tone", "rewrite_outgoing", "brief_meeting")
+
+_MINIMAL_INPUT: dict[str, dict[str, Any]] = {
+    "translate_incoming": {"text": "Please review the doc."},
+    "check_tone": {"text": "This is broken."},
+    "rewrite_outgoing": {"text": "This is broken.", "target_register": "warm"},
+    "brief_meeting": {"transcript": "Priya: own the script?\nThomas: yes.", "me": "Thomas"},
+}
+
+_READER_CONTEXT: dict[str, Any] = {
+    "neurotypes": ["adhd", "asd"],
+    "output_format": "bullet_first",
+    "max_chunk_size": 3,
+    "voice_input_preferred": True,
+    "additional_notes": "Please quote the source.",
+}
+
+
+def _input_validator(schema: dict[str, Any]) -> Draft202012Validator:
+    input_schema = dict(schema["properties"]["input"])
+    if "$defs" in schema:
+        input_schema = {**input_schema, "$defs": schema["$defs"]}
+    return Draft202012Validator(input_schema)
+
+
+@pytest.mark.parametrize("tool", _TOOLS)
+def test_input_without_reader_context_still_validates(
+    schemas: dict[str, dict[str, Any]], tool: str
+) -> None:
+    _input_validator(schemas[tool]).validate(_MINIMAL_INPUT[tool])
+
+
+@pytest.mark.parametrize("tool", _TOOLS)
+def test_input_with_reader_context_validates(schemas: dict[str, dict[str, Any]], tool: str) -> None:
+    payload = {**_MINIMAL_INPUT[tool], "reader_context": _READER_CONTEXT}
+    _input_validator(schemas[tool]).validate(payload)
+
+
+@pytest.mark.parametrize("tool", _TOOLS)
+def test_reader_context_tolerates_extra_keys(schemas: dict[str, dict[str, Any]], tool: str) -> None:
+    payload = {
+        **_MINIMAL_INPUT[tool],
+        "reader_context": {"neurotypes": ["ocd"], "future_knob": 1},
+    }
+    _input_validator(schemas[tool]).validate(payload)
+
+
+@pytest.mark.parametrize("tool", _TOOLS)
+def test_reader_context_rejects_unknown_neurotype_enum(
+    schemas: dict[str, dict[str, Any]], tool: str
+) -> None:
+    payload = {**_MINIMAL_INPUT[tool], "reader_context": {"neurotypes": ["not_a_type"]}}
+    errors = list(_input_validator(schemas[tool]).iter_errors(payload))
+    assert errors, "an out-of-enum neurotype should fail validation"

--- a/uv.lock
+++ b/uv.lock
@@ -1472,11 +1472,12 @@ provides-extras = ["test"]
 
 [[package]]
 name = "neurodock-mcp-translation"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "packages/mcp-translation" }
 dependencies = [
     { name = "fastmcp" },
     { name = "pydantic" },
+    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -1493,6 +1494,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## What

R1 part B — the value-delivering half of ADR-0012. The four translation tools now assemble
the shared `neurotype-addenda` artifact and inject it into the existing
`prompt_for_llm_refinement.content`, so **every MCP client** (Claude Desktop, Cursor, Claude
Code) gets per-neurotype tailoring — not just the browser extension. This closes the
highest-leverage gap in the ND-tailoring analysis (tailoring was extension-only).

- `addenda.py` — a **byte-for-byte Python port** of the core TS assembler, reading a
  drift-guarded committed copy of `v1.json` (`importlib.resources`, safe-default on absence).
- `reader_context` — an optional, additive input (neurotypes / output_format / max_chunk_size
  / voice_input_preferred / additional_notes) with a `~/.neurodock/profile.yaml` fallback;
  precedence is field-by-field. **Absent both ⇒ byte-identical generic prompt** (asserted for
  all 4 tools). Output shape unchanged.
- **Cross-language parity test** (TS≡Python) against a fixture generated from the TS source of
  truth — divergence is a red build. Plus an artifact byte-identity drift guard and a
  structural no-LLM-SDK guard (vendor-neutral — string assembly only).
- Hosted/remote (no home dir) relies on `reader_context`, as designed.

`mcp-translation` 0.2.2→0.3.0; `@neurodock/core` carrier changeset.

## Review

`mcp-architect` (design) → `mcp-translation-expert` (impl), TDD. Reviewed by `code-reviewer`
(APPROVE), `python-reviewer` (1 HIGH fixed: reject boolean `max_chunk_size`), and `mcp-architect`
(**CONFORMS** to ADR-0012 — faithful hybrid, both anti-drift gates load-bearing). Polish applied
(voice-False signal, deepcopy safe-default, parity floor 55, etc.).

## Test plan

- [x] `ruff check` + `ruff format --check` clean; `mypy --strict src` no issues
- [x] `pytest -q` → 176 passed; core vitest → 147 (incl. 60 parity)
- [x] cross-language parity TS≡Python green; artifact drift guard green; no-LLM-SDK guard green
- [x] byte-identical-when-absent regression for all 4 tools
- [x] schemas additive + in sync with the Pydantic `ReaderContext`
- [x] `wrangler.jsonc` excluded