### PR TITLE
chore(core): pre-release fixes (node esm json import, real readme, tarball trim)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,9 @@ uv.lock
 # Generated artifact: written by neurotype-addenda.parity.test.ts in
 # UPDATE_NEUROTYPE_PARITY_FIXTURES mode (JSON.stringify-formatted, not prettier).
 packages/core/data/neurotype-addenda/parity-fixtures.json
+
+# Uses the `with { type: "json" }` import attribute, required for the published
+# dist to load on Node >=22 (and accepted by tsc + Vite/esbuild), but the older
+# pre-commit prettier mirror cannot parse it. The repo's own prettier 3.8.4
+# accepts it; this entry only spares the mirror.
+packages/core/src/neurotype-addenda.ts

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,7 +1,54 @@
 # @neurodock/core
 
-Shared types, profile schema, and plugin protocol for NeuroDock.
+Shared, framework-neutral building blocks for NeuroDock: the profile JSON Schema and
+TypeScript types, the plugin protocol schema, and the per-neurotype prompt-shaping
+artifact + assembler that every NeuroDock surface uses to tailor output.
 
-This package is a Phase 0 stub. Real implementation lands in Phase 1.
+This package has zero runtime dependencies. Data lives as JSON (validated by JSON Schema);
+the assembler is a pure function.
 
-See Sections 5 and 6 for scope.
+## Install
+
+```sh
+pnpm add @neurodock/core
+```
+
+## What's inside
+
+- **Profile types + schema** — `Profile` (and its block interfaces) plus
+  `schemas/profile.schema.json`, the cross-cutting user manifest read by every MCP server
+  and skill. See [ADR 0004](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0004-profile-schema-design.md).
+- **Neurotype-shaping artifact + assembler** — `data/neurotype-addenda/v1.json` is the
+  single source of truth for the per-(tool × neurotype) prompt addenda; `assembleNeurotypeAddendum`
+  turns it into the addendum string. Both the browser extension and the `mcp-translation`
+  server read this artifact so per-neurotype shaping stays identical across surfaces. See
+  [ADR 0012](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0012-shared-neurotype-shaping-layer.md).
+- **Plugin protocol schema** — `schemas/plugin.schema.json`. See
+  [ADR 0007](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0007-plugin-protocol.md).
+
+## Usage
+
+```ts
+import {
+  assembleNeurotypeAddendum,
+  neurotypeAddendaV1,
+  type Profile,
+} from "@neurodock/core";
+
+const addendum = assembleNeurotypeAddendum(neurotypeAddendaV1, {
+  tool: "translate_incoming",
+  neurotypes: ["adhd", "asd"], // fuses to AuDHD
+  outputFormat: "answer_first",
+  maxChunkSize: 5,
+  voiceInputPreferred: false,
+});
+// `addendum` is appended after the JSON schema block of a model prompt.
+// An empty input (no neurotypes, all defaults) returns "".
+```
+
+The addendum is **content**, not schema shape: it never changes a tool's output schema
+(per [ADR 0011](https://github.com/tlennon-ie/neurodock/blob/main/docs/decisions/0011-neurotype-schema-strategy.md)).
+
+## License
+
+AGPL-3.0-or-later

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
   },
   "files": [
     "dist",
-    "data",
+    "data/neurotype-addenda/v1.json",
     "schemas",
     "README.md"
   ],

--- a/packages/core/src/neurotype-addenda.ts
+++ b/packages/core/src/neurotype-addenda.ts
@@ -25,7 +25,7 @@
  * caller's per-list item cap) and `{notes}` (replaced with the reader's
  * free-form notes inside the self-described block).
  */
-import artifactV1 from "../data/neurotype-addenda/v1.json" assert { type: "json" };
+import artifactV1 from "../data/neurotype-addenda/v1.json" with { type: "json" };
 
 /** A prose block: ordered lines joined with the framing line separator. */
 export type AddendumBlock = readonly string[];


### PR DESCRIPTION
## What

Pre-release hardening surfaced by the **production-readiness audit** before cutting the
ND-tailoring release. All three are `@neurodock/core` only.

1. **CRITICAL — broken published dist on Node ≥22.** The neurotype-addenda artifact import
   used `assert { type: "json" }`, which is a hard `SyntaxError` in the *published* `dist`
   on Node ≥22 (removed in favour of `with`). CI never caught it because the only in-repo
   consumer — the browser extension — bundles core's **source** via Vite (which transforms
   the import), not the dist. Switched to `with { type: "json" }` (correct for Node ESM +
   tsc + Vite/esbuild). The older pre-commit prettier *mirror* can't parse `with`, so the one
   file is added to `.prettierignore` (the repo's own prettier 3.8.4 accepts it).
   **Verified:** `node -e "import('./packages/core/dist/index.js')"` now succeeds under Node 25;
   the extension still typechecks + builds from core source.
2. **Stale README** — replaced the "Phase 0 stub" text with the real package purpose + a
   usage example (core now ships a real public API).
3. **Tarball trim** — narrowed `files` so the 84 KB dev-only `parity-fixtures.json` no longer
   ships in the npm tarball (only `v1.json` does).

No version bump here — the version bumps land in the `changeset version` release commit.

## Test plan

- [x] `pnpm --filter @neurodock/core build` → `with` in dist; `node` ESM import of the built dist succeeds
- [x] `pnpm --filter @neurodock/extension-browser typecheck` + `build:chrome` green (core source, `with`)
- [x] `pnpm --filter @neurodock/core test` green
- [x] `npm pack --dry-run` ships `v1.json`, excludes `parity-fixtures.json`
- [x] `wrangler.jsonc` excluded