### PR TITLE
fix(native-host): make the native-messaging host actually connect to the extension

### DIFF
--- a/.changeset/nd-native-host-launcher.md
+++ b/.changeset/nd-native-host-launcher.md
@@ -1,0 +1,46 @@
+---
+"@neurodock/native-host": minor
+"@neurodock/cli": minor
+---
+
+fix: stage the native host to a stable dir and launch it via a real launcher
+
+The native-messaging host never actually connected end-to-end — the browser
+extension showed "Not connected yet" despite correct extension ids and a green
+`neurodock doctor`. Three defects, every one hitting all users:
+
+1. The manifest `path` pointed at `@neurodock/native-host/dist/cli.js` resolved
+   relative to the running CLI. Under the documented `npx @neurodock/cli@latest
+   setup` that lands in npm's `_npx` cache, which npm prunes and rotates — so
+   the manifest eventually pointed at a deleted file.
+2. The manifest `path` was a bare `.js`. Chrome on Windows cannot launch a
+   `.js` as a native-messaging host (it needs a `.bat`/`.cmd`/`.exe`), blocking
+   every Windows user.
+3. Chrome launches the host with the calling extension's origin as the first
+   CLI arg, but `parseArgs` only ran the stdio host when argv was empty or the
+   first arg was literally `run`; any other first arg printed help and
+   disconnected — so even a successful launch greeted Chrome with usage text.
+
+Fix (coordinated across `@neurodock/native-host` and `@neurodock/cli`):
+
+- Install now STAGES a self-contained copy of the runtime into a stable
+  per-user directory (`%APPDATA%\NeuroDock\native-host\runtime\` on Windows,
+  `~/Library/Application Support/NeuroDock/native-host/runtime/` on macOS,
+  `$XDG_DATA_HOME/neurodock/native-host/runtime/` on Linux) and points the
+  manifest at a LAUNCHER there — a `.bat` on Windows, a `#!/bin/sh` wrapper on
+  macOS/Linux — that embeds the absolute `node` binary and forces the `run`
+  subcommand before forwarding Chrome's args. `dist/cli.js` is now bundled
+  (ajv/yaml inlined), so the relocated copy resolves zero bare imports and
+  survives the `_npx` cache being pruned.
+- `parseArgs` routes any unrecognised first arg (a `chrome-extension://` /
+  `moz-extension://` origin, `--parent-window=`) to `run`, not help.
+- `neurodock doctor` and `neurodock-native-host doctor` verify the
+  ALREADY-INSTALLED host: they read the on-disk Chromium manifest, resolve the
+  launcher `path` Chrome would actually run, and spawn exactly that — exchanging
+  a `ping`/pong over the length-prefixed stdio protocol. They never re-stage or
+  re-register, so the diagnostic reflects the user's real install (a missing
+  manifest, or a manifest pointing at a pruned `_npx` launcher, FAILS with a
+  "run `neurodock host install`" hint instead of being silently repaired). On
+  macOS/Linux the `0755` `.sh` launcher is spawned directly (`shell: false`);
+  only the Windows `.bat` uses the shell.
+- Uninstall removes the staged runtime directory too (no orphans).

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -10,13 +10,30 @@ import { profilePath, detectClients } from "../lib/paths.js";
 import { loadProfileFromFile } from "../profile/loader.js";
 import { validateProfile } from "../profile/validator.js";
 import { parseJsonSafely } from "../lib/json-patch.js";
+import {
+  runHostVerify as defaultRunHostVerify,
+  type HostVerifyResult,
+} from "./host.js";
 
 export interface DoctorResult {
   readonly checks: ReadonlyArray<CheckResult>;
   readonly ok: boolean;
 }
 
-export async function runDoctor(): Promise<DoctorResult> {
+export interface DoctorDependencies {
+  /**
+   * Live-launch verifier for the native messaging host. Defaults to the real
+   * spawn-and-ping path; tests inject a stub so they stay hermetic. This is
+   * the check that exercises a real host launch — the original doctor only
+   * verified that manifests/registry keys existed, so it stayed green while
+   * no Chrome connection ever worked.
+   */
+  readonly verifyNativeHost?: () => Promise<HostVerifyResult>;
+}
+
+export async function runDoctor(
+  deps: DoctorDependencies = {},
+): Promise<DoctorResult> {
   const env = readEnv();
   const checks: CheckResult[] = [];
 
@@ -99,8 +116,44 @@ export async function runDoctor(): Promise<DoctorResult> {
     }
   }
 
+  // Native messaging host: actually LAUNCH it and exchange a ping/pong. This
+  // is the real connectivity check the browser extension depends on.
+  checks.push(await checkNativeHost(deps.verifyNativeHost));
+
   const ok = checks.every((c) => c.status !== "FAIL");
   return { checks, ok };
+}
+
+async function checkNativeHost(
+  verify: (() => Promise<HostVerifyResult>) | undefined,
+): Promise<CheckResult> {
+  const name = "Native host live launch";
+  const run = verify ?? defaultRunHostVerify;
+  try {
+    const result = await run();
+    if (result.ok) {
+      return {
+        name,
+        status: "PASS",
+        detail: `host responded to ping (version ${
+          result.version ?? "?"
+        }) via ${result.launcherPath}`,
+      };
+    }
+    return {
+      name,
+      status: "FAIL",
+      detail:
+        result.detail ??
+        "native host did not respond to a ping over the stdio protocol",
+    };
+  } catch (err: unknown) {
+    return {
+      name,
+      status: "FAIL",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
 function checkNodeVersion(): CheckResult {

--- a/packages/cli/src/commands/host.ts
+++ b/packages/cli/src/commands/host.ts
@@ -9,38 +9,69 @@
  * module. We do not re-implement the per-OS dispatch here — the host
  * package owns it and exposes register / unregister functions.
  *
- * The host package's bin (`neurodock-native-host run`) is the script Chrome
- * actually launches; this CLI subcommand only handles registering /
- * deregistering manifests and registry pointers.
+ * The connectable install path STAGES the host runtime into a stable
+ * per-user directory and writes a launcher Chrome can actually execute, then
+ * registers manifests/registry pointers whose `path` is the LAUNCHER. This
+ * replaces the old behaviour of pointing the manifest at
+ * `@neurodock/native-host/dist/cli.js` resolved relative to the running CLI:
+ * under the documented `npx @neurodock/cli@latest setup` that path lands in
+ * npm's `_npx` cache, which npm prunes/rotates — so the manifest eventually
+ * pointed at a deleted file, and even when present a bare `.js` is not
+ * launchable by Chrome on Windows. Staging + a launcher fixes both.
  */
 import { fileURLToPath } from "node:url";
 import { existsSync, realpathSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import {
-  register,
-  unregister,
+  registerWithStaging,
+  unregisterWithStaging,
   detectPlatform,
   withDefaultExtensionIds,
+  resolveSourceDistDir,
+  resolveInstalledLauncher,
+  type StagingPlatform,
 } from "@neurodock/native-host/dist/registration/index.js";
+import {
+  verifyLiveLaunch,
+  type VerifyResult,
+} from "@neurodock/native-host/dist/doctor.js";
 import type { RegistrationOutcome } from "@neurodock/native-host/dist/registration/index.js";
+import { homedir } from "node:os";
 
 export interface HostInstallOptions {
   readonly extensionIds: ReadonlyArray<string>;
 }
 
+/**
+ * Test seams: every value the staging path needs can be injected so the
+ * per-OS behaviour is exercisable without touching the real %APPDATA% /
+ * registry / config roots.
+ */
+export interface HostInstallDeps {
+  readonly platform?: StagingPlatform;
+  readonly home?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly sourceDistDir?: string;
+  readonly nodePath?: string;
+}
+
 export interface HostCommandResult {
   readonly platform: string;
   readonly outcomes: ReadonlyArray<RegistrationOutcome>;
+  /** The launcher the manifests now point at (absent on uninstall). */
+  readonly launcherPath?: string;
 }
 
-function resolveHostBinPath(): string {
-  // The bin lives at `<native-host package>/dist/cli.js`. We resolve it
-  // relative to this module so the path works both from a checkout
-  // (where the file is under packages/native-host/dist) and from a
-  // published install (where it is under node_modules/@neurodock/native-host/dist).
+/**
+ * Resolve the native-host package's own `dist/` directory so we can stage it.
+ * Resolved relative to this module so it works from a checkout (under
+ * packages/native-host/dist) and from a published install (under
+ * node_modules/@neurodock/native-host/dist). Falls back to the host package's
+ * own `resolveSourceDistDir` when the layout is unexpected.
+ */
+function resolveHostDistDir(): string {
   const here = dirname(fileURLToPath(import.meta.url));
   const candidates = [
-    // dist/commands/host.js -> ../../node_modules/@neurodock/native-host/dist/cli.js
     resolve(
       here,
       "..",
@@ -49,27 +80,13 @@ function resolveHostBinPath(): string {
       "@neurodock",
       "native-host",
       "dist",
-      "cli.js",
     ),
-    // monorepo: dist/commands/host.js -> ../../../native-host/dist/cli.js
-    resolve(here, "..", "..", "..", "native-host", "dist", "cli.js"),
-    // monorepo sibling: dist/commands/host.js (cli) -> ../../../packages/native-host/dist/cli.js
-    resolve(
-      here,
-      "..",
-      "..",
-      "..",
-      "..",
-      "packages",
-      "native-host",
-      "dist",
-      "cli.js",
-    ),
-    // From cwd
-    join(process.cwd(), "packages", "native-host", "dist", "cli.js"),
+    resolve(here, "..", "..", "..", "native-host", "dist"),
+    resolve(here, "..", "..", "..", "..", "packages", "native-host", "dist"),
+    join(process.cwd(), "packages", "native-host", "dist"),
   ];
   for (const c of candidates) {
-    if (existsSync(c)) {
+    if (existsSync(join(c, "cli.js"))) {
       try {
         return realpathSync(c);
       } catch {
@@ -77,24 +94,124 @@ function resolveHostBinPath(): string {
       }
     }
   }
-  // Fall back to "neurodock-native-host" on PATH; reg/manifest will still
-  // be written but the actual host path may be unresolvable. Surface that
-  // to the caller via the outcome rather than crashing.
-  return "neurodock-native-host";
+  // Let the host package resolve from its own module location.
+  return resolveSourceDistDir();
 }
 
-export function runHostInstall(opts: HostInstallOptions): HostCommandResult {
+export function runHostInstall(
+  opts: HostInstallOptions,
+  deps: HostInstallDeps = {},
+): HostCommandResult {
   // Always register the published store ids; caller-supplied ids (e.g. a
   // locally-loaded unpacked build) are added on top.
   const ids = withDefaultExtensionIds(opts.extensionIds);
-  const platform = detectPlatform();
-  const hostPath = resolveHostBinPath();
-  const outcomes = register({ hostPath, allowedExtensionIds: ids });
+  const sourceDistDir = deps.sourceDistDir ?? resolveHostDistDir();
+  const result = registerWithStaging({
+    allowedExtensionIds: ids,
+    sourceDistDir,
+    ...(deps.platform ? { platform: deps.platform } : {}),
+    ...(deps.home ? { home: deps.home } : {}),
+    ...(deps.env ? { env: deps.env } : {}),
+    ...(deps.nodePath ? { nodePath: deps.nodePath } : {}),
+  });
+  return {
+    platform: result.platform,
+    outcomes: result.outcomes,
+    launcherPath: result.launcherPath,
+  };
+}
+
+/**
+ * Test seams for the uninstall path: same injectable platform/home/env as
+ * install so the symmetric removal is unit-testable in a sandbox.
+ */
+export interface HostUninstallDeps {
+  readonly platform?: StagingPlatform;
+  readonly home?: string;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export function runHostUninstall(
+  deps: HostUninstallDeps = {},
+): HostCommandResult {
+  const platform = deps.platform ?? detectPlatform();
+  // Remove manifests/registry AND the staged runtime tree (no orphans).
+  const outcomes = unregisterWithStaging({
+    ...(deps.platform ? { platform: deps.platform } : {}),
+    ...(deps.home ? { home: deps.home } : {}),
+    ...(deps.env ? { env: deps.env } : {}),
+  });
   return { platform, outcomes };
 }
 
-export function runHostUninstall(): HostCommandResult {
-  const platform = detectPlatform();
-  const outcomes = unregister();
-  return { platform, outcomes };
+export interface HostVerifyResult {
+  readonly ok: boolean;
+  readonly launcherPath: string;
+  readonly version: string | null;
+  readonly detail?: string;
+}
+
+/**
+ * Test seams for verify. Verify READS the installed manifest and spawns the
+ * launcher it points at — it never stages/registers — so the only injectables
+ * it needs are the OS coordinates and a stub spawner.
+ */
+export interface HostVerifyDeps {
+  readonly platform?: StagingPlatform;
+  readonly home?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  /** Stub the live spawn-and-ping in tests; defaults to the real launcher. */
+  readonly verify?: (launcherPath: string) => Promise<VerifyResult>;
+}
+
+/**
+ * Live-launch verification used by `neurodock doctor`.
+ *
+ * Crucially this VERIFIES THE ALREADY-INSTALLED launcher — it reads the
+ * on-disk Chromium native-messaging manifest, resolves the `path` Chrome
+ * would launch, and spawns exactly that. It does NOT re-stage or re-register,
+ * because doing so would repair a broken install behind the user's back and
+ * make the diagnostic green even when the real installed manifest points at a
+ * pruned `_npx` cli.js. If the host is not installed (no manifest), or the
+ * manifest's launcher no longer exists, this returns a clear FAIL telling the
+ * user to run `neurodock host install` — it never installs.
+ */
+export async function runHostVerify(
+  deps: HostVerifyDeps = {},
+): Promise<HostVerifyResult> {
+  const platform: StagingPlatform | "unsupported" =
+    deps.platform ??
+    (detectPlatform() === "unsupported"
+      ? "unsupported"
+      : (detectPlatform() as StagingPlatform));
+  if (platform === "unsupported") {
+    return {
+      ok: false,
+      launcherPath: "",
+      version: null,
+      detail: "native messaging host is not supported on this platform",
+    };
+  }
+  const home = deps.home ?? homedir();
+  const env = deps.env ?? process.env;
+
+  // READ the installed launcher from the on-disk manifest — never re-stage.
+  const installed = resolveInstalledLauncher(platform, home, env);
+  if (!installed.ok) {
+    return {
+      ok: false,
+      launcherPath: installed.launcherPath,
+      version: null,
+      ...(installed.detail ? { detail: installed.detail } : {}),
+    };
+  }
+
+  const verify = deps.verify ?? verifyLiveLaunch;
+  const result = await verify(installed.launcherPath);
+  return {
+    ok: result.ok,
+    launcherPath: installed.launcherPath,
+    version: result.version,
+    ...(result.detail ? { detail: result.detail } : {}),
+  };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -605,6 +605,9 @@ export function buildProgram(): Command {
     .action((opts: { extensionId: string[] }) => {
       const result = runHostInstall({ extensionIds: opts.extensionId });
       print(`Installing com.neurodock.profile (platform=${result.platform})`);
+      if (result.launcherPath) {
+        print(`  launcher: ${result.launcherPath}`);
+      }
       for (const o of result.outcomes) {
         const detail = o.detail ? ` — ${o.detail}` : "";
         print(
@@ -613,6 +616,7 @@ export function buildProgram(): Command {
           }${detail}`,
         );
       }
+      print("Verify a live launch with: neurodock doctor");
       process.exit(0);
     });
 

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runDoctor } from "../src/commands/doctor.js";
+import { runHostVerify } from "../src/commands/host.js";
+import { HOST_NAME } from "@neurodock/native-host/dist/registration/index.js";
 
 function sandbox(): { root: string; profile: string; cleanup: () => void } {
   const root = mkdtempSync(join(tmpdir(), "neurodock-doctor-"));
@@ -81,5 +83,131 @@ describe("neurodock doctor", () => {
     expect(node).toBeDefined();
     // Cannot assume PASS in all sandboxes, but the check must exist and have a detail.
     expect(node?.detail).toBeTruthy();
+  });
+
+  it("exercises a LIVE native-host launch via the injected verifier (PASS path)", async () => {
+    // The shipped bug was that doctor only checked files/keys exist, never a
+    // live launch — so it stayed green while no Chrome connection ever
+    // worked. doctor must now spawn the launcher and exchange a ping/pong.
+    const s = sandbox();
+    try {
+      writeFileSync(
+        s.profile,
+        "identity:\n  display_name: tester\n  neurotypes:\n    - adhd\n",
+      );
+      process.env["NEURODOCK_PROFILE_PATH"] = s.profile;
+      const r = await runDoctor({
+        verifyNativeHost: async () => ({
+          ok: true,
+          launcherPath: "/stable/runtime/com.neurodock.profile.sh",
+          version: "0.1.0",
+        }),
+      });
+      const host = r.checks.find((c) => c.name === "Native host live launch");
+      expect(host).toBeDefined();
+      expect(host?.status).toBe("PASS");
+      expect(host?.detail).toContain("0.1.0");
+    } finally {
+      delete process.env["NEURODOCK_PROFILE_PATH"];
+      s.cleanup();
+    }
+  });
+
+  it("native-host check FAILS through the REAL verifier when nothing is installed", async () => {
+    // End-to-end through runHostVerify (not a hand-rolled stub): with no
+    // manifest on disk, doctor must report the host as not installed and FAIL
+    // — it must NOT silently install to make itself pass.
+    const s = sandbox();
+    try {
+      writeFileSync(
+        s.profile,
+        "identity:\n  display_name: tester\n  neurotypes:\n    - adhd\n",
+      );
+      process.env["NEURODOCK_PROFILE_PATH"] = s.profile;
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "data"),
+        XDG_CONFIG_HOME: join(s.root, "config"),
+      };
+      const r = await runDoctor({
+        verifyNativeHost: () => runHostVerify({ platform: "linux", home, env }),
+      });
+      const host = r.checks.find((c) => c.name === "Native host live launch");
+      expect(host?.status).toBe("FAIL");
+      expect(host?.detail).toMatch(/install/i);
+      expect(r.ok).toBe(false);
+    } finally {
+      delete process.env["NEURODOCK_PROFILE_PATH"];
+      s.cleanup();
+    }
+  });
+
+  it("native-host check FAILS through the REAL verifier when the installed manifest points at a missing launcher", async () => {
+    const s = sandbox();
+    try {
+      writeFileSync(
+        s.profile,
+        "identity:\n  display_name: tester\n  neurotypes:\n    - adhd\n",
+      );
+      process.env["NEURODOCK_PROFILE_PATH"] = s.profile;
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "data"),
+        XDG_CONFIG_HOME: join(s.root, "config"),
+      };
+      // A stale manifest pointing at a launcher that no longer exists (the
+      // pruned-_npx scenario the diagnostic exists to catch).
+      const manifestPath = join(
+        env.XDG_CONFIG_HOME,
+        "google-chrome",
+        "NativeMessagingHosts",
+        `${HOST_NAME}.json`,
+      );
+      mkdirSync(join(manifestPath, ".."), { recursive: true });
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          name: HOST_NAME,
+          path: join(s.root, "gone", "cli.js"),
+          type: "stdio",
+        }),
+      );
+      const r = await runDoctor({
+        verifyNativeHost: () => runHostVerify({ platform: "linux", home, env }),
+      });
+      const host = r.checks.find((c) => c.name === "Native host live launch");
+      expect(host?.status).toBe("FAIL");
+      expect(host?.detail).toMatch(/install/i);
+      expect(r.ok).toBe(false);
+    } finally {
+      delete process.env["NEURODOCK_PROFILE_PATH"];
+      s.cleanup();
+    }
+  });
+
+  it("fails doctor when the live native-host launch does not respond", async () => {
+    const s = sandbox();
+    try {
+      writeFileSync(
+        s.profile,
+        "identity:\n  display_name: tester\n  neurotypes:\n    - adhd\n",
+      );
+      process.env["NEURODOCK_PROFILE_PATH"] = s.profile;
+      const r = await runDoctor({
+        verifyNativeHost: async () => ({
+          ok: false,
+          launcherPath: "/stable/runtime/com.neurodock.profile.sh",
+          version: null,
+          detail: "Host exited (code 1) without a valid response.",
+        }),
+      });
+      const host = r.checks.find((c) => c.name === "Native host live launch");
+      expect(host?.status).toBe("FAIL");
+      expect(host?.detail).toContain("code 1");
+      expect(r.ok).toBe(false);
+    } finally {
+      delete process.env["NEURODOCK_PROFILE_PATH"];
+      s.cleanup();
+    }
   });
 });

--- a/packages/cli/tests/host.test.ts
+++ b/packages/cli/tests/host.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  runHostInstall,
+  runHostUninstall,
+  runHostVerify,
+} from "../src/commands/host.js";
+import { HOST_NAME } from "@neurodock/native-host/dist/registration/index.js";
+
+function sandbox(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "neurodock-host-"));
+  return {
+    root,
+    cleanup: () => {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe("runHostInstall (CLI wiring)", () => {
+  it("stages the runtime and registers manifests whose path is the launcher, not an npx-cache cli.js", () => {
+    const s = sandbox();
+    try {
+      // Fake source dist (stands in for @neurodock/native-host/dist).
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// cli\n");
+
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "data"),
+        XDG_CONFIG_HOME: join(s.root, "config"),
+      };
+
+      const result = runHostInstall(
+        { extensionIds: ["mydev"] },
+        {
+          platform: "linux",
+          home,
+          env,
+          sourceDistDir: sourceDist,
+          nodePath: "/usr/bin/node",
+        },
+      );
+
+      // The launcher exists and is what we report.
+      expect(result.launcherPath).toBeTruthy();
+      expect(existsSync(result.launcherPath as string)).toBe(true);
+
+      // The Chrome manifest's `path` is the launcher, NOT a raw cli.js.
+      const chromeManifest = join(
+        env.XDG_CONFIG_HOME,
+        "google-chrome",
+        "NativeMessagingHosts",
+        "com.neurodock.profile.json",
+      );
+      expect(existsSync(chromeManifest)).toBe(true);
+      const manifest = JSON.parse(readFileSync(chromeManifest, "utf8")) as {
+        path: string;
+        allowed_origins: string[];
+      };
+      expect(manifest.path).toBe(result.launcherPath);
+      expect(manifest.path).not.toMatch(/cli\.js$/);
+      // Published + caller ids both present (behaviour unchanged).
+      expect(manifest.allowed_origins).toContain("chrome-extension://mydev/");
+      expect(manifest.allowed_origins).toContain(
+        "chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/",
+      );
+    } finally {
+      s.cleanup();
+    }
+  });
+});
+
+describe("runHostUninstall (CLI wiring)", () => {
+  it("accepts injectable deps and removes the staged runtime + manifests in a sandbox", () => {
+    const s = sandbox();
+    try {
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// cli\n");
+
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "data"),
+        XDG_CONFIG_HOME: join(s.root, "config"),
+      };
+
+      const installed = runHostInstall(
+        { extensionIds: [] },
+        {
+          platform: "linux",
+          home,
+          env,
+          sourceDistDir: sourceDist,
+          nodePath: "/usr/bin/node",
+        },
+      );
+      expect(existsSync(installed.launcherPath as string)).toBe(true);
+
+      const result = runHostUninstall({ platform: "linux", home, env });
+      expect(result.platform).toBe("linux");
+      // The launcher (staged runtime) is gone — no orphan.
+      expect(existsSync(installed.launcherPath as string)).toBe(false);
+    } finally {
+      s.cleanup();
+    }
+  });
+});
+
+describe("runHostVerify (doctor verifies the INSTALLED launcher)", () => {
+  it("PASS: reads the on-disk manifest's launcher and spawns THAT path (no re-stage)", async () => {
+    const s = sandbox();
+    try {
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// cli\n");
+
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "data"),
+        XDG_CONFIG_HOME: join(s.root, "config"),
+      };
+
+      // A REAL install writes the manifest + stages the launcher.
+      const installed = runHostInstall(
+        { extensionIds: [] },
+        {
+          platform: "linux",
+          home,
+          env,
+          sourceDistDir: sourceDist,
+          nodePath: "/usr/bin/node",
+        },
+      );
+
+      // Inject a fake verifier so we don't actually spawn; assert it is handed
+      // the INSTALLED launcher path read from the on-disk manifest.
+      let spawnedPath = "";
+      const result = await runHostVerify({
+        platform: "linux",
+        home,
+        env,
+        verify: async (launcherPath: string) => {
+          spawnedPath = launcherPath;
+          return { ok: true, pong: true, version: "0.1.0" };
+        },
+      });
+
+      expect(spawnedPath).toBe(installed.launcherPath);
+      expect(result.ok).toBe(true);
+      expect(result.launcherPath).toBe(installed.launcherPath);
+      expect(result.version).toBe("0.1.0");
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("FAIL: manifest points at a non-existent (pruned _npx) launcher — does NOT re-stage, reports not-installed", async () => {
+    const s = sandbox();
+    try {
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "data"),
+        XDG_CONFIG_HOME: join(s.root, "config"),
+      };
+
+      // Hand-write a stale manifest pointing at an old _npx cli.js that was
+      // pruned. This is the exact failure the diagnostic must catch.
+      const manifestPath = join(
+        env.XDG_CONFIG_HOME,
+        "google-chrome",
+        "NativeMessagingHosts",
+        `${HOST_NAME}.json`,
+      );
+      mkdirSync(join(manifestPath, ".."), { recursive: true });
+      const deadLauncher = join(s.root, "_npx", "deleted", "cli.js");
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({ name: HOST_NAME, path: deadLauncher, type: "stdio" }),
+      );
+
+      let verifierCalled = false;
+      const result = await runHostVerify({
+        platform: "linux",
+        home,
+        env,
+        verify: async () => {
+          verifierCalled = true;
+          return { ok: true, pong: true, version: "0.1.0" };
+        },
+      });
+
+      // Verify must NOT spawn a stale/missing launcher.
+      expect(verifierCalled).toBe(false);
+      expect(result.ok).toBe(false);
+      expect(result.detail).toBeTruthy();
+      // And it must NOT have silently re-staged a launcher to make itself pass.
+      const stagedLauncher = join(
+        env.XDG_DATA_HOME,
+        "neurodock",
+        "native-host",
+        "runtime",
+        `${HOST_NAME}.sh`,
+      );
+      expect(existsSync(stagedLauncher)).toBe(false);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("FAIL: no manifest at all — reports not installed and does not install", async () => {
+    const s = sandbox();
+    try {
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "data"),
+        XDG_CONFIG_HOME: join(s.root, "config"),
+      };
+      const result = await runHostVerify({
+        platform: "linux",
+        home,
+        env,
+        verify: async () => ({ ok: true, pong: true, version: "0.1.0" }),
+      });
+      expect(result.ok).toBe(false);
+      expect(result.detail).toMatch(/install/i);
+      // No manifest was written, no runtime staged.
+      const manifestPath = join(
+        env.XDG_CONFIG_HOME,
+        "google-chrome",
+        "NativeMessagingHosts",
+        `${HOST_NAME}.json`,
+      );
+      expect(existsSync(manifestPath)).toBe(false);
+    } finally {
+      s.cleanup();
+    }
+  });
+});

--- a/packages/native-host/README.md
+++ b/packages/native-host/README.md
@@ -69,7 +69,51 @@ Per-platform manifest locations:
 | Windows  | Manifest JSON under `%APPDATA%\NeuroDock\native-host\`; registry pointer under `HKCU\Software\<browser>\NativeMessagingHosts\com.neurodock.profile` (via `reg.exe`) |
 
 Uninstall removes every manifest and registry pointer the install step
-created.
+created, plus the staged runtime directory below — no orphans.
+
+### Staging and the launcher (how Chrome actually launches the host)
+
+Install does NOT point the manifest at the package's `dist/cli.js`. That
+path is unstable: run via `npx`/`pnpx`, it lives in npm's `_npx` cache,
+which npm prunes and rotates, so the manifest would eventually point at a
+deleted file. A bare `.js` is also not launchable by Chrome on Windows.
+
+Instead, install **stages** a self-contained copy of the runtime into a
+stable per-user directory and points the manifest at a **launcher** there:
+
+| Platform | Staged runtime dir                                                              | Launcher                    |
+| -------- | ------------------------------------------------------------------------------- | --------------------------- |
+| macOS    | `~/Library/Application Support/NeuroDock/native-host/runtime/`                  | `com.neurodock.profile.sh`  |
+| Linux    | `$XDG_DATA_HOME/neurodock/native-host/runtime/` (fallback `~/.local/share/...`) | `com.neurodock.profile.sh`  |
+| Windows  | `%APPDATA%\NeuroDock\native-host\runtime\`                                      | `com.neurodock.profile.bat` |
+
+The launcher embeds the absolute `node` binary that ran the installer and
+forces the `run` subcommand before forwarding Chrome's args (Chrome passes
+the calling extension's origin, e.g. `chrome-extension://<id>/`, as the
+first arg). `dist/cli.js` is a single bundled file with `ajv` / `yaml`
+inlined, so the relocated copy resolves zero bare imports and survives the
+`_npx` cache being pruned.
+
+### Verifying a live launch
+
+`doctor` verifies the **already-installed** host. It reads the on-disk
+Chromium manifest, resolves the `path` Chrome would launch, and spawns
+exactly that launcher, exchanging a `ping`/pong over the length-prefixed
+protocol:
+
+```bash
+neurodock-native-host doctor   # or `neurodock doctor` from the CLI
+```
+
+This exercises a real launch (file present, launchable, speaks the
+protocol) rather than merely asserting that manifests/registry keys exist.
+Crucially, `doctor` does **not** re-stage or re-register — it reflects the
+user's real install. If the host is not installed, or the manifest points at
+a launcher that no longer exists (e.g. an old `_npx` cache file that npm
+pruned), `doctor` reports a clear failure telling you to run
+`neurodock host install`; it never silently repairs the install. On
+macOS/Linux the launcher is a `0755` `#!/bin/sh` script spawned directly
+(`shell: false`); only the Windows `.bat` goes through the shell.
 
 ## Profile path precedence
 

--- a/packages/native-host/package.json
+++ b/packages/native-host/package.json
@@ -26,7 +26,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node scripts/bundle-cli.mjs",
     "lint": "echo 'native-host: lint via tsc strict mode' && pnpm typecheck",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.21",
+    "esbuild": ">=0.28.1",
     "rimraf": "^6.0.1",
     "tsx": "^4.22.4",
     "typescript": "^5.7.2",

--- a/packages/native-host/scripts/bundle-cli.mjs
+++ b/packages/native-host/scripts/bundle-cli.mjs
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * Bundle the host bin (`src/cli.ts`) into a single self-contained
+ * `dist/cli.js` with its runtime deps (ajv, ajv-formats, yaml) inlined.
+ *
+ * Why: the installer STAGES this file into a stable per-user directory and
+ * points the native-messaging manifest's launcher at it (see
+ * src/registration/staging.ts). Once relocated out of npm's `_npx` cache the
+ * file must resolve ZERO bare imports — npm prunes the cache, and a published
+ * install flattens deps into a shared node_modules the staged copy can't see.
+ * A bundle is the only artifact that is reliably relocatable across npm and
+ * pnpm layouts, so the staged host is truly self-contained.
+ *
+ * tsc still emits the per-module `dist/**` (the programmatic API the CLI
+ * imports with its OWN node_modules); this step overwrites only `dist/cli.js`
+ * with the bundle.
+ */
+import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(here, "..");
+
+await build({
+  entryPoints: [resolve(packageRoot, "src", "cli.ts")],
+  outfile: resolve(packageRoot, "dist", "cli.js"),
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  // platform:node keeps node: builtins external; everything else (ajv / yaml
+  // / the host's own modules) is inlined into the single output file.
+  //
+  // ajv and yaml are CommonJS. esbuild's ESM output replaces their internal
+  // `require(...)` with a shim that throws "Dynamic require ... not supported"
+  // unless a real `require` exists. Re-create one from import.meta.url so the
+  // inlined CJS deps load their node: builtins (process, util, ...) at runtime.
+  //
+  // No shebang banner: the launcher invokes `node cli.js run` explicitly, and
+  // a `#!` line would be a syntax error if the staged copy is ever loaded as
+  // CommonJS. The bundle stays ESM; staging drops a `{"type":"module"}`
+  // package.json next to it so node treats the relocated `.js` as ESM even
+  // outside the package (where `.js` would otherwise default to CommonJS).
+  banner: {
+    js: [
+      'import { createRequire as __nd_createRequire } from "node:module";',
+      "const require = __nd_createRequire(import.meta.url);",
+    ].join("\n"),
+  },
+  logLevel: "info",
+});

--- a/packages/native-host/src/cli.ts
+++ b/packages/native-host/src/cli.ts
@@ -14,16 +14,18 @@
  * The bin defaults to `run` so the script can be wired directly into a
  * native-messaging manifest without a wrapper.
  */
-import { fileURLToPath } from "node:url";
-import { realpathSync } from "node:fs";
+import { homedir } from "node:os";
 import { runHost } from "./index.js";
 import {
   detectPlatform,
-  register,
-  unregister,
+  registerWithStaging,
+  unregisterWithStaging,
+  resolveInstalledLauncher,
   withDefaultExtensionIds,
   HOST_NAME,
+  type StagingPlatform,
 } from "./registration/index.js";
+import { verifyLiveLaunch } from "./doctor.js";
 
 const USAGE = `neurodock-native-host <command> [options]
 
@@ -33,6 +35,7 @@ Commands:
                  --extension-id <id>    Repeatable. Defaults to the published
                                         NeuroDock extension ID for each store.
   uninstall    Remove all NeuroDock host manifests / registry entries.
+  doctor       Spawn the registered launcher and verify a live ping/pong.
   run          Behave as the stdio native messaging host (default).
   --help       Print this help.
   --version    Print the host version.
@@ -40,14 +43,31 @@ Commands:
 Examples:
   neurodock-native-host install --extension-id abcdefghijklmnopqrstuvwxyzabcdef
   neurodock-native-host uninstall
+  neurodock-native-host doctor
 `;
 
 interface ParsedArgs {
-  readonly command: "install" | "uninstall" | "run" | "help" | "version";
+  readonly command:
+    | "install"
+    | "uninstall"
+    | "doctor"
+    | "run"
+    | "help"
+    | "version";
   readonly extensionIds: ReadonlyArray<string>;
 }
 
-function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
+/**
+ * Parse the bin's argv.
+ *
+ * Critically, Chrome launches the host with the calling extension's ORIGIN as
+ * the first arg (e.g. `chrome-extension://<id>/`; on Windows also a
+ * `--parent-window=` arg). Any first arg that is NOT a known subcommand must
+ * route to `run`, NOT to help — otherwise the host greets Chrome with usage
+ * text and the port disconnects. Only the explicit management subcommands and
+ * the help/version flags are recognised; everything else is `run`.
+ */
+export function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
   if (argv.length === 0) {
     return { command: "run", extensionIds: [] };
   }
@@ -60,6 +80,9 @@ function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
   }
   if (first === "run") {
     return { command: "run", extensionIds: [] };
+  }
+  if (first === "doctor") {
+    return { command: "doctor", extensionIds: [] };
   }
   if (first === "install" || first === "uninstall") {
     const ids: string[] = [];
@@ -75,15 +98,11 @@ function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
     }
     return { command: first, extensionIds: ids };
   }
-  return { command: "help", extensionIds: [] };
-}
-
-function resolveHostPath(): string {
-  try {
-    return realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return fileURLToPath(import.meta.url);
-  }
+  // Unrecognised first arg (a Chrome-supplied origin / --parent-window=, or
+  // anything else): behave as the stdio host. This is belt-and-suspenders for
+  // the launcher, which already forces `run`, and keeps an older
+  // direct-cli.js manifest working.
+  return { command: "run", extensionIds: [] };
 }
 
 interface PrintableOutcome {
@@ -104,9 +123,16 @@ function printOutcomes(outcomes: ReadonlyArray<PrintableOutcome>): void {
   }
 }
 
-export function main(
+/**
+ * Run the bin. Returns an exit code for terminal subcommands, or `null` for
+ * `run` — the stdio host owns the process lifecycle and exits only when
+ * stdin closes, so the caller must NOT `process.exit` after a `run`. (The
+ * original code did, killing the host before it could read a single frame —
+ * the deepest layer of defect #3.)
+ */
+export async function main(
   argv: ReadonlyArray<string> = process.argv.slice(2),
-): number {
+): Promise<number | null> {
   const parsed = parseArgs(argv);
 
   if (parsed.command === "help") {
@@ -119,7 +145,7 @@ export function main(
   }
   if (parsed.command === "run") {
     runHost();
-    return 0;
+    return null;
   }
   if (parsed.command === "install") {
     // Always register the published store ids; any --extension-id values
@@ -127,17 +153,53 @@ export function main(
     const ids = withDefaultExtensionIds(parsed.extensionIds);
     const platformId = detectPlatform();
     process.stdout.write(`Installing ${HOST_NAME} (platform=${platformId})\n`);
-    const outcomes = register({
-      hostPath: resolveHostPath(),
-      allowedExtensionIds: ids,
-    });
-    printOutcomes(outcomes);
+    // Stage the runtime into a stable per-user dir and register manifests
+    // whose `path` is the launcher (never this npx-cache cli.js).
+    const result = registerWithStaging({ allowedExtensionIds: ids });
+    process.stdout.write(`  launcher: ${result.launcherPath}\n`);
+    printOutcomes(result.outcomes);
     return 0;
+  }
+  if (parsed.command === "doctor") {
+    process.stdout.write(`Verifying ${HOST_NAME} live launch...\n`);
+    const platform = detectPlatform();
+    if (platform === "unsupported") {
+      process.stdout.write(
+        "  [fail] native messaging host is not supported on this platform\n",
+      );
+      return 1;
+    }
+    // READ the installed launcher from the on-disk manifest — verify the
+    // user's REAL install, never re-stage (which would mask a broken install).
+    const installed = resolveInstalledLauncher(
+      platform as StagingPlatform,
+      homedir(),
+      process.env,
+    );
+    if (!installed.ok) {
+      process.stdout.write(
+        `  [fail] ${installed.detail ?? "native host not installed"}\n`,
+      );
+      return 1;
+    }
+    process.stdout.write(`  launcher: ${installed.launcherPath}\n`);
+    const verify = await verifyLiveLaunch(installed.launcherPath);
+    if (verify.ok) {
+      process.stdout.write(
+        `  [ok] host responded to ping (version ${verify.version ?? "?"})\n`,
+      );
+      return 0;
+    }
+    process.stdout.write(
+      `  [fail] ${verify.detail ?? "host did not respond"}\n`,
+    );
+    return 1;
   }
   if (parsed.command === "uninstall") {
     const platformId = detectPlatform();
     process.stdout.write(`Removing ${HOST_NAME} (platform=${platformId})\n`);
-    const outcomes = unregister();
+    // Symmetric uninstall: manifests/registry AND the staged runtime tree.
+    const outcomes = unregisterWithStaging();
     printOutcomes(outcomes);
     return 0;
   }
@@ -151,5 +213,11 @@ const invokedFromCli =
     process.argv[1].endsWith("neurodock-native-host"));
 
 if (invokedFromCli) {
-  process.exit(main());
+  void main().then((code) => {
+    // `run` returns null: the host keeps the process alive until stdin
+    // closes, so do not exit here. Terminal subcommands return a number.
+    if (code !== null) {
+      process.exit(code);
+    }
+  });
 }

--- a/packages/native-host/src/doctor.ts
+++ b/packages/native-host/src/doctor.ts
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * Live-launch verification: spawn the registered launcher exactly as Chrome
+ * would and exchange a `ping`/pong over the length-prefixed stdio protocol.
+ *
+ * This is the check that would have caught all three shipped defects:
+ *   - a manifest pointing at a deleted npx-cache file -> spawn fails;
+ *   - a bare `.js` Chrome cannot launch on Windows -> spawn fails;
+ *   - the host printing help instead of running -> no valid pong frame.
+ *
+ * `neurodock doctor` (CLI) and `neurodock-native-host doctor` (bin) both
+ * call this against the launcher the registration wrote.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import {
+  encodeMessage,
+  tryDecodeMessage,
+  HOST_VERSION,
+  type HostResponse,
+  type PingData,
+} from "./protocol.js";
+
+export interface VerifyOptions {
+  /** Hard cap on the whole exchange. Defaults to 8s. */
+  readonly timeoutMs?: number;
+}
+
+export interface VerifyResult {
+  readonly ok: boolean;
+  readonly pong: boolean;
+  readonly version: string | null;
+  readonly detail?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 8000;
+
+/**
+ * Spawn `launcherPath` and exchange a single ping/pong. Resolves (never
+ * rejects) with a structured result so callers can fold it into a check list.
+ */
+export function verifyLiveLaunch(
+  launcherPath: string,
+  options: VerifyOptions = {},
+): Promise<VerifyResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return new Promise<VerifyResult>((resolve) => {
+    if (!existsSync(launcherPath)) {
+      resolve({
+        ok: false,
+        pong: false,
+        version: null,
+        detail: `Launcher not found at ${launcherPath}. Re-run 'neurodock host install'.`,
+      });
+      return;
+    }
+
+    let settled = false;
+    const finish = (result: VerifyResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        child.kill();
+      } catch {
+        // already gone
+      }
+      resolve(result);
+    };
+
+    let child: ChildProcess;
+    try {
+      // Windows cannot CreateProcess a `.bat` directly — cmd.exe must
+      // interpret it — so on win32 we go through the shell. On macOS/Linux the
+      // launcher is a `0755` `#!/bin/sh` script: spawn it directly with
+      // shell:false so no shell parses the path (removes any theoretical
+      // shell-metachar concern about the launcher path).
+      const useShell = process.platform === "win32";
+      child = spawn(launcherPath, [], {
+        stdio: ["pipe", "pipe", "ignore"],
+        shell: useShell,
+      });
+    } catch (err) {
+      finish({
+        ok: false,
+        pong: false,
+        version: null,
+        detail: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      finish({
+        ok: false,
+        pong: false,
+        version: null,
+        detail: `No response within ${timeoutMs}ms.`,
+      });
+    }, timeoutMs);
+
+    child.on("error", (err: Error) => {
+      finish({
+        ok: false,
+        pong: false,
+        version: null,
+        detail: err.message,
+      });
+    });
+
+    child.on("exit", (code) => {
+      // We now close stdin right after the ping, so a healthy host pongs and
+      // then exits 0 on EOF. The pong frame ('data') and the process 'exit'
+      // can race, so defer the failure verdict by a tick to let any buffered
+      // stdout drain and call finish() first. If a pong was already decoded,
+      // `settled` makes this a no-op. A genuine no-protocol exit (e.g. the
+      // host printed help and quit) still fails.
+      setImmediate(() => {
+        finish({
+          ok: false,
+          pong: false,
+          version: null,
+          detail: `Host exited (code ${
+            code ?? "null"
+          }) without a valid response.`,
+        });
+      });
+    });
+
+    let buffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+    if (child.stdout) {
+      child.stdout.on("data", (chunk: Buffer) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        let step;
+        try {
+          step = tryDecodeMessage(buffer);
+        } catch (err) {
+          finish({
+            ok: false,
+            pong: false,
+            version: null,
+            detail: err instanceof Error ? err.message : String(err),
+          });
+          return;
+        }
+        if (!step) return;
+        const response = step.message as HostResponse<PingData>;
+        const data = response.data;
+        const pong = response.ok === true && data != null && data.pong === true;
+        finish({
+          ok: pong,
+          pong,
+          version: data?.version ?? response.version ?? null,
+          ...(pong
+            ? {}
+            : {
+                detail: response.error ?? "Host did not return a valid pong.",
+              }),
+        });
+      });
+    }
+
+    // Send the ping the moment the child is up, then close stdin. Ending
+    // stdin exercises the host's clean stdin-EOF exit path (its `end` handler
+    // does process.exit(0)) instead of relying solely on child.kill().
+    try {
+      const frame = encodeMessage({ op: "ping", id: "doctor" });
+      child.stdin?.write(frame);
+      child.stdin?.end();
+    } catch (err) {
+      finish({
+        ok: false,
+        pong: false,
+        version: HOST_VERSION,
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+}

--- a/packages/native-host/src/index.ts
+++ b/packages/native-host/src/index.ts
@@ -104,6 +104,8 @@ export { detectCapabilities } from "./capabilities.js";
 export type { CapabilityProbeDeps } from "./capabilities.js";
 export { encodeMessage, tryDecodeMessage, HOST_VERSION } from "./protocol.js";
 export { resolveProfilePath, readProfile, writeProfile } from "./profile-io.js";
+export { verifyLiveLaunch } from "./doctor.js";
+export type { VerifyOptions, VerifyResult } from "./doctor.js";
 export type {
   HostRequest,
   HostResponse,

--- a/packages/native-host/src/registration/index.ts
+++ b/packages/native-host/src/registration/index.ts
@@ -6,10 +6,16 @@
  * Platform-dispatching registration entry point used by `neurodock host install`
  * and the bin `neurodock-native-host install`.
  */
-import { platform } from "node:os";
+import { homedir, platform } from "node:os";
 import { registerDarwin, unregisterDarwin } from "./darwin.js";
 import { registerLinux, unregisterLinux } from "./linux.js";
 import { registerWindows, unregisterWindows } from "./windows.js";
+import {
+  resolveSourceDistDir,
+  stageRuntime,
+  removeStagedRuntime,
+  type StagingPlatform,
+} from "./staging.js";
 import type {
   RegistrationOptions,
   RegistrationOutcome,
@@ -70,6 +76,147 @@ export function unregister(
   }
 }
 
+/**
+ * Register one platform directly, bypassing live OS detection. Used by
+ * `registerWithStaging` so the per-OS path is exercisable in tests.
+ */
+function registerForPlatform(
+  p: StagingPlatform,
+  opts: RegistrationOptions,
+): ReadonlyArray<RegistrationOutcome> {
+  switch (p) {
+    case "darwin":
+      return registerDarwin(opts);
+    case "linux":
+      return registerLinux(opts);
+    case "win32":
+      return registerWindows(opts);
+  }
+}
+
+function unregisterForPlatform(
+  p: StagingPlatform,
+  opts: UnregisterOptions,
+): ReadonlyArray<RegistrationOutcome> {
+  switch (p) {
+    case "darwin":
+      return unregisterDarwin(opts);
+    case "linux":
+      return unregisterLinux(opts);
+    case "win32":
+      return unregisterWindows(opts);
+  }
+}
+
+export interface UnregisterWithStagingOptions {
+  readonly platform?: StagingPlatform;
+  readonly home?: string;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * The symmetric uninstall: remove manifests / registry pointers AND the
+ * staged runtime tree, so nothing the install step created is left behind.
+ */
+export function unregisterWithStaging(
+  opts: UnregisterWithStagingOptions = {},
+): ReadonlyArray<RegistrationOutcome> {
+  const detected = detectPlatform();
+  const p: StagingPlatform | "unsupported" =
+    opts.platform ?? (detected === "unsupported" ? "unsupported" : detected);
+  if (p === "unsupported") {
+    return unregister(opts);
+  }
+  const home = opts.home ?? homedir();
+  const env = opts.env ?? process.env;
+  const outcomes = unregisterForPlatform(p, { home, env });
+  removeStagedRuntime(p, home, env);
+  return outcomes;
+}
+
+export interface RegisterWithStagingOptions {
+  readonly allowedExtensionIds: ReadonlyArray<string>;
+  /** Defaults to the live OS; tests pass an explicit platform. */
+  readonly platform?: StagingPlatform;
+  /** Defaults to `os.homedir()`. */
+  readonly home?: string;
+  /** Defaults to `process.env`. */
+  readonly env?: NodeJS.ProcessEnv;
+  /**
+   * The native-host `dist/` to copy from. Defaults to this package's own
+   * dist, resolved from the running module.
+   */
+  readonly sourceDistDir?: string;
+  /**
+   * Absolute node binary embedded in the launcher. Defaults to the node
+   * running the installer (`process.execPath`).
+   */
+  readonly nodePath?: string;
+}
+
+export interface RegisterWithStagingResult {
+  readonly platform: SupportedPlatform | "unsupported";
+  readonly launcherPath: string;
+  readonly runtimeDir: string;
+  readonly outcomes: ReadonlyArray<RegistrationOutcome>;
+}
+
+/**
+ * The connectable install path: stage the runtime into a stable per-user
+ * dir, write a launcher Chrome can execute, then register manifests/registry
+ * pointers whose `path` is the LAUNCHER (never the raw, npx-cache cli.js).
+ */
+export function registerWithStaging(
+  opts: RegisterWithStagingOptions,
+): RegisterWithStagingResult {
+  const detected = detectPlatform();
+  const p: StagingPlatform | "unsupported" =
+    opts.platform ?? (detected === "unsupported" ? "unsupported" : detected);
+
+  if (p === "unsupported") {
+    return {
+      platform: "unsupported",
+      launcherPath: "",
+      runtimeDir: "",
+      outcomes: [
+        {
+          browser: "unsupported",
+          manifestPath: "",
+          action: "skip",
+          detail: `Platform ${platform()} is not supported. Open an issue if you need this.`,
+        },
+      ],
+    };
+  }
+
+  const home = opts.home ?? homedir();
+  const env = opts.env ?? process.env;
+  const sourceDistDir = opts.sourceDistDir ?? resolveSourceDistDir();
+  const nodePath = opts.nodePath ?? process.execPath;
+
+  const staged = stageRuntime({
+    platform: p,
+    home,
+    env,
+    sourceDistDir,
+    nodePath,
+  });
+
+  const outcomes = registerForPlatform(p, {
+    hostPath: staged.launcherPath,
+    allowedExtensionIds: opts.allowedExtensionIds,
+    home,
+    env,
+  });
+
+  return {
+    platform: p,
+    launcherPath: staged.launcherPath,
+    runtimeDir: staged.runtimeDir,
+    outcomes,
+  };
+}
+
 export type {
   RegistrationOptions,
   RegistrationOutcome,
@@ -80,3 +227,11 @@ export {
   PUBLISHED_EXTENSION_IDS,
   withDefaultExtensionIds,
 } from "./types.js";
+export {
+  resolveSourceDistDir,
+  stableRuntimeDir,
+  chromiumManifestPath,
+  resolveInstalledLauncher,
+  type InstalledLauncher,
+  type StagingPlatform,
+} from "./staging.js";

--- a/packages/native-host/src/registration/linux.ts
+++ b/packages/native-host/src/registration/linux.ts
@@ -62,8 +62,9 @@ export function registerLinux(
   opts: RegistrationOptions,
 ): ReadonlyArray<RegistrationOutcome> {
   const home = opts.home ?? homedir();
+  const env = opts.env ?? process.env;
   const out: RegistrationOutcome[] = [];
-  for (const t of targets(home, process.env)) {
+  for (const t of targets(home, env)) {
     const manifestPath = join(t.dir, `${HOST_NAME}.json`);
     try {
       mkdirSync(t.dir, { recursive: true });
@@ -91,8 +92,9 @@ export function unregisterLinux(
   opts: UnregisterOptions = {},
 ): ReadonlyArray<RegistrationOutcome> {
   const home = opts.home ?? homedir();
+  const env = opts.env ?? process.env;
   const out: RegistrationOutcome[] = [];
-  for (const t of targets(home, process.env)) {
+  for (const t of targets(home, env)) {
     const manifestPath = join(t.dir, `${HOST_NAME}.json`);
     if (!existsSync(manifestPath)) {
       out.push({

--- a/packages/native-host/src/registration/staging.ts
+++ b/packages/native-host/src/registration/staging.ts
@@ -1,0 +1,370 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ */
+/**
+ * Stage the native-host runtime into a STABLE per-user directory and write a
+ * launcher Chrome can actually execute.
+ *
+ * Why this exists (three shipped defects this module fixes):
+ *
+ *   1. Pointing a native-messaging manifest's `path` at
+ *      `@neurodock/native-host/dist/cli.js` resolved relative to a `npx`
+ *      invocation lands inside npm's `_npx` cache, which npm prunes/rotates.
+ *      The manifest then points at a deleted file. We copy `dist/**` (pure
+ *      Node, zero runtime deps) into a stable location at install time.
+ *
+ *   2. Chrome on Windows cannot launch a bare `.js` as a native-messaging
+ *      host (it fails CreateProcess or runs under Windows Script Host, not
+ *      Node). We write a `.bat` (Windows) / `#!/bin/sh` wrapper (macOS,
+ *      Linux) that invokes the absolute node binary with the staged cli.js.
+ *
+ *   3. Chrome launches the host with the calling extension's origin as the
+ *      first CLI arg, which the old `parseArgs` treated as "print help". The
+ *      launcher forces the literal `run` subcommand BEFORE forwarding
+ *      Chrome's args, so the origin lands harmlessly after `run`.
+ *
+ * Everything here is OS-parameterised (`platform`, `home`, `env`, `nodePath`,
+ * `sourceDistDir` are all injected) so the per-OS artifacts are unit-testable
+ * on Linux CI without the actual OS.
+ */
+import {
+  cpSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  realpathSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { HOST_NAME } from "./types.js";
+
+export type StagingPlatform = "darwin" | "linux" | "win32";
+
+// A double-quote closes the quoted "<path>" in the launcher; any C0 control
+// char (incl. CR / LF / NUL) could splice an extra launcher line. Defined as a
+// constructed RegExp so the source file stays free of literal control bytes.
+// eslint-disable-next-line no-control-regex
+const UNSAFE_PATH_CHARS = new RegExp('["\\u0000-\\u001f]');
+
+/**
+ * Reject a runtime directory that could not be embedded safely inside a
+ * quoted launcher path. A double-quote, newline, or other control char in the
+ * resolved dir — which could arrive via a hostile `XDG_DATA_HOME` / `APPDATA`
+ * — would break out of the quoted `"<path>"` in the `.sh` / `.bat` launcher
+ * (shell injection / a broken launcher). The legitimate per-user data roots
+ * never contain these, so failing fast is safe and cheap.
+ */
+function assertSafeRuntimeDir(dir: string): void {
+  if (UNSAFE_PATH_CHARS.test(dir)) {
+    throw new Error(
+      "Refusing to stage the native host: the resolved runtime directory " +
+        "contains an unsafe character (a double-quote or control character). " +
+        "Check your APPDATA / XDG_DATA_HOME environment.",
+    );
+  }
+}
+
+/**
+ * The stable, per-user directory the runtime is staged into. Lives next to
+ * (or under) the same NeuroDock data root the per-OS registration already
+ * uses, so uninstall can find and remove it.
+ *
+ *   Windows: %APPDATA%\NeuroDock\native-host\runtime\
+ *   macOS:   ~/Library/Application Support/NeuroDock/native-host/runtime/
+ *   Linux:   $XDG_DATA_HOME/neurodock/native-host/runtime/
+ *            (fallback ~/.local/share/neurodock/native-host/runtime/)
+ */
+export function stableRuntimeDir(
+  platform: StagingPlatform,
+  home: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (platform === "win32") {
+    const appdata = env["APPDATA"];
+    const root =
+      appdata && appdata.trim().length > 0
+        ? appdata
+        : join(home, "AppData", "Roaming");
+    return join(root, "NeuroDock", "native-host", "runtime");
+  }
+  if (platform === "darwin") {
+    return join(
+      home,
+      "Library",
+      "Application Support",
+      "NeuroDock",
+      "native-host",
+      "runtime",
+    );
+  }
+  // linux
+  const xdgData = env["XDG_DATA_HOME"];
+  const dataRoot =
+    xdgData && xdgData.trim().length > 0
+      ? xdgData
+      : join(home, ".local", "share");
+  return join(dataRoot, "neurodock", "native-host", "runtime");
+}
+
+/**
+ * Absolute path to the Chromium (Chrome/Chromium/Brave/Edge/Vivaldi) native
+ * messaging host manifest that the per-OS registration writes. This is the
+ * file `neurodock doctor` reads to discover the ALREADY-INSTALLED launcher —
+ * verify must reflect the real on-disk install, never re-stage.
+ *
+ *   Windows: %APPDATA%\NeuroDock\native-host\com.neurodock.profile.json
+ *            (a single manifest file the HKCU registry pointers reference)
+ *   macOS:   ~/Library/Application Support/Google/Chrome/NativeMessagingHosts/
+ *            com.neurodock.profile.json
+ *   Linux:   $XDG_CONFIG_HOME/google-chrome/NativeMessagingHosts/
+ *            com.neurodock.profile.json (fallback ~/.config)
+ *
+ * Chrome is the canonical reference manifest; on macOS/Linux the other
+ * Chromium browsers each get their own copy with an identical `path`, so any
+ * one of them resolves the same launcher. We read Chrome's.
+ */
+export function chromiumManifestPath(
+  platform: StagingPlatform,
+  home: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  if (platform === "win32") {
+    const appdata = env["APPDATA"];
+    const root =
+      appdata && appdata.trim().length > 0
+        ? appdata
+        : join(home, "AppData", "Roaming");
+    return join(root, "NeuroDock", "native-host", `${HOST_NAME}.json`);
+  }
+  if (platform === "darwin") {
+    return join(
+      home,
+      "Library",
+      "Application Support",
+      "Google",
+      "Chrome",
+      "NativeMessagingHosts",
+      `${HOST_NAME}.json`,
+    );
+  }
+  // linux
+  const xdg = env["XDG_CONFIG_HOME"];
+  const cfg = xdg && xdg.trim().length > 0 ? xdg : join(home, ".config");
+  return join(
+    cfg,
+    "google-chrome",
+    "NativeMessagingHosts",
+    `${HOST_NAME}.json`,
+  );
+}
+
+export interface InstalledLauncher {
+  readonly ok: boolean;
+  /** The `path` the on-disk manifest points at (empty when unreadable). */
+  readonly launcherPath: string;
+  /** The manifest file that was read. */
+  readonly manifestPath: string;
+  /** Why resolution failed (absent on success). */
+  readonly detail?: string;
+}
+
+/**
+ * Resolve the launcher of the ALREADY-INSTALLED host by reading the on-disk
+ * Chromium manifest and returning its `path` — without staging or registering
+ * anything. This is what `neurodock doctor` spawns, so the diagnostic
+ * reflects the user's real install: a manifest that points at a pruned old
+ * `_npx` cache cli.js, or a missing manifest, FAILS rather than being silently
+ * repaired.
+ */
+export function resolveInstalledLauncher(
+  platform: StagingPlatform,
+  home: string,
+  env: NodeJS.ProcessEnv,
+): InstalledLauncher {
+  const manifestPath = chromiumManifestPath(platform, home, env);
+  if (!existsSync(manifestPath)) {
+    return {
+      ok: false,
+      launcherPath: "",
+      manifestPath,
+      detail:
+        `native host not installed (no manifest at ${manifestPath}) — ` +
+        "run 'neurodock host install'.",
+    };
+  }
+  let parsed: { path?: unknown };
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      path?: unknown;
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      launcherPath: "",
+      manifestPath,
+      detail:
+        `native host manifest at ${manifestPath} is unreadable ` +
+        `(${err instanceof Error ? err.message : String(err)}) — ` +
+        "re-run 'neurodock host install'.",
+    };
+  }
+  const launcherPath = typeof parsed.path === "string" ? parsed.path : "";
+  if (launcherPath.length === 0) {
+    return {
+      ok: false,
+      launcherPath: "",
+      manifestPath,
+      detail:
+        `native host manifest at ${manifestPath} has no usable 'path' — ` +
+        "re-run 'neurodock host install'.",
+    };
+  }
+  if (!existsSync(launcherPath)) {
+    return {
+      ok: false,
+      launcherPath,
+      manifestPath,
+      detail:
+        `native host launcher is missing at ${launcherPath} ` +
+        "(the manifest points at a path that no longer exists) — " +
+        "re-run 'neurodock host install'.",
+    };
+  }
+  return { ok: true, launcherPath, manifestPath };
+}
+
+/** Launcher file name per OS: a `.bat` on Windows, a `.sh` elsewhere. */
+export function launcherFileName(platform: StagingPlatform): string {
+  return platform === "win32" ? `${HOST_NAME}.bat` : `${HOST_NAME}.sh`;
+}
+
+/**
+ * The exact content of the launcher script. The launcher embeds the absolute
+ * node binary (so Chrome's launch environment need not have `node` on PATH)
+ * and forces the `run` subcommand before forwarding Chrome's args.
+ */
+export function buildLauncherContent(
+  platform: StagingPlatform,
+  nodePath: string,
+  stagedCliPath: string,
+): string {
+  if (platform === "win32") {
+    // CRLF line endings; quote both paths; `run` before `%*` so Chrome's
+    // origin arg (and `--parent-window=`) arrive after the subcommand.
+    return "@echo off\r\n" + `"${nodePath}" "${stagedCliPath}" run %*\r\n`;
+  }
+  // POSIX shell wrapper. `exec` replaces the shell so the stdio pipes Chrome
+  // opened are inherited directly by node. `run` precedes "$@".
+  return `#!/bin/sh\nexec "${nodePath}" "${stagedCliPath}" run "$@"\n`;
+}
+
+export interface StageRuntimeOptions {
+  readonly platform: StagingPlatform;
+  readonly home: string;
+  readonly env: NodeJS.ProcessEnv;
+  /** The native-host `dist/` directory to copy from. */
+  readonly sourceDistDir: string;
+  /** Absolute path to the node binary to embed in the launcher. */
+  readonly nodePath: string;
+}
+
+export interface StageRuntimeResult {
+  /** The stable directory the dist tree was copied into. */
+  readonly runtimeDir: string;
+  /** Absolute path to the staged cli.js the launcher invokes. */
+  readonly stagedCliPath: string;
+  /** Absolute path to the launcher the manifest should point at. */
+  readonly launcherPath: string;
+}
+
+/**
+ * Copy the source `dist/**` into the stable runtime dir (idempotent — a
+ * re-install overwrites), then write the launcher and return its path. The
+ * returned `launcherPath` is what the manifest `path` should be set to.
+ */
+export function stageRuntime(opts: StageRuntimeOptions): StageRuntimeResult {
+  const runtimeDir = stableRuntimeDir(opts.platform, opts.home, opts.env);
+  // Guard before we write a launcher whose body embeds the dir inside quotes:
+  // an unsafe char here would produce a broken / injectable launcher.
+  assertSafeRuntimeDir(runtimeDir);
+  mkdirSync(runtimeDir, { recursive: true });
+
+  // Overwrite-copy the entire dist tree. cpSync with recursive+force makes
+  // the operation idempotent across re-installs. The dist is a self-contained
+  // bundle (cli.js inlines ajv / ajv-formats / yaml — see build:bundle), so
+  // the relocated host resolves zero bare imports and survives npm pruning
+  // the `_npx` cache without staging any node_modules.
+  cpSync(opts.sourceDistDir, runtimeDir, { recursive: true, force: true });
+
+  // The bundled cli.js is ESM. Outside the package (the staged copy has no
+  // ancestor package.json) node treats a bare `.js` as CommonJS, which would
+  // fail to parse the ESM bundle. Drop a minimal module manifest so the
+  // relocated file is loaded as ESM.
+  writeFileSync(
+    join(runtimeDir, "package.json"),
+    JSON.stringify({ type: "module" }, null, 2) + "\n",
+  );
+
+  const stagedCliPath = join(runtimeDir, "cli.js");
+  const launcherPath = join(runtimeDir, launcherFileName(opts.platform));
+  const content = buildLauncherContent(
+    opts.platform,
+    opts.nodePath,
+    stagedCliPath,
+  );
+  // 0o755 so the unix wrapper is executable. Windows ignores the mode bits.
+  writeFileSync(launcherPath, content, { mode: 0o755 });
+
+  return { runtimeDir, stagedCliPath, launcherPath };
+}
+
+/**
+ * Remove the staged runtime tree so uninstall leaves no orphan launcher /
+ * bundle behind. Best-effort: a missing dir is a no-op.
+ */
+export function removeStagedRuntime(
+  platform: StagingPlatform,
+  home: string,
+  env: NodeJS.ProcessEnv,
+): { removed: boolean; dir: string } {
+  const runtimeDir = stableRuntimeDir(platform, home, env);
+  if (!existsSync(runtimeDir)) {
+    return { removed: false, dir: runtimeDir };
+  }
+  try {
+    rmSync(runtimeDir, { recursive: true, force: true });
+    return { removed: true, dir: runtimeDir };
+  } catch {
+    return { removed: false, dir: runtimeDir };
+  }
+}
+
+/**
+ * Resolve the native-host package's own `dist/` directory from the running
+ * module, robust to symlinks. When this file runs from `dist/registration/`,
+ * the dist root is one level up.
+ *
+ * Falls back to the directory this module sits in if the expected layout is
+ * not found — callers may also pass an explicit `sourceDistDir`.
+ */
+export function resolveSourceDistDir(): string {
+  let here: string;
+  try {
+    here = realpathSync(dirname(fileURLToPath(import.meta.url)));
+  } catch {
+    here = dirname(fileURLToPath(import.meta.url));
+  }
+  // dist/registration/staging.js -> dist
+  const distRoot = dirname(here);
+  if (existsSync(join(distRoot, "cli.js"))) {
+    return distRoot;
+  }
+  // Already at dist (defensive) or running from source under tsx.
+  if (existsSync(join(here, "cli.js"))) {
+    return here;
+  }
+  return distRoot;
+}

--- a/packages/native-host/src/registration/types.ts
+++ b/packages/native-host/src/registration/types.ts
@@ -60,10 +60,18 @@ export interface RegistrationOptions {
   readonly hostPath: string;
   readonly allowedExtensionIds: ReadonlyArray<string>;
   readonly home?: string;
+  /**
+   * Override the process environment used to resolve config roots
+   * (`APPDATA`, `XDG_CONFIG_HOME`). Defaults to `process.env`. Tests inject
+   * a sandbox env so the per-OS layout is exercisable without writing to the
+   * real user directories.
+   */
+  readonly env?: NodeJS.ProcessEnv;
 }
 
 export interface UnregisterOptions {
   readonly home?: string;
+  readonly env?: NodeJS.ProcessEnv;
 }
 
 export function buildManifest(

--- a/packages/native-host/src/registration/windows.ts
+++ b/packages/native-host/src/registration/windows.ts
@@ -108,7 +108,8 @@ export function registerWindows(
   opts: RegistrationOptions,
 ): ReadonlyArray<RegistrationOutcome> {
   const home = opts.home ?? homedir();
-  const dir = manifestDir(home, process.env);
+  const env = opts.env ?? process.env;
+  const dir = manifestDir(home, env);
   mkdirSync(dir, { recursive: true });
 
   const chromiumManifestPath = join(dir, `${HOST_NAME}.json`);
@@ -146,7 +147,8 @@ export function unregisterWindows(
   opts: UnregisterOptions = {},
 ): ReadonlyArray<RegistrationOutcome> {
   const home = opts.home ?? homedir();
-  const dir = manifestDir(home, process.env);
+  const env = opts.env ?? process.env;
+  const dir = manifestDir(home, env);
   const chromiumManifestPath = join(dir, `${HOST_NAME}.json`);
   const firefoxManifestPath = join(dir, `${HOST_NAME}.firefox.json`);
 

--- a/packages/native-host/tests/cli-doctor.test.ts
+++ b/packages/native-host/tests/cli-doctor.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir, platform as osPlatform } from "node:os";
+import { join } from "node:path";
+import { main } from "../src/cli.js";
+import { HOST_NAME } from "../src/registration/types.js";
+
+function sandbox(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "nd-bindoc-"));
+  return {
+    root,
+    cleanup: () => {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe("neurodock-native-host doctor (bin) verifies the INSTALLED launcher", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports a not-installed FAIL (exit 1) when no manifest is on disk — does not re-stage", async () => {
+    const s = sandbox();
+    const isWin = osPlatform() === "win32";
+    // Point the per-OS manifest root at an empty sandbox so the bin sees no
+    // installed manifest. (Skips on platforms whose root we cannot redirect
+    // here; the CLI-level test covers Linux explicitly.)
+    if (!isWin && !process.env["XDG_CONFIG_HOME"]) {
+      // On a unix host with no XDG override we cannot safely redirect; rely on
+      // the explicit Linux coverage in the CLI doctor tests.
+    }
+    const savedAppData = process.env["APPDATA"];
+    const savedXdg = process.env["XDG_CONFIG_HOME"];
+    const out: string[] = [];
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        out.push(typeof chunk === "string" ? chunk : chunk.toString());
+        return true;
+      });
+    try {
+      if (isWin) {
+        process.env["APPDATA"] = join(s.root, "appdata-empty");
+      } else {
+        process.env["XDG_CONFIG_HOME"] = join(s.root, "config-empty");
+      }
+      const code = await main(["doctor"]);
+      expect(code).toBe(1);
+      const text = out.join("");
+      expect(text).toMatch(/fail/i);
+      expect(text).toMatch(/install/i);
+    } finally {
+      spy.mockRestore();
+      if (savedAppData === undefined) delete process.env["APPDATA"];
+      else process.env["APPDATA"] = savedAppData;
+      if (savedXdg === undefined) delete process.env["XDG_CONFIG_HOME"];
+      else process.env["XDG_CONFIG_HOME"] = savedXdg;
+      s.cleanup();
+    }
+  });
+
+  it("FAILS (exit 1) when the installed manifest points at a missing launcher", async () => {
+    const s = sandbox();
+    const isWin = osPlatform() === "win32";
+    const savedAppData = process.env["APPDATA"];
+    const savedXdg = process.env["XDG_CONFIG_HOME"];
+    const out: string[] = [];
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: string | Uint8Array): boolean => {
+        out.push(typeof chunk === "string" ? chunk : chunk.toString());
+        return true;
+      });
+    try {
+      let manifestPath: string;
+      if (isWin) {
+        const appdata = join(s.root, "appdata");
+        process.env["APPDATA"] = appdata;
+        manifestPath = join(
+          appdata,
+          "NeuroDock",
+          "native-host",
+          `${HOST_NAME}.json`,
+        );
+      } else {
+        const cfg = join(s.root, "config");
+        process.env["XDG_CONFIG_HOME"] = cfg;
+        manifestPath = join(
+          cfg,
+          "google-chrome",
+          "NativeMessagingHosts",
+          `${HOST_NAME}.json`,
+        );
+      }
+      mkdirSync(join(manifestPath, ".."), { recursive: true });
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          name: HOST_NAME,
+          path: join(s.root, "gone", "launcher"),
+          type: "stdio",
+        }),
+      );
+      const code = await main(["doctor"]);
+      expect(code).toBe(1);
+      const text = out.join("");
+      expect(text).toMatch(/fail/i);
+      expect(text).toMatch(/install/i);
+    } finally {
+      spy.mockRestore();
+      if (savedAppData === undefined) delete process.env["APPDATA"];
+      else process.env["APPDATA"] = savedAppData;
+      if (savedXdg === undefined) delete process.env["XDG_CONFIG_HOME"];
+      else process.env["XDG_CONFIG_HOME"] = savedXdg;
+      s.cleanup();
+    }
+  });
+});

--- a/packages/native-host/tests/cli-parse-args.test.ts
+++ b/packages/native-host/tests/cli-parse-args.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs } from "../src/cli.js";
+
+describe("parseArgs", () => {
+  it("runs the stdio host when argv is empty", () => {
+    expect(parseArgs([]).command).toBe("run");
+  });
+
+  it("runs when the first arg is literally 'run'", () => {
+    expect(parseArgs(["run"]).command).toBe("run");
+  });
+
+  it("routes a chrome-extension:// origin arg to run (defect #3 fix)", () => {
+    // Chrome launches the host with the calling extension's origin as the
+    // first CLI arg. An unrecognised first arg must NOT print help.
+    expect(
+      parseArgs(["chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/"])
+        .command,
+    ).toBe("run");
+  });
+
+  it("routes a moz-extension:// origin arg to run", () => {
+    expect(
+      parseArgs(["moz-extension://abcdef12-3456-7890-abcd-ef1234567890/"])
+        .command,
+    ).toBe("run");
+  });
+
+  it("routes Chrome's Windows --parent-window= arg to run", () => {
+    expect(parseArgs(["--parent-window=0"]).command).toBe("run");
+  });
+
+  it("still recognises install / uninstall explicitly", () => {
+    expect(parseArgs(["install"]).command).toBe("install");
+    expect(parseArgs(["uninstall"]).command).toBe("uninstall");
+  });
+
+  it("still recognises --help and --version explicitly", () => {
+    expect(parseArgs(["--help"]).command).toBe("help");
+    expect(parseArgs(["-h"]).command).toBe("help");
+    expect(parseArgs(["--version"]).command).toBe("version");
+    expect(parseArgs(["-v"]).command).toBe("version");
+  });
+
+  it("still collects --extension-id values on install", () => {
+    const parsed = parseArgs(["install", "--extension-id", "myid"]);
+    expect(parsed.command).toBe("install");
+    expect(parsed.extensionIds).toContain("myid");
+  });
+});

--- a/packages/native-host/tests/doctor.test.ts
+++ b/packages/native-host/tests/doctor.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir, platform as osPlatform } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { stageRuntime } from "../src/registration/staging.js";
+import { verifyLiveLaunch } from "../src/doctor.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// tests/ -> package root -> dist
+const builtDist = resolve(here, "..", "dist");
+
+function sandbox(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "nd-doctor-"));
+  return {
+    root,
+    cleanup: () => {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe("verifyLiveLaunch", () => {
+  beforeAll(() => {
+    if (!existsSync(join(builtDist, "cli.js"))) {
+      throw new Error(
+        `native-host dist not built at ${builtDist}; run \`pnpm --filter @neurodock/native-host build\` before the live-launch test.`,
+      );
+    }
+  });
+
+  it("spawns the staged launcher and exchanges a ping/pong over the length-prefixed protocol", async () => {
+    // This is the test that would have caught all three shipped defects: it
+    // stages the runtime out of the real built dist, writes a launcher for
+    // the CURRENT OS, then SPAWNS that launcher (as Chrome would) and asserts
+    // a valid pong. Staging for the current platform means the launcher is
+    // actually runnable here (a .bat on Windows, a .sh on unix).
+    const isWin = osPlatform() === "win32";
+    const s = sandbox();
+    try {
+      const staged = stageRuntime({
+        platform: isWin ? "win32" : "linux",
+        home: join(s.root, "home"),
+        env: isWin
+          ? { APPDATA: join(s.root, "appdata") }
+          : { XDG_DATA_HOME: join(s.root, "xdgdata") },
+        sourceDistDir: builtDist,
+        nodePath: process.execPath,
+      });
+
+      const result = await verifyLiveLaunch(staged.launcherPath, {
+        timeoutMs: 10000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.pong).toBe(true);
+      expect(typeof result.version).toBe("string");
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("spawns the unix launcher with shell:false — a path containing a space still launches", async () => {
+    // Fix #2: on macOS/Linux the .sh wrapper is 0755 + shebang, so it must be
+    // spawned directly (shell:false). With shell:true the space in the dir
+    // would split the launcher path into two argv tokens and fail to launch.
+    // (Windows .bat genuinely needs shell:true, so this assertion is unix-only.)
+    if (osPlatform() === "win32") return;
+    const s = sandbox();
+    try {
+      const home = join(s.root, "home with space");
+      const staged = stageRuntime({
+        platform: "linux",
+        home,
+        env: { XDG_DATA_HOME: join(s.root, "xdg data home") },
+        sourceDistDir: builtDist,
+        nodePath: process.execPath,
+      });
+      expect(staged.launcherPath).toContain(" ");
+      const result = await verifyLiveLaunch(staged.launcherPath, {
+        timeoutMs: 10000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.pong).toBe(true);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("closes stdin after the ping so the host exits via its clean stdin-EOF path", async () => {
+    // Fix #3: verifyLiveLaunch must call child.stdin.end() right after writing
+    // the ping frame. We assert the staged host both pongs AND exits 0 (its
+    // stdin "end" handler does process.exit(0)) within the window — i.e. it
+    // was driven to a clean EOF shutdown, not left hanging until kill().
+    const isWin = osPlatform() === "win32";
+    const s = sandbox();
+    try {
+      const staged = stageRuntime({
+        platform: isWin ? "win32" : "linux",
+        home: join(s.root, "home"),
+        env: isWin
+          ? { APPDATA: join(s.root, "appdata") }
+          : { XDG_DATA_HOME: join(s.root, "xdgdata") },
+        sourceDistDir: builtDist,
+        nodePath: process.execPath,
+      });
+      const result = await verifyLiveLaunch(staged.launcherPath, {
+        timeoutMs: 10000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.pong).toBe(true);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("reports ok:false with a detail when the launcher path does not exist", async () => {
+    const s = sandbox();
+    try {
+      const missing = join(s.root, "does-not-exist.sh");
+      const result = await verifyLiveLaunch(missing, { timeoutMs: 3000 });
+      expect(result.ok).toBe(false);
+      expect(result.detail).toBeTruthy();
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("reports ok:false when the launched process never speaks the protocol", async () => {
+    const s = sandbox();
+    try {
+      // A launcher that exits immediately without writing a frame (defect #3:
+      // the host printing help instead of a pong). Simulate by pointing at a
+      // node one-liner that prints text and exits.
+      const dummyCli = join(s.root, "dummy.js");
+      writeFileSync(
+        dummyCli,
+        "process.stdout.write('USAGE: help text\\n'); process.exit(0);\n",
+      );
+      let launcherPath: string;
+      if (osPlatform() === "win32") {
+        launcherPath = join(s.root, "dummy.bat");
+        writeFileSync(
+          launcherPath,
+          `@echo off\r\n"${process.execPath}" "${dummyCli}" %*\r\n`,
+        );
+      } else {
+        launcherPath = join(s.root, "dummy.sh");
+        writeFileSync(
+          launcherPath,
+          `#!/bin/sh\nexec "${process.execPath}" "${dummyCli}" "$@"\n`,
+          { mode: 0o755 },
+        );
+      }
+      const result = await verifyLiveLaunch(launcherPath, { timeoutMs: 3000 });
+      expect(result.ok).toBe(false);
+    } finally {
+      s.cleanup();
+    }
+  });
+});

--- a/packages/native-host/tests/installed-launcher.test.ts
+++ b/packages/native-host/tests/installed-launcher.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  chromiumManifestPath,
+  resolveInstalledLauncher,
+} from "../src/registration/staging.js";
+import { HOST_NAME } from "../src/registration/types.js";
+
+function sandbox(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "nd-installed-"));
+  return {
+    root,
+    cleanup: () => {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe("chromiumManifestPath", () => {
+  it("Windows: %APPDATA%\\NeuroDock\\native-host\\com.neurodock.profile.json", () => {
+    const p = chromiumManifestPath("win32", "C:\\Users\\me", {
+      APPDATA: "C:\\Users\\me\\AppData\\Roaming",
+    });
+    expect(p).toContain("NeuroDock");
+    expect(p).toContain("native-host");
+    expect(p).toContain(`${HOST_NAME}.json`);
+    expect(p).toContain("Roaming");
+  });
+
+  it("macOS: under Google/Chrome/NativeMessagingHosts", () => {
+    const p = chromiumManifestPath("darwin", "/Users/me", {});
+    expect(p).toContain("Library");
+    expect(p).toContain("Application Support");
+    expect(p).toContain("Google");
+    expect(p).toContain("Chrome");
+    expect(p).toContain("NativeMessagingHosts");
+    expect(p).toContain(`${HOST_NAME}.json`);
+  });
+
+  it("Linux: honours $XDG_CONFIG_HOME under google-chrome/NativeMessagingHosts", () => {
+    const p = chromiumManifestPath("linux", "/home/me", {
+      XDG_CONFIG_HOME: "/home/me/.xdgconfig",
+    });
+    expect(p).toContain(".xdgconfig");
+    expect(p).toContain("google-chrome");
+    expect(p).toContain("NativeMessagingHosts");
+    expect(p).toContain(`${HOST_NAME}.json`);
+  });
+
+  it("Linux: falls back to ~/.config when XDG_CONFIG_HOME unset", () => {
+    const p = chromiumManifestPath("linux", "/home/me", {});
+    expect(p).toContain(".config");
+    expect(p).toContain("google-chrome");
+  });
+});
+
+describe("resolveInstalledLauncher", () => {
+  it("reads the on-disk chromium manifest and returns its `path` when the launcher exists", () => {
+    const s = sandbox();
+    try {
+      const home = join(s.root, "home");
+      const env = { XDG_CONFIG_HOME: join(s.root, "config") };
+      // Stage a launcher file on disk and a manifest pointing at it.
+      const launcher = join(s.root, "runtime", `${HOST_NAME}.sh`);
+      mkdirSync(join(s.root, "runtime"), { recursive: true });
+      writeFileSync(launcher, "#!/bin/sh\nexec node\n", { mode: 0o755 });
+
+      const manifestPath = chromiumManifestPath("linux", home, env);
+      mkdirSync(join(manifestPath, ".."), { recursive: true });
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({ name: HOST_NAME, path: launcher, type: "stdio" }),
+      );
+
+      const r = resolveInstalledLauncher("linux", home, env);
+      expect(r.ok).toBe(true);
+      expect(r.launcherPath).toBe(launcher);
+      expect(r.manifestPath).toBe(manifestPath);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("FAILS when the manifest is missing (not installed)", () => {
+    const s = sandbox();
+    try {
+      const home = join(s.root, "home");
+      const env = { XDG_CONFIG_HOME: join(s.root, "config") };
+      const r = resolveInstalledLauncher("linux", home, env);
+      expect(r.ok).toBe(false);
+      expect(r.detail).toBeTruthy();
+      // Clear, actionable message that points the user at install.
+      expect(r.detail).toMatch(/install/i);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("FAILS when the manifest exists but its `path` does not exist on disk (stale/pruned launcher)", () => {
+    const s = sandbox();
+    try {
+      const home = join(s.root, "home");
+      const env = { XDG_CONFIG_HOME: join(s.root, "config") };
+      const manifestPath = chromiumManifestPath("linux", home, env);
+      mkdirSync(join(manifestPath, ".."), { recursive: true });
+      // Point at an old _npx cache file that no longer exists.
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          name: HOST_NAME,
+          path: join(s.root, "_npx", "deleted", "cli.js"),
+          type: "stdio",
+        }),
+      );
+
+      const r = resolveInstalledLauncher("linux", home, env);
+      expect(r.ok).toBe(false);
+      expect(r.launcherPath).toBe(join(s.root, "_npx", "deleted", "cli.js"));
+      expect(r.detail).toBeTruthy();
+      expect(r.detail).toMatch(/install/i);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("FAILS with a clear message when the manifest is unreadable JSON", () => {
+    const s = sandbox();
+    try {
+      const home = join(s.root, "home");
+      const env = { XDG_CONFIG_HOME: join(s.root, "config") };
+      const manifestPath = chromiumManifestPath("linux", home, env);
+      mkdirSync(join(manifestPath, ".."), { recursive: true });
+      writeFileSync(manifestPath, "{ this is not json");
+
+      const r = resolveInstalledLauncher("linux", home, env);
+      expect(r.ok).toBe(false);
+      expect(r.detail).toBeTruthy();
+    } finally {
+      s.cleanup();
+    }
+  });
+});

--- a/packages/native-host/tests/register-with-staging.test.ts
+++ b/packages/native-host/tests/register-with-staging.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  registerWithStaging,
+  unregisterWithStaging,
+} from "../src/registration/index.js";
+import { HOST_NAME } from "../src/registration/types.js";
+
+function sandbox(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "nd-regstage-"));
+  return {
+    root,
+    cleanup: () => {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe("registerWithStaging (Linux)", () => {
+  it("stages the runtime then writes manifests whose `path` is the staged launcher, not the raw cli.js", () => {
+    const s = sandbox();
+    try {
+      // Arrange: a fake source dist.
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// cli\n");
+
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "xdgdata"),
+        XDG_CONFIG_HOME: join(s.root, "xdgconfig"),
+      };
+
+      // Act
+      const result = registerWithStaging({
+        platform: "linux",
+        home,
+        env,
+        sourceDistDir: sourceDist,
+        nodePath: "/usr/bin/node",
+        allowedExtensionIds: ["abc"],
+      });
+
+      // Launcher staged.
+      expect(existsSync(result.launcherPath)).toBe(true);
+      expect(result.launcherPath).toMatch(/\.sh$/);
+
+      // A Chrome manifest was written and its `path` is the launcher.
+      const chromeManifestPath = join(
+        env.XDG_CONFIG_HOME,
+        "google-chrome",
+        "NativeMessagingHosts",
+        `${HOST_NAME}.json`,
+      );
+      expect(existsSync(chromeManifestPath)).toBe(true);
+      const manifest = JSON.parse(readFileSync(chromeManifestPath, "utf8")) as {
+        path: string;
+        allowed_origins: string[];
+      };
+      expect(manifest.path).toBe(result.launcherPath);
+      expect(manifest.path).not.toMatch(/cli\.js$/);
+      // allowed_origins behaviour unchanged.
+      expect(manifest.allowed_origins).toContain("chrome-extension://abc/");
+
+      // Firefox manifest also points at the launcher.
+      const firefoxManifestPath = join(
+        home,
+        ".mozilla",
+        "native-messaging-hosts",
+        `${HOST_NAME}.json`,
+      );
+      expect(existsSync(firefoxManifestPath)).toBe(true);
+      const ff = JSON.parse(readFileSync(firefoxManifestPath, "utf8")) as {
+        path: string;
+      };
+      expect(ff.path).toBe(result.launcherPath);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("unregisterWithStaging removes the staged runtime dir (no orphans)", () => {
+    const s = sandbox();
+    try {
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// cli\n");
+
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "xdgdata"),
+        XDG_CONFIG_HOME: join(s.root, "xdgconfig"),
+      };
+
+      const installed = registerWithStaging({
+        platform: "linux",
+        home,
+        env,
+        sourceDistDir: sourceDist,
+        nodePath: "/usr/bin/node",
+        allowedExtensionIds: ["abc"],
+      });
+      expect(existsSync(installed.runtimeDir)).toBe(true);
+      expect(existsSync(installed.launcherPath)).toBe(true);
+
+      unregisterWithStaging({ platform: "linux", home, env });
+
+      // The staged runtime tree is gone — no dangling launcher / bundle.
+      expect(existsSync(installed.runtimeDir)).toBe(false);
+      // And the manifests it pointed at are removed too.
+      const chromeManifestPath = join(
+        env.XDG_CONFIG_HOME,
+        "google-chrome",
+        "NativeMessagingHosts",
+        `${HOST_NAME}.json`,
+      );
+      expect(existsSync(chromeManifestPath)).toBe(false);
+    } finally {
+      s.cleanup();
+    }
+  });
+});

--- a/packages/native-host/tests/staging.test.ts
+++ b/packages/native-host/tests/staging.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+  statSync,
+} from "node:fs";
+import { tmpdir, platform as osPlatform } from "node:os";
+import { join } from "node:path";
+import {
+  stableRuntimeDir,
+  launcherFileName,
+  buildLauncherContent,
+  stageRuntime,
+} from "../src/registration/staging.js";
+
+function sandbox(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "nd-staging-"));
+  return {
+    root,
+    cleanup: () => {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
+
+describe("stableRuntimeDir", () => {
+  it("Windows: places runtime under %APPDATA%\\NeuroDock\\native-host\\runtime", () => {
+    const dir = stableRuntimeDir("win32", "C:\\Users\\me", {
+      APPDATA: "C:\\Users\\me\\AppData\\Roaming",
+    });
+    // Path separators are normalised by node:path on the host OS; assert the
+    // segments are present and stable rather than the literal separator.
+    expect(dir).toContain("NeuroDock");
+    expect(dir).toContain("native-host");
+    expect(dir).toContain("runtime");
+    expect(dir).toContain("Roaming");
+  });
+
+  it("Windows: falls back to home\\AppData\\Roaming when APPDATA unset", () => {
+    const dir = stableRuntimeDir("win32", "C:\\Users\\me", {});
+    expect(dir).toContain("AppData");
+    expect(dir).toContain("Roaming");
+    expect(dir).toContain("runtime");
+  });
+
+  it("macOS: places runtime under ~/Library/Application Support/NeuroDock/native-host/runtime", () => {
+    const dir = stableRuntimeDir("darwin", "/Users/me", {});
+    expect(dir).toContain("Library");
+    expect(dir).toContain("Application Support");
+    expect(dir).toContain("NeuroDock");
+    expect(dir).toContain("native-host");
+    expect(dir).toContain("runtime");
+  });
+
+  it("Linux: honours $XDG_DATA_HOME when set", () => {
+    const dir = stableRuntimeDir("linux", "/home/me", {
+      XDG_DATA_HOME: "/home/me/.xdgdata",
+    });
+    expect(dir).toContain(".xdgdata");
+    expect(dir).toContain("neurodock");
+    expect(dir).toContain("native-host");
+    expect(dir).toContain("runtime");
+  });
+
+  it("Linux: falls back to ~/.local/share when XDG_DATA_HOME unset", () => {
+    const dir = stableRuntimeDir("linux", "/home/me", {});
+    expect(dir).toContain(".local");
+    expect(dir).toContain("share");
+    expect(dir).toContain("neurodock");
+    expect(dir).toContain("runtime");
+  });
+});
+
+describe("launcherFileName", () => {
+  it("is a .bat on Windows", () => {
+    expect(launcherFileName("win32")).toBe("com.neurodock.profile.bat");
+  });
+  it("is a .sh on macOS / Linux", () => {
+    expect(launcherFileName("darwin")).toBe("com.neurodock.profile.sh");
+    expect(launcherFileName("linux")).toBe("com.neurodock.profile.sh");
+  });
+});
+
+describe("buildLauncherContent", () => {
+  it("Windows .bat invokes the embedded node.exe with the staged cli.js and forces 'run' before %*", () => {
+    const content = buildLauncherContent(
+      "win32",
+      "C:\\Program Files\\nodejs\\node.exe",
+      "C:\\Users\\me\\AppData\\Roaming\\NeuroDock\\native-host\\runtime\\cli.js",
+    );
+    // node + cli are quoted (paths can contain spaces).
+    expect(content).toContain('"C:\\Program Files\\nodejs\\node.exe"');
+    expect(content).toContain(
+      '"C:\\Users\\me\\AppData\\Roaming\\NeuroDock\\native-host\\runtime\\cli.js"',
+    );
+    // `run` precedes the forwarded args so Chrome's origin arg arrives after.
+    expect(content).toMatch(/run\s+%\*/);
+    // The order must be node, then cli.js, then the run subcommand, then %*.
+    // Match ` run ` with surrounding whitespace so the "run" inside the
+    // "runtime" path segment is not mistaken for the subcommand.
+    const nodeIdx = content.indexOf("node.exe");
+    const cliIdx = content.indexOf("cli.js");
+    const runIdx = content.search(/\srun\s/);
+    const argsIdx = content.indexOf("%*");
+    expect(nodeIdx).toBeLessThan(cliIdx);
+    expect(cliIdx).toBeLessThan(runIdx);
+    expect(runIdx).toBeLessThan(argsIdx);
+  });
+
+  it("unix wrapper has a shebang, exec's the embedded node + staged cli.js, forces 'run', and forwards \"$@\"", () => {
+    const content = buildLauncherContent(
+      "linux",
+      "/usr/bin/node",
+      "/home/me/.local/share/neurodock/native-host/runtime/cli.js",
+    );
+    expect(content.startsWith("#!/bin/sh")).toBe(true);
+    expect(content).toContain('exec "/usr/bin/node"');
+    expect(content).toContain(
+      '"/home/me/.local/share/neurodock/native-host/runtime/cli.js"',
+    );
+    expect(content).toMatch(/run\s+"\$@"/);
+    const nodeIdx = content.indexOf("/usr/bin/node");
+    const cliIdx = content.indexOf("cli.js");
+    const runIdx = content.indexOf(" run ");
+    const argsIdx = content.indexOf('"$@"');
+    expect(nodeIdx).toBeLessThan(cliIdx);
+    expect(cliIdx).toBeLessThan(runIdx);
+    expect(runIdx).toBeLessThan(argsIdx);
+  });
+});
+
+describe("stageRuntime", () => {
+  it("copies the source dist tree into the stable runtime dir and writes the launcher pointing at the staged cli.js", () => {
+    const s = sandbox();
+    try {
+      // Arrange: a fake source dist with cli.js + a nested file.
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(join(sourceDist, "registration"), { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// staged cli\n");
+      writeFileSync(join(sourceDist, "index.js"), "// staged index\n");
+      writeFileSync(
+        join(sourceDist, "registration", "index.js"),
+        "// nested\n",
+      );
+
+      const home = join(s.root, "home");
+      // Point the stable dir resolution into the sandbox via env/home.
+      const result = stageRuntime({
+        platform: "linux",
+        home,
+        env: { XDG_DATA_HOME: join(s.root, "xdgdata") },
+        sourceDistDir: sourceDist,
+        nodePath: "/usr/bin/node",
+      });
+
+      // The staged cli.js must exist and match source.
+      const stagedCli = join(result.runtimeDir, "cli.js");
+      expect(existsSync(stagedCli)).toBe(true);
+      expect(readFileSync(stagedCli, "utf8")).toBe("// staged cli\n");
+      // Nested files copied too.
+      expect(
+        existsSync(join(result.runtimeDir, "registration", "index.js")),
+      ).toBe(true);
+
+      // Launcher written, points at staged cli.js, and result.launcherPath matches.
+      expect(existsSync(result.launcherPath)).toBe(true);
+      const launcher = readFileSync(result.launcherPath, "utf8");
+      expect(launcher).toContain(stagedCli);
+      expect(launcher).toContain("/usr/bin/node");
+      expect(launcher).toMatch(/run\s+"\$@"/);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("is idempotent: a second stageRuntime overwrites the staged files", () => {
+    const s = sandbox();
+    try {
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// v1\n");
+
+      const home = join(s.root, "home");
+      const env = { XDG_DATA_HOME: join(s.root, "xdgdata") };
+      const first = stageRuntime({
+        platform: "linux",
+        home,
+        env,
+        sourceDistDir: sourceDist,
+        nodePath: "/usr/bin/node",
+      });
+      expect(readFileSync(join(first.runtimeDir, "cli.js"), "utf8")).toBe(
+        "// v1\n",
+      );
+
+      // Re-stage with updated source.
+      writeFileSync(join(sourceDist, "cli.js"), "// v2\n");
+      const second = stageRuntime({
+        platform: "linux",
+        home,
+        env,
+        sourceDistDir: sourceDist,
+        nodePath: "/usr/bin/node",
+      });
+      expect(second.runtimeDir).toBe(first.runtimeDir);
+      expect(readFileSync(join(second.runtimeDir, "cli.js"), "utf8")).toBe(
+        "// v2\n",
+      );
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("refuses to stage when the resolved runtime dir contains a double-quote (hostile XDG_DATA_HOME)", () => {
+    const s = sandbox();
+    try {
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// cli\n");
+      // A data root with a double-quote would land inside the launcher's
+      // quoted "<path>" and break out of it. Fail fast.
+      expect(() =>
+        stageRuntime({
+          platform: "linux",
+          home: join(s.root, "home"),
+          env: { XDG_DATA_HOME: `${s.root}/ev"il` },
+          sourceDistDir: sourceDist,
+          nodePath: "/usr/bin/node",
+        }),
+      ).toThrow(/unsafe character/i);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("refuses to stage when the resolved runtime dir contains a control character (newline)", () => {
+    const s = sandbox();
+    try {
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// cli\n");
+      expect(() =>
+        stageRuntime({
+          platform: "linux",
+          home: join(s.root, "home"),
+          env: { XDG_DATA_HOME: `${s.root}/ev\nil` },
+          sourceDistDir: sourceDist,
+          nodePath: "/usr/bin/node",
+        }),
+      ).toThrow(/unsafe character/i);
+    } finally {
+      s.cleanup();
+    }
+  });
+
+  it("makes the unix launcher executable (mode 0755)", () => {
+    // Windows filesystems do not honour POSIX mode bits, so this assertion
+    // is only meaningful on a unix host (where CI runs the unix branch).
+    if (osPlatform() === "win32") return;
+    const s = sandbox();
+    try {
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// cli\n");
+      const result = stageRuntime({
+        platform: "linux",
+        home: join(s.root, "home"),
+        env: { XDG_DATA_HOME: join(s.root, "xdgdata") },
+        sourceDistDir: sourceDist,
+        nodePath: "/usr/bin/node",
+      });
+      const mode = statSync(result.launcherPath).mode & 0o777;
+      expect(mode & 0o100).toBe(0o100);
+    } finally {
+      s.cleanup();
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       '@types/node':
         specifier: ^22.19.21
         version: 22.19.21
+      esbuild:
+        specifier: '>=0.28.1'
+        version: 0.28.1
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3


### PR DESCRIPTION
## What

The extension's "full NeuroDock" card always showed **"Not connected yet"** even after
`npx @neurodock/cli setup` and a green `doctor`. Tracing the install code found **four**
compounding defects in the native-messaging host — none ever exercised because only the
*registration* (files/registry exist) was verified, never a live Chrome launch:

1. **Ephemeral path** — the manifest `path` was registered as `…/npm-cache/_npx/<hash>/…/cli.js`; npm prunes that cache, so the path goes dead.
2. **Raw `.js` on Windows** — Chrome can't launch a `.js` as a native host (needs `.bat`/`.exe`).
3. **Origin arg → help** — Chrome launches the host with the extension origin as `argv[0]`; the bin routed any unrecognised first arg to "print usage" instead of running the stdio host.
4. **`process.exit(main())`** killed the `run` path before it read a frame.

## Fix

- **Stage** a self-contained esbuild bundle of the host into a **stable per-user dir** (survives npx-cache pruning); `uninstall` removes it.
- Write a **per-OS launcher** (`.bat` / `.sh`) that runs `node <staged cli.js> run "$@"` and point the manifest `path` at the **launcher** (fixes #1, #2, and forces `run` ahead of Chrome's origin arg).
- **`parseArgs`**: route `chrome-extension://…` / `moz-extension://…` / `--parent-window=` to `run`; **`main()` no longer `process.exit`es** the run path (#3, #4).
- **`neurodock doctor`** now spawns the **actual installed launcher** and exchanges a real ping/pong (read-only — no re-stage), so a broken/missing install is **diagnosed, not masked**.

## Review

`native-host-expert` (TDD). `code-reviewer` (APPROVE) + `security-reviewer` (no critical/high — launcher paths trusted+quoted, `shell:true` only on Windows now, esbuild pinned `>=0.28.1`). Fixes applied: doctor verifies the installed launcher instead of re-staging; Unix spawn `shell:false`; `stdin.end()` after ping; reject unsafe runtime paths; injectable uninstall deps.

## Test plan (verified on a real Windows box)

- [x] `neurodock doctor` **before** install → FAIL "native host not installed" (no side-effect staging)
- [x] after `neurodock host install` → **PASS**: real ping/pong (version 0.1.0) through the installed `.bat`
- [x] stale manifest (pruned-`_npx` path) → FAIL "launcher missing — re-run host install"
- [x] native-host 84 tests, cli 141 tests; both typecheck + build clean; esbuild bundle relocatable
- [x] `wrangler.jsonc` excluded