### PR TITLE
ci(extension): independent per-store publish so one store can't block the others

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -73,8 +73,13 @@ jobs:
   # Store submission. Runs only on `extension-browser@X.Y.Z` tag pushes (or a
   # manual dispatch with the `publish` confirmation input). Each store step is
   # skipped gracefully when its secrets are not configured, so the job never
-  # fails just because a store has no credentials yet. Credentials setup and
-  # the first-submission caveat are documented in
+  # fails just because a store has no credentials yet. Each store also runs
+  # `continue-on-error`, so one store failing (e.g. Chrome returning
+  # ITEM_NOT_UPDATABLE because a prior version is still in review) does NOT
+  # block the other stores or the GitHub-release zip attach — the failure is
+  # surfaced in the submission summary and as a warning annotation, and the
+  # release can be re-run for the still-pending store later. Credentials setup
+  # and the first-submission caveat are documented in
   # packages/extension-browser/PUBLISHING.md.
   publish:
     name: Publish to web stores
@@ -182,8 +187,13 @@ jobs:
             echo "::warning::no web-store credentials configured — nothing was submitted to any store. The zips are still attached to the GitHub release. See packages/extension-browser/PUBLISHING.md to set up store secrets."
           fi
 
+      # Each store publishes independently: `continue-on-error` keeps one
+      # store's failure (e.g. Chrome ITEM_NOT_UPDATABLE while a prior version
+      # is in review) from aborting the others or the zip attach below.
       - name: Publish to Chrome Web Store
+        id: chrome
         if: steps.stores.outputs.has_chrome == 'true'
+        continue-on-error: true
         working-directory: packages/extension-browser
         run: pnpm exec wxt submit --chrome-zip "${{ steps.zips.outputs.chrome_zip }}"
         env:
@@ -193,7 +203,9 @@ jobs:
           CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
 
       - name: Publish to Firefox Add-ons (AMO)
+        id: firefox
         if: steps.stores.outputs.has_firefox == 'true'
+        continue-on-error: true
         working-directory: packages/extension-browser
         run: pnpm exec wxt submit --firefox-zip "${{ steps.zips.outputs.firefox_zip }}" --firefox-sources-zip "${{ steps.zips.outputs.sources_zip }}"
         env:
@@ -202,7 +214,9 @@ jobs:
           FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
 
       - name: Publish to Edge Add-ons
+        id: edge
         if: steps.stores.outputs.has_edge == 'true'
+        continue-on-error: true
         working-directory: packages/extension-browser
         run: pnpm exec wxt submit --edge-zip "${{ steps.zips.outputs.edge_zip }}"
         env:
@@ -213,11 +227,43 @@ jobs:
       # release.yml does not create GitHub releases (npm / PyPI only), so this
       # is the repo's first release-creating step. softprops/action-gh-release
       # is pinned by major tag, matching how the other third-party actions in
-      # .github/workflows are pinned.
+      # .github/workflows are pinned. `always()` so the zips reach the release
+      # even when a store submission above failed (continue-on-error).
       - name: Attach zips to GitHub release
-        if: startsWith(github.ref, 'refs/tags/extension-browser@')
+        if: ${{ always() && startsWith(github.ref, 'refs/tags/extension-browser@') }}
         uses: softprops/action-gh-release@v3
         with:
           name: ${{ github.ref_name }}
           files: packages/extension-browser/.output/*.zip
           generate_release_notes: true
+
+      # Honest summary: a green job must not imply every store published. Each
+      # store's real outcome (success / failure / skipped) is surfaced here and
+      # as a warning annotation for any failure, without failing the release.
+      - name: Store submission summary
+        if: always()
+        run: |
+          {
+            echo "## Web-store submission summary"
+            report() {
+              local store="$1" outcome="$2"
+              case "$outcome" in
+                success) echo "- **$store**: submitted ✅" ;;
+                failure) echo "- **$store**: failed ❌ — tolerated; the release continued. Common cause: a prior version is still in store review. Re-run this tag's workflow once the store is ready." ;;
+                skipped|"") echo "- **$store**: skipped (secrets not configured)" ;;
+                *) echo "- **$store**: $outcome" ;;
+              esac
+            }
+            report Chrome "${{ steps.chrome.outcome }}"
+            report Firefox "${{ steps.firefox.outcome }}"
+            report Edge "${{ steps.edge.outcome }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.chrome.outcome }}" = "failure" ]; then
+            echo "::warning::Chrome Web Store submission failed (tolerated). See the Chrome step log; re-run once the store is ready."
+          fi
+          if [ "${{ steps.firefox.outcome }}" = "failure" ]; then
+            echo "::warning::Firefox AMO submission failed (tolerated). See the Firefox step log."
+          fi
+          if [ "${{ steps.edge.outcome }}" = "failure" ]; then
+            echo "::warning::Edge Add-ons submission failed (tolerated). See the Edge step log."
+          fi


### PR DESCRIPTION
## What

Hardens `extension.yml` so the browser-extension release isn't held hostage by one store.

In the `extension-browser@0.1.0` run, the Chrome upload failed with `ITEM_NOT_UPDATABLE`
(the prior 0.0.38 is still in Chrome review), and because the store steps ran sequentially
with no `continue-on-error`, that aborted the **Firefox** submit **and** the GitHub-release
**zip attach**.

This change:
- adds `continue-on-error: true` + a step `id` to each store publish step (Chrome / Firefox
  / Edge), so one store failing no longer aborts the others;
- runs the **zip attach** with `always()` so the zips reach the GitHub release regardless;
- adds a **submission-summary** step that reports each store's real outcome
  (submitted / failed / skipped) in the job summary and as warning annotations — so a green
  run never implies a store published when it didn't.

## Effect

Once this merges, re-pushing the `extension-browser@0.1.0` tag (at the fixed commit) will:
Firefox 0.1.0 submits, the zips attach to the GitHub release, and Chrome continues to fail
**gracefully** (annotated, not blocking) until the 0.0.38 review clears — at which point a
re-run submits Chrome too. The release is no longer blocked while Chrome catches up.

## Test plan

- [x] `extension.yml` is valid YAML
- [x] CI-only change (no package code); no changeset needed
- [x] the `build` job's PR-path still runs (paths filter unchanged)