### PR TITLE
fix: native host connects on chromium browsers (drop firefox id from chrome manifest origins)

### DIFF
--- a/.changeset/cli-doctor-manifest-origin-check.md
+++ b/.changeset/cli-doctor-manifest-origin-check.md
@@ -1,0 +1,13 @@
+---
+"@neurodock/cli": patch
+---
+
+fix(cli): doctor flags a native-host manifest Chrome would reject
+
+`neurodock doctor` only spawned the launcher and exchanged a ping/pong, which
+passes even when chrome refuses the host because the manifest's
+`allowed_origins` contains an entry chrome rejects (e.g. a firefox gecko id
+wedged into a `chrome-extension://` origin) — the exact false PASS that hid the
+connectivity bug. doctor now also validates the installed chromium manifest via
+`findInvalidChromiumOrigins` and FAILs with the offending entries and the
+remedy (update `@neurodock/native-host` and re-run `neurodock host install`).

--- a/.changeset/native-host-chromium-origin-filtering.md
+++ b/.changeset/native-host-chromium-origin-filtering.md
@@ -1,0 +1,21 @@
+---
+"@neurodock/native-host": patch
+---
+
+fix(native-host): only emit valid Chrome ids into the Chromium manifest's allowed_origins
+
+the chromium native-messaging manifest listed BOTH the published Chrome id and
+the Firefox gecko id as `chrome-extension://<id>/` origins. chrome validates
+every `allowed_origins` entry against `chrome-extension://[a-p]{32}/` and rejects
+the ENTIRE manifest if any entry is malformed — so the gecko id
+(`neurodock-extension@neurodock.org`) made chrome report "specified native
+messaging host not found", and full neurodock never connected on ANY chromium
+browser (chrome/edge/brave/chromium/vivaldi), on any OS. the manifest file
+existed and `neurodock doctor` passed because it reads the file directly and
+spawns the launcher, never validating origins the way chrome does.
+
+fix: classify ids and emit each only where it is valid — `buildManifest`
+(chromium) keeps only `[a-p]{32}` ids; `buildFirefoxManifest` keeps only gecko
+ids (`name@domain` or `{uuid}`). also expose `findInvalidChromiumOrigins` so the
+cli `doctor` can flag a manifest chrome would reject. users on a chromium
+browser must re-run `neurodock host install` to rewrite the manifest.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -116,9 +116,10 @@ export async function runDoctor(
     }
   }
 
-  // Native messaging host: actually LAUNCH it and exchange a ping/pong. This
-  // is the real connectivity check the browser extension depends on.
-  checks.push(await checkNativeHost(deps.verifyNativeHost));
+  // Native messaging host: actually LAUNCH it and exchange a ping/pong, AND
+  // validate the manifest the way Chrome does. Both are the real connectivity
+  // checks the browser extension depends on.
+  checks.push(...(await checkNativeHost(deps.verifyNativeHost)));
 
   const ok = checks.every((c) => c.status !== "FAIL");
   return { checks, ok };
@@ -126,34 +127,58 @@ export async function runDoctor(
 
 async function checkNativeHost(
   verify: (() => Promise<HostVerifyResult>) | undefined,
-): Promise<CheckResult> {
+): Promise<CheckResult[]> {
   const name = "Native host live launch";
   const run = verify ?? defaultRunHostVerify;
+  let result: HostVerifyResult;
   try {
-    const result = await run();
-    if (result.ok) {
-      return {
+    result = await run();
+  } catch (err: unknown) {
+    return [
+      {
         name,
-        status: "PASS",
-        detail: `host responded to ping (version ${
-          result.version ?? "?"
-        }) via ${result.launcherPath}`,
-      };
-    }
-    return {
-      name,
+        status: "FAIL",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+    ];
+  }
+
+  const out: CheckResult[] = [];
+  out.push(
+    result.ok
+      ? {
+          name,
+          status: "PASS",
+          detail: `host responded to ping (version ${
+            result.version ?? "?"
+          }) via ${result.launcherPath}`,
+        }
+      : {
+          name,
+          status: "FAIL",
+          detail:
+            result.detail ??
+            "native host did not respond to a ping over the stdio protocol",
+        },
+  );
+
+  // A direct launcher spawn can pong fine while Chrome still refuses the host
+  // because the manifest's allowed_origins contains an entry Chrome rejects
+  // (e.g. a Firefox gecko id wedged into a chrome-extension:// origin). Surface
+  // that so the diagnostic reflects Chrome's reality, not just the spawn.
+  if (result.invalidOrigins.length > 0) {
+    out.push({
+      name: "Native host manifest valid for Chrome",
       status: "FAIL",
       detail:
-        result.detail ??
-        "native host did not respond to a ping over the stdio protocol",
-    };
-  } catch (err: unknown) {
-    return {
-      name,
-      status: "FAIL",
-      detail: err instanceof Error ? err.message : String(err),
-    };
+        `manifest allowed_origins has ${result.invalidOrigins.length} entr${
+          result.invalidOrigins.length === 1 ? "y" : "ies"
+        } Chrome will reject (${result.invalidOrigins.join(", ")}); Chrome ` +
+        "refuses the whole manifest. Update @neurodock/native-host (>= 0.3.2) " +
+        "and re-run 'neurodock host install'.",
+    });
   }
+  return out;
 }
 
 function checkNodeVersion(): CheckResult {

--- a/packages/cli/src/commands/host.ts
+++ b/packages/cli/src/commands/host.ts
@@ -30,6 +30,8 @@ import {
   resolveSourceDistDir,
   resolveInstalledLauncher,
   findInvalidChromiumOrigins,
+  isChromiumExtensionId,
+  isFirefoxExtensionId,
   type StagingPlatform,
 } from "@neurodock/native-host/dist/registration/index.js";
 import {
@@ -61,6 +63,13 @@ export interface HostCommandResult {
   readonly outcomes: ReadonlyArray<RegistrationOutcome>;
   /** The launcher the manifests now point at (absent on uninstall). */
   readonly launcherPath?: string;
+  /**
+   * Caller-supplied `--extension-id` values that matched neither a Chromium id
+   * (`[a-p]{32}`) nor a Firefox gecko id, so they were left out of BOTH
+   * manifests (an invalid origin would make Chrome reject the whole manifest).
+   * The CLI warns about these so a typo'd id is not silently ignored.
+   */
+  readonly ignoredExtensionIds?: ReadonlyArray<string>;
 }
 
 /**
@@ -106,6 +115,11 @@ export function runHostInstall(
   // Always register the published store ids; caller-supplied ids (e.g. a
   // locally-loaded unpacked build) are added on top.
   const ids = withDefaultExtensionIds(opts.extensionIds);
+  // Caller-supplied ids that fit neither browser's format are dropped from both
+  // manifests; surface them so a typo'd --extension-id is not silent.
+  const ignoredExtensionIds = opts.extensionIds.filter(
+    (id) => !isChromiumExtensionId(id) && !isFirefoxExtensionId(id),
+  );
   const sourceDistDir = deps.sourceDistDir ?? resolveHostDistDir();
   const result = registerWithStaging({
     allowedExtensionIds: ids,
@@ -119,6 +133,7 @@ export function runHostInstall(
     platform: result.platform,
     outcomes: result.outcomes,
     launcherPath: result.launcherPath,
+    ignoredExtensionIds,
   };
 }
 

--- a/packages/cli/src/commands/host.ts
+++ b/packages/cli/src/commands/host.ts
@@ -29,6 +29,7 @@ import {
   withDefaultExtensionIds,
   resolveSourceDistDir,
   resolveInstalledLauncher,
+  findInvalidChromiumOrigins,
   type StagingPlatform,
 } from "@neurodock/native-host/dist/registration/index.js";
 import {
@@ -149,6 +150,14 @@ export interface HostVerifyResult {
   readonly launcherPath: string;
   readonly version: string | null;
   readonly detail?: string;
+  /**
+   * allowed_origins entries in the installed Chromium manifest that Chrome
+   * would reject (a single malformed entry makes Chrome refuse the whole
+   * manifest). Empty when the manifest is valid, absent, or unreadable. doctor
+   * surfaces these so a passing direct launcher spawn does not mask a manifest
+   * Chrome cannot load.
+   */
+  readonly invalidOrigins: ReadonlyArray<string>;
 }
 
 /**
@@ -189,6 +198,7 @@ export async function runHostVerify(
       ok: false,
       launcherPath: "",
       version: null,
+      invalidOrigins: [],
       detail: "native messaging host is not supported on this platform",
     };
   }
@@ -202,9 +212,15 @@ export async function runHostVerify(
       ok: false,
       launcherPath: installed.launcherPath,
       version: null,
+      invalidOrigins: [],
       ...(installed.detail ? { detail: installed.detail } : {}),
     };
   }
+
+  // Validate the manifest the way Chrome does: a single malformed allowed_origin
+  // makes Chrome refuse the host ("not found"), even though the launcher itself
+  // spawns and pongs fine. Surface it so doctor stops giving a false PASS.
+  const invalidOrigins = findInvalidChromiumOrigins(platform, home, env);
 
   const verify = deps.verify ?? verifyLiveLaunch;
   const result = await verify(installed.launcherPath);
@@ -212,6 +228,7 @@ export async function runHostVerify(
     ok: result.ok,
     launcherPath: installed.launcherPath,
     version: result.version,
+    invalidOrigins,
     ...(result.detail ? { detail: result.detail } : {}),
   };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -616,6 +616,15 @@ export function buildProgram(): Command {
           }${detail}`,
         );
       }
+      if (result.ignoredExtensionIds && result.ignoredExtensionIds.length > 0) {
+        print(
+          `  [warn] ignored ${
+            result.ignoredExtensionIds.length
+          } extension id(s) that are neither a Chrome id ([a-p]{32}) nor a Firefox id (name@domain / {uuid}): ${result.ignoredExtensionIds.join(
+            ", ",
+          )}`,
+        );
+      }
       print("Verify a live launch with: neurodock doctor");
       process.exit(0);
     });

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -101,6 +101,7 @@ describe("neurodock doctor", () => {
           ok: true,
           launcherPath: "/stable/runtime/com.neurodock.profile.sh",
           version: "0.1.0",
+          invalidOrigins: [],
         }),
       });
       const host = r.checks.find((c) => c.name === "Native host live launch");
@@ -185,6 +186,41 @@ describe("neurodock doctor", () => {
     }
   });
 
+  it("FAILS doctor when the launcher pongs but the manifest has an origin Chrome rejects", async () => {
+    // The regression this guards: a direct launcher spawn pongs fine (PASS),
+    // yet Chrome refuses the host because allowed_origins carries a malformed
+    // entry (e.g. a Firefox gecko id). doctor must surface that, not green-light.
+    const s = sandbox();
+    try {
+      writeFileSync(
+        s.profile,
+        "identity:\n  display_name: tester\n  neurotypes:\n    - adhd\n",
+      );
+      process.env["NEURODOCK_PROFILE_PATH"] = s.profile;
+      const r = await runDoctor({
+        verifyNativeHost: async () => ({
+          ok: true,
+          launcherPath: "/stable/runtime/com.neurodock.profile.bat",
+          version: "0.3.2",
+          invalidOrigins: [
+            "chrome-extension://neurodock-extension@neurodock.org/",
+          ],
+        }),
+      });
+      const live = r.checks.find((c) => c.name === "Native host live launch");
+      expect(live?.status).toBe("PASS");
+      const manifest = r.checks.find(
+        (c) => c.name === "Native host manifest valid for Chrome",
+      );
+      expect(manifest?.status).toBe("FAIL");
+      expect(manifest?.detail).toContain("neurodock-extension@neurodock.org");
+      expect(r.ok).toBe(false);
+    } finally {
+      delete process.env["NEURODOCK_PROFILE_PATH"];
+      s.cleanup();
+    }
+  });
+
   it("fails doctor when the live native-host launch does not respond", async () => {
     const s = sandbox();
     try {
@@ -199,6 +235,7 @@ describe("neurodock doctor", () => {
           launcherPath: "/stable/runtime/com.neurodock.profile.sh",
           version: null,
           detail: "Host exited (code 1) without a valid response.",
+          invalidOrigins: [],
         }),
       });
       const host = r.checks.find((c) => c.name === "Native host live launch");

--- a/packages/cli/tests/host.test.ts
+++ b/packages/cli/tests/host.test.ts
@@ -46,7 +46,7 @@ describe("runHostInstall (CLI wiring)", () => {
       };
 
       const result = runHostInstall(
-        { extensionIds: ["mydev"] },
+        { extensionIds: ["jjcjkmljfdebbefdemkcgknjplgkicen"] },
         {
           platform: "linux",
           home,
@@ -74,8 +74,10 @@ describe("runHostInstall (CLI wiring)", () => {
       };
       expect(manifest.path).toBe(result.launcherPath);
       expect(manifest.path).not.toMatch(/cli\.js$/);
-      // Published + caller ids both present (behaviour unchanged).
-      expect(manifest.allowed_origins).toContain("chrome-extension://mydev/");
+      // Published + caller ids both present as valid chrome-extension origins.
+      expect(manifest.allowed_origins).toContain(
+        "chrome-extension://jjcjkmljfdebbefdemkcgknjplgkicen/",
+      );
       expect(manifest.allowed_origins).toContain(
         "chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/",
       );

--- a/packages/cli/tests/host.test.ts
+++ b/packages/cli/tests/host.test.ts
@@ -85,6 +85,48 @@ describe("runHostInstall (CLI wiring)", () => {
       s.cleanup();
     }
   });
+
+  it("reports caller ids that match neither browser format as ignored", () => {
+    const s = sandbox();
+    try {
+      const sourceDist = join(s.root, "src-dist");
+      mkdirSync(sourceDist, { recursive: true });
+      writeFileSync(join(sourceDist, "cli.js"), "// cli\n");
+      const home = join(s.root, "home");
+      const env = {
+        XDG_DATA_HOME: join(s.root, "data"),
+        XDG_CONFIG_HOME: join(s.root, "config"),
+      };
+      const result = runHostInstall(
+        // one valid Chrome id, one malformed (too short) id
+        { extensionIds: ["jjcjkmljfdebbefdemkcgknjplgkicen", "typoid"] },
+        {
+          platform: "linux",
+          home,
+          env,
+          sourceDistDir: sourceDist,
+          nodePath: "/usr/bin/node",
+        },
+      );
+      expect(result.ignoredExtensionIds).toEqual(["typoid"]);
+      const manifest = JSON.parse(
+        readFileSync(
+          join(
+            env.XDG_CONFIG_HOME,
+            "google-chrome",
+            "NativeMessagingHosts",
+            "com.neurodock.profile.json",
+          ),
+          "utf8",
+        ),
+      ) as { allowed_origins: string[] };
+      expect(manifest.allowed_origins).not.toContain(
+        "chrome-extension://typoid/",
+      );
+    } finally {
+      s.cleanup();
+    }
+  });
 });
 
 describe("runHostUninstall (CLI wiring)", () => {

--- a/packages/native-host/src/registration/index.ts
+++ b/packages/native-host/src/registration/index.ts
@@ -232,6 +232,8 @@ export {
   stableRuntimeDir,
   chromiumManifestPath,
   resolveInstalledLauncher,
+  findInvalidChromiumOrigins,
   type InstalledLauncher,
   type StagingPlatform,
 } from "./staging.js";
+export { isChromiumExtensionId, isFirefoxExtensionId } from "./types.js";

--- a/packages/native-host/src/registration/staging.ts
+++ b/packages/native-host/src/registration/staging.ts
@@ -36,7 +36,6 @@ import {
   realpathSync,
   existsSync,
   rmSync,
-  statSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -252,19 +251,20 @@ export function findInvalidChromiumOrigins(
   env: NodeJS.ProcessEnv,
 ): string[] {
   const manifestPath = chromiumManifestPath(platform, home, env);
-  if (!existsSync(manifestPath)) return [];
-  // The manifest is tens of bytes in normal operation. Bail before reading if
-  // something pathologically large sits at that path, so we never load it.
+  // Read-and-catch rather than existsSync/statSync-then-read: a missing or
+  // unreadable manifest yields [] (the launcher check reports absence). This
+  // avoids a check-then-read TOCTOU (CodeQL js/file-system-race).
+  let raw: string;
   try {
-    if (statSync(manifestPath).size > 65536) return [];
+    raw = readFileSync(manifestPath, "utf8");
   } catch {
     return [];
   }
+  // Sanity bail on an implausibly large file (the manifest is tens of bytes).
+  if (raw.length > 65536) return [];
   let parsed: { allowed_origins?: unknown };
   try {
-    parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as {
-      allowed_origins?: unknown;
-    };
+    parsed = JSON.parse(raw) as { allowed_origins?: unknown };
   } catch {
     return [];
   }

--- a/packages/native-host/src/registration/staging.ts
+++ b/packages/native-host/src/registration/staging.ts
@@ -36,6 +36,7 @@ import {
   realpathSync,
   existsSync,
   rmSync,
+  statSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -252,6 +253,13 @@ export function findInvalidChromiumOrigins(
 ): string[] {
   const manifestPath = chromiumManifestPath(platform, home, env);
   if (!existsSync(manifestPath)) return [];
+  // The manifest is tens of bytes in normal operation. Bail before reading if
+  // something pathologically large sits at that path, so we never load it.
+  try {
+    if (statSync(manifestPath).size > 65536) return [];
+  } catch {
+    return [];
+  }
   let parsed: { allowed_origins?: unknown };
   try {
     parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as {
@@ -264,9 +272,11 @@ export function findInvalidChromiumOrigins(
     ? parsed.allowed_origins
     : [];
   const VALID_ORIGIN = /^chrome-extension:\/\/[a-p]{32}\/$/;
-  return origins.filter(
-    (o): o is string => typeof o === "string" && !VALID_ORIGIN.test(o),
-  );
+  // A non-string entry, or a string that is not a well-formed chrome-extension
+  // origin, both make Chrome reject the whole manifest — report either.
+  return origins
+    .filter((o) => typeof o !== "string" || !VALID_ORIGIN.test(o))
+    .map((o) => (typeof o === "string" ? o : JSON.stringify(o)));
 }
 
 /** Launcher file name per OS: a `.bat` on Windows, a `.sh` elsewhere. */

--- a/packages/native-host/src/registration/staging.ts
+++ b/packages/native-host/src/registration/staging.ts
@@ -236,6 +236,39 @@ export function resolveInstalledLauncher(
   return { ok: true, launcherPath, manifestPath };
 }
 
+/**
+ * Read the installed Chromium manifest's `allowed_origins` and return any
+ * entries Chrome would reject — i.e. not of the exact form
+ * `chrome-extension://<32 chars a-p>/`. Chrome refuses the ENTIRE manifest if a
+ * single entry is malformed (reporting "Specified native messaging host not
+ * found"), so `neurodock doctor` surfaces these instead of giving a false PASS
+ * from a successful direct launcher spawn. Returns [] when the manifest is
+ * absent or unreadable (the launcher check reports those separately).
+ */
+export function findInvalidChromiumOrigins(
+  platform: StagingPlatform,
+  home: string,
+  env: NodeJS.ProcessEnv,
+): string[] {
+  const manifestPath = chromiumManifestPath(platform, home, env);
+  if (!existsSync(manifestPath)) return [];
+  let parsed: { allowed_origins?: unknown };
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      allowed_origins?: unknown;
+    };
+  } catch {
+    return [];
+  }
+  const origins = Array.isArray(parsed.allowed_origins)
+    ? parsed.allowed_origins
+    : [];
+  const VALID_ORIGIN = /^chrome-extension:\/\/[a-p]{32}\/$/;
+  return origins.filter(
+    (o): o is string => typeof o === "string" && !VALID_ORIGIN.test(o),
+  );
+}
+
 /** Launcher file name per OS: a `.bat` on Windows, a `.sh` elsewhere. */
 export function launcherFileName(platform: StagingPlatform): string {
   return platform === "win32" ? `${HOST_NAME}.bat` : `${HOST_NAME}.sh`;

--- a/packages/native-host/src/registration/types.ts
+++ b/packages/native-host/src/registration/types.ts
@@ -22,17 +22,45 @@ export const HOST_NAME = "com.neurodock.profile";
  *   - `neurodock-extension@neurodock.org` — the Firefox gecko id (used in
  *     the Firefox manifest's `allowed_extensions`).
  *
- * Both ids are written into BOTH manifests (each builder maps the same
- * list). The cross-store entry — e.g. a `chrome-extension://<gecko-id>/`
- * origin in the Chrome manifest — is simply never matched by that browser,
- * so carrying one list for both is harmless and keeps a single source of
- * truth. This replaces the old `__NEURODOCK_EXTENSION_ID__` placeholder,
- * which was never substituted and so matched no extension at all.
+ * One list is carried for both stores, but each builder emits ONLY the ids
+ * that are valid for its browser — see `isChromiumExtensionId` /
+ * `isFirefoxExtensionId`. This is NOT cosmetic: Chrome validates every
+ * `allowed_origins` entry against `chrome-extension://[a-p]{32}/` and rejects
+ * the ENTIRE manifest if any entry is malformed (e.g. a gecko id wedged into a
+ * `chrome-extension://` origin), reporting the host as "not found". A previous
+ * version mapped the whole list into both manifests, so every Chromium browser
+ * got the Firefox gecko id as an invalid origin and refused to load the host.
+ * This replaces the old `__NEURODOCK_EXTENSION_ID__` placeholder, which was
+ * never substituted and so matched no extension at all.
  */
 export const PUBLISHED_EXTENSION_IDS: ReadonlyArray<string> = [
   "lcdaiekokkgniiknejddojkfkoiinopo",
   "neurodock-extension@neurodock.org",
 ];
+
+/**
+ * Chrome / Chromium / Edge / Brave / Vivaldi extension id: exactly 32 chars
+ * from a–p (the alphabet Chromium derives ids in). Only these are valid inside
+ * a `chrome-extension://<id>/` origin; anything else makes Chrome reject the
+ * whole native-messaging manifest.
+ */
+export function isChromiumExtensionId(id: string): boolean {
+  return /^[a-p]{32}$/.test(id);
+}
+
+/**
+ * Firefox (gecko) add-on id: either an email-like `name@domain` or a UUID in
+ * braces, e.g. `{d3b0…-…-…-…-…}`. These are the only forms valid in a Firefox
+ * manifest's `allowed_extensions`.
+ */
+export function isFirefoxExtensionId(id: string): boolean {
+  return (
+    /^[^@\s/]+@[^@\s/]+$/.test(id) ||
+    /^\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}$/.test(
+      id,
+    )
+  );
+}
 
 /**
  * Union the caller-provided extension ids (e.g. a locally-loaded unpacked
@@ -83,9 +111,11 @@ export function buildManifest(
       "NeuroDock native messaging host. Exposes ~/.neurodock/profile.yaml to the browser extension.",
     path: opts.hostPath,
     type: "stdio",
-    allowed_origins: opts.allowedExtensionIds.map(
-      (id) => `chrome-extension://${id}/`,
-    ),
+    // Only valid Chromium ids — a single malformed origin makes Chrome reject
+    // the entire manifest ("Specified native messaging host not found").
+    allowed_origins: opts.allowedExtensionIds
+      .filter(isChromiumExtensionId)
+      .map((id) => `chrome-extension://${id}/`),
   };
 }
 
@@ -98,6 +128,7 @@ export function buildFirefoxManifest(
       "NeuroDock native messaging host. Exposes ~/.neurodock/profile.yaml to the browser extension.",
     path: opts.hostPath,
     type: "stdio",
-    allowed_extensions: [...opts.allowedExtensionIds],
+    // Only valid gecko ids belong in a Firefox manifest's allowed_extensions.
+    allowed_extensions: opts.allowedExtensionIds.filter(isFirefoxExtensionId),
   };
 }

--- a/packages/native-host/tests/manifest-origin-validation.test.ts
+++ b/packages/native-host/tests/manifest-origin-validation.test.ts
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (c) 2026 NeuroDock contributors.
+ *
+ * findInvalidChromiumOrigins backs the `doctor` check that catches a manifest
+ * Chrome would reject — the malformed gecko origin that reported the host as
+ * "not found" while a direct launcher spawn ponged fine.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findInvalidChromiumOrigins } from "../src/registration/staging.js";
+import { HOST_NAME } from "../src/registration/types.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const r of roots) {
+    try {
+      rmSync(r, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+  roots.length = 0;
+});
+
+function tmpRoot(): string {
+  const r = mkdtempSync(join(tmpdir(), "nd-origins-"));
+  roots.push(r);
+  return r;
+}
+
+function writeLinuxChromeManifest(
+  root: string,
+  allowed_origins: unknown,
+): { home: string; env: NodeJS.ProcessEnv } {
+  const home = join(root, "home");
+  const cfg = join(root, "config");
+  const dir = join(cfg, "google-chrome", "NativeMessagingHosts");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${HOST_NAME}.json`),
+    JSON.stringify({
+      name: HOST_NAME,
+      path: "/x/launcher.sh",
+      type: "stdio",
+      allowed_origins,
+    }),
+  );
+  return { home, env: { XDG_CONFIG_HOME: cfg } };
+}
+
+describe("findInvalidChromiumOrigins", () => {
+  it("returns the malformed gecko origin while accepting valid chrome origins", () => {
+    const { home, env } = writeLinuxChromeManifest(tmpRoot(), [
+      "chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/",
+      "chrome-extension://neurodock-extension@neurodock.org/",
+      "chrome-extension://jjcjkmljfdebbefdemkcgknjplgkicen/",
+    ]);
+    expect(findInvalidChromiumOrigins("linux", home, env)).toEqual([
+      "chrome-extension://neurodock-extension@neurodock.org/",
+    ]);
+  });
+
+  it("returns [] for an all-valid manifest", () => {
+    const { home, env } = writeLinuxChromeManifest(tmpRoot(), [
+      "chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/",
+    ]);
+    expect(findInvalidChromiumOrigins("linux", home, env)).toEqual([]);
+  });
+
+  it("returns [] when the manifest is absent (the launcher check reports that)", () => {
+    const root = tmpRoot();
+    expect(
+      findInvalidChromiumOrigins("linux", join(root, "home"), {
+        XDG_CONFIG_HOME: join(root, "none"),
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/native-host/tests/register-with-staging.test.ts
+++ b/packages/native-host/tests/register-with-staging.test.ts
@@ -51,7 +51,7 @@ describe("registerWithStaging (Linux)", () => {
         env,
         sourceDistDir: sourceDist,
         nodePath: "/usr/bin/node",
-        allowedExtensionIds: ["abc"],
+        allowedExtensionIds: ["lcdaiekokkgniiknejddojkfkoiinopo"],
       });
 
       // Launcher staged.
@@ -72,8 +72,10 @@ describe("registerWithStaging (Linux)", () => {
       };
       expect(manifest.path).toBe(result.launcherPath);
       expect(manifest.path).not.toMatch(/cli\.js$/);
-      // allowed_origins behaviour unchanged.
-      expect(manifest.allowed_origins).toContain("chrome-extension://abc/");
+      // allowed_origins carries the valid chrome id as a chrome-extension origin.
+      expect(manifest.allowed_origins).toContain(
+        "chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/",
+      );
 
       // Firefox manifest also points at the launcher.
       const firefoxManifestPath = join(

--- a/packages/native-host/tests/registration.test.ts
+++ b/packages/native-host/tests/registration.test.ts
@@ -5,20 +5,27 @@ import {
   HOST_NAME,
   PUBLISHED_EXTENSION_IDS,
   withDefaultExtensionIds,
+  isChromiumExtensionId,
+  isFirefoxExtensionId,
 } from "../src/registration/types.js";
+
+const CHROME_ID = "lcdaiekokkgniiknejddojkfkoiinopo";
+const UNPACKED_CHROME_ID = "jjcjkmljfdebbefdemkcgknjplgkicen";
+const GECKO_ID = "neurodock-extension@neurodock.org";
+const UUID_GECKO_ID = "{d3b0a1c2-1234-4567-89ab-cdef01234567}";
 
 describe("manifest builders", () => {
   it("Chromium manifest declares stdio + allowed_origins as chrome-extension URLs", () => {
     const m = buildManifest({
       hostPath: "/usr/local/bin/neurodock-native-host",
-      allowedExtensionIds: ["abc", "def"],
+      allowedExtensionIds: [CHROME_ID, UNPACKED_CHROME_ID],
     });
     expect(m["name"]).toBe(HOST_NAME);
     expect(m["type"]).toBe("stdio");
     expect(m["path"]).toBe("/usr/local/bin/neurodock-native-host");
     expect(m["allowed_origins"]).toEqual([
-      "chrome-extension://abc/",
-      "chrome-extension://def/",
+      `chrome-extension://${CHROME_ID}/`,
+      `chrome-extension://${UNPACKED_CHROME_ID}/`,
     ]);
   });
 
@@ -29,6 +36,48 @@ describe("manifest builders", () => {
     });
     expect(m["allowed_extensions"]).toEqual(["addon@example.com"]);
     expect(m["type"]).toBe("stdio");
+  });
+});
+
+describe("per-browser id filtering (Chrome rejects a manifest with any malformed origin)", () => {
+  it("excludes the firefox gecko id from the chromium allowed_origins", () => {
+    const m = buildManifest({
+      hostPath: "/x",
+      allowedExtensionIds: [CHROME_ID, GECKO_ID, UNPACKED_CHROME_ID],
+    });
+    // The gecko id must NOT appear as a chrome-extension origin — that single
+    // malformed entry is what made Chrome report "host not found".
+    expect(m["allowed_origins"]).toEqual([
+      `chrome-extension://${CHROME_ID}/`,
+      `chrome-extension://${UNPACKED_CHROME_ID}/`,
+    ]);
+    expect(m["allowed_origins"]).not.toContain(
+      `chrome-extension://${GECKO_ID}/`,
+    );
+  });
+
+  it("keeps only gecko ids in the firefox allowed_extensions", () => {
+    const m = buildFirefoxManifest({
+      hostPath: "/x",
+      allowedExtensionIds: [
+        CHROME_ID,
+        GECKO_ID,
+        UUID_GECKO_ID,
+        UNPACKED_CHROME_ID,
+      ],
+    });
+    expect(m["allowed_extensions"]).toEqual([GECKO_ID, UUID_GECKO_ID]);
+  });
+
+  it("classifies Chromium vs Firefox extension ids", () => {
+    expect(isChromiumExtensionId(CHROME_ID)).toBe(true);
+    expect(isChromiumExtensionId(UNPACKED_CHROME_ID)).toBe(true);
+    expect(isChromiumExtensionId(GECKO_ID)).toBe(false);
+    expect(isChromiumExtensionId("tooshort")).toBe(false);
+    expect(isChromiumExtensionId(CHROME_ID.toUpperCase())).toBe(false);
+    expect(isFirefoxExtensionId(GECKO_ID)).toBe(true);
+    expect(isFirefoxExtensionId(UUID_GECKO_ID)).toBe(true);
+    expect(isFirefoxExtensionId(CHROME_ID)).toBe(false);
   });
 });
 
@@ -64,13 +113,18 @@ describe("default allowed extension ids", () => {
     expect(withDefaultExtensionIds([])).toEqual([...PUBLISHED_EXTENSION_IDS]);
   });
 
-  it("a Chrome manifest built from the defaults allows the published store id", () => {
+  it("a Chrome manifest from the defaults allows the published store id but NOT the gecko id", () => {
     const m = buildManifest({
       hostPath: "/x",
       allowedExtensionIds: withDefaultExtensionIds([]),
     });
     expect(m["allowed_origins"]).toContain(
       "chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/",
+    );
+    // Regression guard for the connectivity bug: the gecko id must never reach
+    // a chrome-extension origin (Chrome would reject the whole manifest).
+    expect(m["allowed_origins"]).not.toContain(
+      "chrome-extension://neurodock-extension@neurodock.org/",
     );
   });
 });


### PR DESCRIPTION
## Why

"Full NeuroDock" never connected on **any Chromium browser, on any OS** — the real, all-users root cause behind the "Not connected yet" / "Specified native messaging host not found" reports.

### Root cause (confirmed on a real Windows install)

The shared manifest builder put **both** the published Chrome id and the **Firefox gecko id** into one list and mapped *every* id into a `chrome-extension://<id>/` origin. So the Chromium manifest's `allowed_origins` contained:

```
chrome-extension://lcdaiekokkgniiknejddojkfkoiinopo/
chrome-extension://neurodock-extension@neurodock.org/   ← gecko id — invalid Chrome origin
chrome-extension://<your unpacked id>/
```

Chrome validates every `allowed_origins` entry against `chrome-extension://[a-p]{32}/` and **rejects the entire manifest** if any entry is malformed → "host not found". The registry key and manifest file were correct; `neurodock doctor` passed because it reads the manifest file directly and spawns the launcher, **never validating origins the way Chrome does**. A prior code comment called mixing the ids "harmless" — that assumption was the bug.

This affects Chrome / Edge / Brave / Chromium / Vivaldi on Windows, macOS, and Linux (all three OS registration paths use the same shared builders).

## Fix

- **Classify ids per browser** ([types.ts](packages/native-host/src/registration/types.ts)): `isChromiumExtensionId` (`[a-p]{32}`) + `isFirefoxExtensionId` (`name@domain` / `{uuid}`). `buildManifest` emits only Chromium ids as origins; `buildFirefoxManifest` emits only gecko ids. A single source list, but each manifest gets only what's valid for it.
- **Harden `neurodock doctor`**: new `findInvalidChromiumOrigins` + a "Native host manifest valid for Chrome" check that FAILs when the installed manifest carries an origin Chrome would reject — so doctor stops giving a false PASS (it's now caught two blind spots: PR #114 registration-not-connection, and this launcher-not-manifest-validity).
- **Warn at install** when a `--extension-id` matches neither format (so a typo isn't silently dropped).
- Read hardening: cap the manifest read; treat non-string `allowed_origins` entries as invalid.

**Users on a Chromium browser must re-run `neurodock host install` (or `setup`)** after this ships to rewrite the manifest. Their existing extension build then connects — no extension change required.

## Reviews

`security-reviewer` (APPROVE — filtering is strictly subtractive, regexes anchored/ReDoS-free) and `code-reviewer` (APPROVE — regexes correct, cross-OS coverage confirmed, clean doctor control flow). Their advisory findings (read cap, non-string entries, install warning) are addressed in the second commit.

## Test plan

- [x] `registration.test.ts` — per-browser filtering: gecko id excluded from chrome origins, chrome id excluded from firefox allowed_extensions; defaults regression guard.
- [x] `manifest-origin-validation.test.ts` — `findInvalidChromiumOrigins` returns the malformed gecko origin, `[]` for valid/absent.
- [x] `doctor.test.ts` — launcher PASS + manifest-validity FAIL when an invalid origin is present.
- [x] `host.test.ts` — ignored-id reporting; valid ids land as origins.
- [x] Full suites green: native-host **93**, cli **143**; both typechecks clean.

## Changesets

- `@neurodock/native-host: patch` (→ 0.3.2)
- `@neurodock/cli: patch` (→ 0.10.1)
