### PR TITLE
fix: connect native host via nativemessaging permission + report real host version

### DIFF
--- a/.changeset/extension-native-messaging-permission.md
+++ b/.changeset/extension-native-messaging-permission.md
@@ -1,0 +1,19 @@
+---
+"@neurodock/extension-browser": patch
+---
+
+fix(extension): declare nativemessaging so the native host can connect
+
+"full neurodock" never connected for any user. the manifest never declared the
+`nativeMessaging` permission, so `chrome.runtime.connectNative` was undefined and
+`probeNativeHost` silently reported "not connected" without ever launching the
+host. that is why clicking "check again" produced no network / console / service
+worker activity, while `neurodock doctor` — which spawns the launcher directly
+and bypasses chrome — passed.
+
+the permission is declared in `optional_permissions` (not `permissions`) and
+requested at runtime on the "turn on full neurodock" / "check again" user gesture
+via `chrome.permissions.request`, so a plain install shows no native-messaging
+warning. the auto-poll stays non-interactive and never prompts; the grant
+persists across restarts. verified against chrome, firefox 115+, and edge
+(`nativeMessaging` is requestable as an optional permission on all three).

--- a/.changeset/native-host-version-from-package.md
+++ b/.changeset/native-host-version-from-package.md
@@ -1,0 +1,13 @@
+---
+"@neurodock/native-host": patch
+---
+
+fix(native-host): report the real package version over ping and --version
+
+the host hardcoded "0.1.0" for both the native-messaging `ping` response and the
+`neurodock-native-host --version` flag, so it advertised a stale version on every
+build (e.g. `neurodock doctor` reported "version 0.1.0" against a 0.3.0 host).
+`HOST_VERSION` now derives from package.json — baked into the staged bundle at
+build time via an esbuild `define` (the staged copy has no real package.json to
+read), with a `createRequire` fallback for the tsc/dev/test path. no behaviour
+change beyond the reported version string.

--- a/packages/extension-browser/src/lib/full-setup.ts
+++ b/packages/extension-browser/src/lib/full-setup.ts
@@ -22,24 +22,29 @@ export function useFullSetupStatus(pollMs = 4000): {
   const [status, setStatus] = useState<FullSetupStatus>("checking");
   const mounted = useRef(true);
 
-  const probe = useCallback(async () => {
-    const hello = await probeNativeHost();
+  // `nativeMessaging` is an optional permission, so the auto-probe must stay
+  // NON-interactive (no prompt without a user gesture). The "Check again"
+  // button is the gesture that may request it — see `recheck`.
+  const probe = useCallback(async (interactive: boolean) => {
+    const hello = await probeNativeHost({ interactive });
     if (mounted.current) setStatus(hello.status);
   }, []);
 
   useEffect(() => {
     mounted.current = true;
-    void probe();
-    const id = pollMs > 0 ? setInterval(() => void probe(), pollMs) : undefined;
+    void probe(false);
+    const id =
+      pollMs > 0 ? setInterval(() => void probe(false), pollMs) : undefined;
     return () => {
       mounted.current = false;
       if (id) clearInterval(id);
     };
   }, [probe, pollMs]);
 
+  // User gesture: allowed to request the optional nativeMessaging permission.
   const recheck = useCallback(() => {
     setStatus("checking");
-    void probe();
+    void probe(true);
   }, [probe]);
 
   return { status, recheck };

--- a/packages/extension-browser/src/lib/native-host-client.ts
+++ b/packages/extension-browser/src/lib/native-host-client.ts
@@ -15,6 +15,7 @@
  * rather than thrown. The caller (profile.ts) then falls back to the
  * extension-local store. The native host is OPTIONAL.
  */
+import { getPermissionsApi } from "./permissions.js";
 
 export type NativeHostStatus = "active" | "absent" | "error";
 
@@ -69,53 +70,9 @@ function getRuntime(): NativeRuntime | null {
   return null;
 }
 
-interface NativePermissions {
-  contains(
-    perms: { permissions: string[] },
-    cb: (granted: boolean) => void,
-  ): void;
-  request(
-    perms: { permissions: string[] },
-    cb: (granted: boolean) => void,
-  ): void;
-}
-
-const NATIVE_MESSAGING_PERMISSION = { permissions: ["nativeMessaging"] };
-
-function getPermissions(): NativePermissions | null {
-  const g = globalThis as unknown as {
-    chrome?: { permissions?: NativePermissions };
-  };
-  return g.chrome?.permissions ?? null;
-}
-
-function hasNativeMessagingPermission(): Promise<boolean> {
-  const perms = getPermissions();
-  if (!perms) return Promise.resolve(false);
-  return new Promise((resolve) => {
-    try {
-      perms.contains(NATIVE_MESSAGING_PERMISSION, (granted) =>
-        resolve(Boolean(granted)),
-      );
-    } catch {
-      resolve(false);
-    }
-  });
-}
-
-function requestNativeMessagingPermission(): Promise<boolean> {
-  const perms = getPermissions();
-  if (!perms) return Promise.resolve(false);
-  return new Promise((resolve) => {
-    try {
-      perms.request(NATIVE_MESSAGING_PERMISSION, (granted) =>
-        resolve(Boolean(granted)),
-      );
-    } catch {
-      resolve(false);
-    }
-  });
-}
+const NATIVE_MESSAGING_PERMISSION: chrome.permissions.Permissions = {
+  permissions: ["nativeMessaging"],
+};
 
 /**
  * Ensure the optional `nativeMessaging` permission before opening a port.
@@ -134,9 +91,11 @@ function requestNativeMessagingPermission(): Promise<boolean> {
 function ensureNativeMessagingPermission(
   interactive: boolean,
 ): Promise<boolean> {
+  const perms = getPermissionsApi();
+  if (!perms) return Promise.resolve(false);
   return interactive
-    ? requestNativeMessagingPermission()
-    : hasNativeMessagingPermission();
+    ? perms.request(NATIVE_MESSAGING_PERMISSION)
+    : perms.contains(NATIVE_MESSAGING_PERMISSION);
 }
 
 interface PendingRequest {
@@ -295,6 +254,10 @@ export async function probeNativeHost(
 }
 
 export async function nativeHostGetProfile(): Promise<NativeHostGetResult | null> {
+  // Same gate as probeNativeHost (non-interactive — this is a background read,
+  // never a user gesture): without the permission connectNative is undefined,
+  // so report unavailable up front rather than silently failing in openSession.
+  if (!(await ensureNativeMessagingPermission(false))) return null;
   const session = openSession();
   if (!session) return null;
   try {
@@ -323,6 +286,17 @@ export async function nativeHostSetProfile(
   profile: Record<string, unknown>,
   opts: NativeHostSetOptions = {},
 ): Promise<NativeHostSetOutcome> {
+  // Same non-interactive gate as nativeHostGetProfile — a profile write is
+  // never a user gesture, so it must not prompt; without the permission the
+  // host is simply unreachable.
+  if (!(await ensureNativeMessagingPermission(false))) {
+    return {
+      ok: false,
+      confirmRequired: false,
+      error: "native host not available",
+      result: null,
+    };
+  }
   const session = openSession();
   if (!session) {
     return {

--- a/packages/extension-browser/src/lib/native-host-client.ts
+++ b/packages/extension-browser/src/lib/native-host-client.ts
@@ -69,6 +69,76 @@ function getRuntime(): NativeRuntime | null {
   return null;
 }
 
+interface NativePermissions {
+  contains(
+    perms: { permissions: string[] },
+    cb: (granted: boolean) => void,
+  ): void;
+  request(
+    perms: { permissions: string[] },
+    cb: (granted: boolean) => void,
+  ): void;
+}
+
+const NATIVE_MESSAGING_PERMISSION = { permissions: ["nativeMessaging"] };
+
+function getPermissions(): NativePermissions | null {
+  const g = globalThis as unknown as {
+    chrome?: { permissions?: NativePermissions };
+  };
+  return g.chrome?.permissions ?? null;
+}
+
+function hasNativeMessagingPermission(): Promise<boolean> {
+  const perms = getPermissions();
+  if (!perms) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    try {
+      perms.contains(NATIVE_MESSAGING_PERMISSION, (granted) =>
+        resolve(Boolean(granted)),
+      );
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+function requestNativeMessagingPermission(): Promise<boolean> {
+  const perms = getPermissions();
+  if (!perms) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    try {
+      perms.request(NATIVE_MESSAGING_PERMISSION, (granted) =>
+        resolve(Boolean(granted)),
+      );
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/**
+ * Ensure the optional `nativeMessaging` permission before opening a port.
+ *
+ * `nativeMessaging` is an OPTIONAL permission (declared in
+ * `optional_permissions`, not `permissions`), so `chrome.runtime.connectNative`
+ * is only exposed once the user grants it. The grant persists across restarts.
+ *
+ * - interactive (a user gesture — the "Check again" / "Turn on full NeuroDock"
+ *   button): call `request()` DIRECTLY. Firefox invalidates the user gesture
+ *   across an awaited `contains()`, and `request()` resolves true without a
+ *   prompt when the permission is already held.
+ * - non-interactive (auto-poll, background profile sync): only consult
+ *   `contains()` — never prompt.
+ */
+function ensureNativeMessagingPermission(
+  interactive: boolean,
+): Promise<boolean> {
+  return interactive
+    ? requestNativeMessagingPermission()
+    : hasNativeMessagingPermission();
+}
+
 interface PendingRequest {
   resolve: (value: NativeHostResponse) => void;
   reject: (err: Error) => void;
@@ -171,10 +241,35 @@ function openSession(): NativeHostSession | null {
   }
 }
 
+export interface ProbeOptions {
+  /**
+   * When true, request the optional `nativeMessaging` permission if it is not
+   * already granted. MUST originate from a user gesture (e.g. a button click)
+   * or the browser rejects the prompt. Defaults to false — auto-poll and
+   * background profile sync never prompt.
+   */
+  readonly interactive?: boolean;
+}
+
 /**
  * Probe the native host. Returns active/absent/error and never throws.
+ *
+ * Gated on the optional `nativeMessaging` permission: without it,
+ * `chrome.runtime.connectNative` is undefined and no host could ever be
+ * reached, so we report `absent` up front rather than silently failing later.
  */
-export async function probeNativeHost(): Promise<NativeHostHello> {
+export async function probeNativeHost(
+  opts: ProbeOptions = {},
+): Promise<NativeHostHello> {
+  const granted = await ensureNativeMessagingPermission(
+    opts.interactive ?? false,
+  );
+  if (!granted) {
+    return {
+      status: "absent",
+      detail: "nativeMessaging permission not granted",
+    };
+  }
   const session = openSession();
   if (!session) {
     return {

--- a/packages/extension-browser/src/lib/permissions.ts
+++ b/packages/extension-browser/src/lib/permissions.ts
@@ -83,14 +83,19 @@ function isAlwaysGranted(origin: string): boolean {
   }
 }
 
-interface PermissionsApi {
+export interface PermissionsApi {
   readonly request: (perm: chrome.permissions.Permissions) => Promise<boolean>;
   readonly contains: (perm: chrome.permissions.Permissions) => Promise<boolean>;
   readonly remove: (perm: chrome.permissions.Permissions) => Promise<boolean>;
   readonly getAll: () => Promise<chrome.permissions.Permissions>;
 }
 
-function getPermissionsApi(): PermissionsApi | null {
+/**
+ * Promise-wrapped `chrome.permissions` surface, or null when the API is
+ * unavailable. Shared by the host-permission helpers below and by the native
+ * messaging client (native-host-client.ts) so both speak one wrapper.
+ */
+export function getPermissionsApi(): PermissionsApi | null {
   const c = (globalThis as { chrome?: typeof chrome }).chrome;
   if (!c?.permissions) return null;
   return {

--- a/packages/extension-browser/tests/unit/manifest-native-messaging.test.ts
+++ b/packages/extension-browser/tests/unit/manifest-native-messaging.test.ts
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * Regression guard for the connectivity bug: the extension manifest must
+ * declare `nativeMessaging` so `chrome.runtime.connectNative` is exposed.
+ * It lives in `optional_permissions` (not `permissions`) on purpose — the
+ * permission is requested at runtime on the "Turn on full NeuroDock" gesture,
+ * so a plain install adds no native-messaging warning. Without this entry the
+ * native host can never connect and "full NeuroDock" stays unreachable.
+ */
+import { describe, it, expect } from "vitest";
+import config from "../../wxt.config.js";
+
+function manifestOf(cfg: unknown): {
+  permissions?: string[];
+  optional_permissions?: string[];
+} {
+  const m = (cfg as { manifest?: unknown }).manifest;
+  return (m ?? {}) as {
+    permissions?: string[];
+    optional_permissions?: string[];
+  };
+}
+
+describe("extension manifest — native messaging", () => {
+  it("declares nativeMessaging as an optional permission", () => {
+    const { optional_permissions } = manifestOf(config);
+    expect(optional_permissions ?? []).toContain("nativeMessaging");
+  });
+
+  it("does NOT put nativeMessaging in install-time permissions (no install warning)", () => {
+    const { permissions } = manifestOf(config);
+    expect(permissions ?? []).not.toContain("nativeMessaging");
+  });
+});

--- a/packages/extension-browser/tests/unit/native-host-client-permissions.test.ts
+++ b/packages/extension-browser/tests/unit/native-host-client-permissions.test.ts
@@ -18,7 +18,11 @@
  *     granted.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { probeNativeHost } from "../../src/lib/native-host-client.js";
+import {
+  probeNativeHost,
+  nativeHostGetProfile,
+  nativeHostSetProfile,
+} from "../../src/lib/native-host-client.js";
 
 interface FakePort {
   postMessage(value: unknown): void;
@@ -144,6 +148,33 @@ describe("probeNativeHost permission gating", () => {
     const { requestSpy } = stubChrome({ contains: false, request: true });
     const hello = await probeNativeHost();
     expect(hello.status).toBe("absent");
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  // The profile read/write helpers share the same gate (non-interactive,
+  // never prompt) so a future caller cannot reach connectNative without the
+  // permission — consistency the reviewers flagged.
+  it("nativeHostGetProfile returns null and never connects without the permission", async () => {
+    const { connectNativeSpy, requestSpy } = stubChrome({
+      contains: false,
+      request: true,
+    });
+    const result = await nativeHostGetProfile();
+    expect(result).toBeNull();
+    expect(connectNativeSpy).not.toHaveBeenCalled();
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it("nativeHostSetProfile reports not-available and never connects without the permission", async () => {
+    const { connectNativeSpy, requestSpy } = stubChrome({
+      contains: false,
+      request: true,
+    });
+    const outcome = await nativeHostSetProfile({
+      identity: { display_name: "T", neurotypes: [] },
+    });
+    expect(outcome.ok).toBe(false);
+    expect(connectNativeSpy).not.toHaveBeenCalled();
     expect(requestSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension-browser/tests/unit/native-host-client-permissions.test.ts
+++ b/packages/extension-browser/tests/unit/native-host-client-permissions.test.ts
@@ -1,0 +1,149 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * `probeNativeHost` must be gated on the optional `nativeMessaging`
+ * permission. Regression guard: the shipped extension never declared
+ * `nativeMessaging`, so `chrome.runtime.connectNative` was `undefined` and
+ * the probe silently returned "absent" without ever launching the host —
+ * the reason "full NeuroDock" never connected for anyone.
+ *
+ * Contract:
+ *   - non-interactive probe: proceeds only when the permission is already
+ *     held (chrome.permissions.contains); never prompts; never touches
+ *     connectNative otherwise.
+ *   - interactive probe (the "Check again" gesture): calls
+ *     chrome.permissions.request directly — an awaited contains() first
+ *     would invalidate the user gesture in Firefox — then proceeds only if
+ *     granted.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { probeNativeHost } from "../../src/lib/native-host-client.js";
+
+interface FakePort {
+  postMessage(value: unknown): void;
+  disconnect(): void;
+  onMessage: { addListener(fn: (msg: unknown) => void): void };
+  onDisconnect: { addListener(fn: () => void): void };
+}
+
+/** A port that replies to a `ping` with a well-formed pong on a microtask. */
+function makePingablePort(version: string): FakePort {
+  const listeners: Array<(m: unknown) => void> = [];
+  return {
+    postMessage(value: unknown) {
+      const msg = value as { id?: string; op?: string };
+      if (msg.op !== "ping") return;
+      const reply = {
+        id: msg.id,
+        ok: true,
+        op: "ping",
+        data: { pong: true, version },
+        error: null,
+        version,
+      };
+      queueMicrotask(() => listeners.forEach((l) => l(reply)));
+    },
+    disconnect() {},
+    onMessage: {
+      addListener: (fn) => {
+        listeners.push(fn);
+      },
+    },
+    onDisconnect: { addListener: () => {} },
+  };
+}
+
+interface ChromeStub {
+  connectNativeSpy: ReturnType<typeof vi.fn>;
+  containsSpy: ReturnType<typeof vi.fn>;
+  requestSpy: ReturnType<typeof vi.fn>;
+}
+
+function stubChrome(opts: {
+  contains: boolean;
+  request: boolean;
+  port?: FakePort;
+}): ChromeStub {
+  const connectNativeSpy = vi.fn(() => opts.port ?? makePingablePort("0.0.0"));
+  const containsSpy = vi.fn((_p: unknown, cb: (granted: boolean) => void) =>
+    cb(opts.contains),
+  );
+  const requestSpy = vi.fn((_p: unknown, cb: (granted: boolean) => void) =>
+    cb(opts.request),
+  );
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: { connectNative: connectNativeSpy, lastError: undefined },
+    permissions: { contains: containsSpy, request: requestSpy },
+  };
+  return { connectNativeSpy, containsSpy, requestSpy };
+}
+
+describe("probeNativeHost permission gating", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    delete (globalThis as unknown as { chrome?: unknown }).chrome;
+  });
+
+  it("non-interactive: returns absent and never connects when permission is not held", async () => {
+    const { connectNativeSpy, requestSpy } = stubChrome({
+      contains: false,
+      request: true,
+    });
+    const hello = await probeNativeHost({ interactive: false });
+    expect(hello.status).toBe("absent");
+    expect(connectNativeSpy).not.toHaveBeenCalled();
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it("non-interactive: connects and pings when permission is already held", async () => {
+    const { connectNativeSpy, requestSpy } = stubChrome({
+      contains: true,
+      request: false,
+      port: makePingablePort("0.3.0"),
+    });
+    const hello = await probeNativeHost({ interactive: false });
+    expect(hello.status).toBe("active");
+    expect(hello.version).toBe("0.3.0");
+    expect(connectNativeSpy).toHaveBeenCalledWith("com.neurodock.profile");
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it("interactive: requests the permission (gesture-preserving) and connects when granted", async () => {
+    const { connectNativeSpy, requestSpy, containsSpy } = stubChrome({
+      contains: false,
+      request: true,
+      port: makePingablePort("0.3.0"),
+    });
+    const hello = await probeNativeHost({ interactive: true });
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(requestSpy.mock.calls[0]?.[0]).toEqual({
+      permissions: ["nativeMessaging"],
+    });
+    // Gesture preservation: request() is called directly, not gated behind
+    // an awaited contains().
+    expect(containsSpy).not.toHaveBeenCalled();
+    expect(hello.status).toBe("active");
+    expect(connectNativeSpy).toHaveBeenCalledWith("com.neurodock.profile");
+  });
+
+  it("interactive: returns absent and never connects when the user denies", async () => {
+    const { connectNativeSpy, requestSpy } = stubChrome({
+      contains: false,
+      request: false,
+    });
+    const hello = await probeNativeHost({ interactive: true });
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(hello.status).toBe("absent");
+    expect(connectNativeSpy).not.toHaveBeenCalled();
+  });
+
+  it("defaults to non-interactive when no options are passed", async () => {
+    const { requestSpy } = stubChrome({ contains: false, request: true });
+    const hello = await probeNativeHost();
+    expect(hello.status).toBe("absent");
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension-browser/tests/unit/native-host-client.test.ts
+++ b/packages/extension-browser/tests/unit/native-host-client.test.ts
@@ -121,6 +121,12 @@ function installFakeRuntime(
       },
       lastError: undefined as { message?: string } | undefined,
     },
+    // probeNativeHost is gated on the optional `nativeMessaging` permission.
+    // These existing tests exercise the post-permission path, so grant it.
+    permissions: {
+      contains: (_p: unknown, cb: (granted: boolean) => void) => cb(true),
+      request: (_p: unknown, cb: (granted: boolean) => void) => cb(true),
+    },
   };
   (globalThis as unknown as { chrome?: unknown }).chrome = fakeChrome;
   return () => {

--- a/packages/extension-browser/wxt.config.ts
+++ b/packages/extension-browser/wxt.config.ts
@@ -102,6 +102,15 @@ export default defineConfig({
       "scripting",
       "notifications",
     ],
+    // "Full NeuroDock" reaches the on-disk profile.yaml through the
+    // com.neurodock.profile native messaging host. nativeMessaging is OPTIONAL
+    // (not in `permissions`) on purpose: a plain install must not show a
+    // "Communicate with cooperating native applications" warning. It is
+    // requested at runtime on the "Turn on full NeuroDock" gesture via
+    // chrome.permissions.request — the same consent-first pattern used for
+    // optional_host_permissions. Without this entry chrome.runtime.connectNative
+    // is undefined and the host can never connect.
+    optional_permissions: ["nativeMessaging"],
     host_permissions: [
       "https://mail.google.com/*",
       "https://app.slack.com/*",

--- a/packages/native-host/scripts/bundle-cli.mjs
+++ b/packages/native-host/scripts/bundle-cli.mjs
@@ -32,6 +32,11 @@ const packageRoot = resolve(here, "..");
 const { version } = JSON.parse(
   readFileSync(resolve(packageRoot, "package.json"), "utf8"),
 );
+if (typeof version !== "string" || version.length === 0) {
+  throw new Error(
+    "native-host: package.json has no usable version to bake into the bundle",
+  );
+}
 
 await build({
   entryPoints: [resolve(packageRoot, "src", "cli.ts")],

--- a/packages/native-host/scripts/bundle-cli.mjs
+++ b/packages/native-host/scripts/bundle-cli.mjs
@@ -20,9 +20,18 @@
 import { build } from "esbuild";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { readFileSync } from "node:fs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(here, "..");
+
+// Bake the package version into the bundle. The staged copy Chrome launches
+// has no real package.json to read at runtime (staging drops only a
+// `{"type":"module"}` shim), so protocol.ts reads this define instead. See
+// resolveHostVersion() in src/protocol.ts.
+const { version } = JSON.parse(
+  readFileSync(resolve(packageRoot, "package.json"), "utf8"),
+);
 
 await build({
   entryPoints: [resolve(packageRoot, "src", "cli.ts")],
@@ -49,6 +58,9 @@ await build({
       'import { createRequire as __nd_createRequire } from "node:module";',
       "const require = __nd_createRequire(import.meta.url);",
     ].join("\n"),
+  },
+  define: {
+    __NEURODOCK_HOST_VERSION__: JSON.stringify(version),
   },
   logLevel: "info",
 });

--- a/packages/native-host/src/cli.ts
+++ b/packages/native-host/src/cli.ts
@@ -26,6 +26,7 @@ import {
   type StagingPlatform,
 } from "./registration/index.js";
 import { verifyLiveLaunch } from "./doctor.js";
+import { HOST_VERSION } from "./protocol.js";
 
 const USAGE = `neurodock-native-host <command> [options]
 
@@ -140,7 +141,7 @@ export async function main(
     return 0;
   }
   if (parsed.command === "version") {
-    process.stdout.write("0.1.0\n");
+    process.stdout.write(`${HOST_VERSION}\n`);
     return 0;
   }
   if (parsed.command === "run") {

--- a/packages/native-host/src/protocol.ts
+++ b/packages/native-host/src/protocol.ts
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  * Copyright (c) 2026 NeuroDock contributors.
  */
+import { createRequire } from "node:module";
+
 /**
  * Chrome Native Messaging protocol primitives.
  *
@@ -31,8 +33,6 @@ export interface HostResponse<T = unknown> {
   readonly error: string | null;
   readonly version: string;
 }
-
-import { createRequire } from "node:module";
 
 /**
  * The host version, sourced from package.json — never a hardcoded literal.

--- a/packages/native-host/src/protocol.ts
+++ b/packages/native-host/src/protocol.ts
@@ -32,7 +32,39 @@ export interface HostResponse<T = unknown> {
   readonly version: string;
 }
 
-export const HOST_VERSION = "0.1.0";
+import { createRequire } from "node:module";
+
+/**
+ * The host version, sourced from package.json — never a hardcoded literal.
+ *
+ * Two runtime shapes resolve it:
+ *   - The bundled host (`dist/cli.js`, what Chrome launches): esbuild replaces
+ *     `__NEURODOCK_HOST_VERSION__` with the package version at build time (see
+ *     `scripts/bundle-cli.mjs`). The bundle is STAGED into a per-user dir whose
+ *     only package.json is a `{"type":"module"}` shim, so the version must be
+ *     baked in at build time — a runtime read would find no version there.
+ *   - dev / tests (tsc / vitest): the define is absent, so read package.json
+ *     next to the package root via createRequire.
+ */
+declare const __NEURODOCK_HOST_VERSION__: string | undefined;
+
+function resolveHostVersion(): string {
+  if (typeof __NEURODOCK_HOST_VERSION__ === "string") {
+    return __NEURODOCK_HOST_VERSION__;
+  }
+  try {
+    const nodeRequire = createRequire(import.meta.url);
+    const pkg = nodeRequire("../package.json") as { version?: string };
+    if (typeof pkg.version === "string" && pkg.version.length > 0) {
+      return pkg.version;
+    }
+  } catch {
+    /* fall through to the dev sentinel below */
+  }
+  return "0.0.0-dev";
+}
+
+export const HOST_VERSION: string = resolveHostVersion();
 
 /**
  * Capability flags reported by the `ping` op — the "fully set up"

--- a/packages/native-host/tests/version.test.ts
+++ b/packages/native-host/tests/version.test.ts
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * The host version must track package.json — never a hardcoded literal.
+ * Regression guard: the published host long reported "0.1.0" over ping and
+ * `--version` while the package was already at 0.3.0, so users (and `doctor`)
+ * saw a stale version that did not identify the build they were running.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { HOST_VERSION } from "../src/protocol.js";
+import { main } from "../src/cli.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(resolve(here, "..", "package.json"), "utf8"),
+) as { version: string };
+
+describe("HOST_VERSION", () => {
+  it("matches the package.json version, not a hardcoded literal", () => {
+    expect(HOST_VERSION).toBe(pkg.version);
+  });
+
+  it("is a non-empty semver-shaped string", () => {
+    expect(HOST_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("neurodock-native-host --version", () => {
+  it("prints the real package version", async () => {
+    const writes: string[] = [];
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: unknown) => {
+        writes.push(String(chunk));
+        return true;
+      });
+    try {
+      const code = await main(["--version"]);
+      expect(code).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(writes.join("").trim()).toBe(pkg.version);
+  });
+});

--- a/packages/native-host/tests/version.test.ts
+++ b/packages/native-host/tests/version.test.ts
@@ -44,6 +44,8 @@ describe("neurodock-native-host --version", () => {
     } finally {
       spy.mockRestore();
     }
+    // Self-documenting failure if the spy never intercepted a write.
+    expect(writes.length).toBeGreaterThan(0);
     expect(writes.join("").trim()).toBe(pkg.version);
   });
 });


### PR DESCRIPTION
## Why

Two fixes that together make "full NeuroDock" actually connect, and make the host report a truthful version.

### 1. The extension could never connect to the native host (the real bug)

"Turn on full NeuroDock" stayed **"Not connected yet"** for every user, and clicking **Check again** produced *no* network / console / service-worker activity at all.

Root cause: the extension manifest never declared the **`nativeMessaging`** permission, so `chrome.runtime.connectNative` was **`undefined`**. `getRuntime()` returned null and `probeNativeHost` silently reported `absent` — it never even attempted to launch the host. This is why `neurodock doctor` *passed* (it spawns the launcher directly via Node, bypassing Chrome's permission gate) while the extension stayed disconnected. PR #114 fixed the host side; this is the missing extension side.

**Fix:** declare `nativeMessaging` in **`optional_permissions`** (not `permissions`) and request it at runtime on the **"Check again" / "Turn on full NeuroDock" user gesture** via `chrome.permissions.request`. A plain install therefore shows **no** native-messaging warning — the same consent-first / runtime-grant pattern the manifest already uses for host permissions. The auto-poll stays non-interactive and never prompts; the grant persists across restarts. `request()` is called directly (not behind an awaited `contains()`) so the user gesture survives on Firefox. Verified `nativeMessaging` is requestable as an optional permission on Chrome, Firefox 115+, and Edge.

The same non-interactive gate now also fronts `nativeHostGetProfile` / `nativeHostSetProfile`, so no caller can reach `connectNative` without the permission (reviewer-flagged consistency).

### 2. native-host reported a hardcoded `0.1.0`

`HOST_VERSION` (ping responses) and `neurodock-native-host --version` were hardcoded `0.1.0` regardless of the published package (e.g. `doctor` showed "version 0.1.0" against a 0.3.0 host). Now derived from `package.json`: baked into the staged bundle at build time via an esbuild `define` (the staged copy Chrome launches has no real `package.json` to read), with a `createRequire` fallback for the tsc/dev/test path.

## Reviews

Reviewed by `security-reviewer` (APPROVE), `typescript-reviewer` (APPROVE), and `code-reviewer` (WARNING → all findings addressed → re-verified APPROVE). The convergent HIGH finding (profile read/write bypassing the new gate) and the duplication / cosmetic findings were fixed in the second commit and re-reviewed clean.

## Test plan

- [x] New: `tests/unit/native-host-client-permissions.test.ts` — non-interactive vs interactive gating, gesture preservation (no `contains()` before `request()`), denial, default-non-interactive, get/set gating.
- [x] New: `tests/unit/manifest-native-messaging.test.ts` — `nativeMessaging` is in `optional_permissions`, NOT `permissions` (regression guard for the exact shipped bug).
- [x] New: `packages/native-host/tests/version.test.ts` — `HOST_VERSION` and `--version` equal `package.json`.
- [x] Full suites green: extension **10422** passed, native-host **87** passed.
- [x] Typecheck clean (both packages).
- [x] Chrome bundle rebuilt; built manifest confirmed to carry `optional_permissions:["nativeMessaging"]`.
- [x] Built native-host bundle: `node dist/cli.js --version` → `0.3.0`.

## Changesets

- `@neurodock/native-host: patch` (carries into `@neurodock/cli` via `updateInternalDependencies`)
- `@neurodock/extension-browser: patch`
