### PR TITLE
fix: surface why the native host isn't connected + chrome privacy-policy disclosure

### DIFF
--- a/.changeset/extension-native-host-cold-start-timeout.md
+++ b/.changeset/extension-native-host-cold-start-timeout.md
@@ -1,0 +1,15 @@
+---
+"@neurodock/extension-browser": patch
+---
+
+fix(extension): give the native-host ping a realistic cold-start timeout and surface the reason
+
+after granting the nativemessaging permission the host still showed "not
+connected". chrome spawns a FRESH host process for every `connectNative`, so
+every probe is a cold start (cmd.exe → node → the ~600 KB bundle, frequently
+with windows defender scanning the spawn) that routinely needs 1–3 s. the ping
+cap was 1 s, so it timed out before a healthy host could pong — while
+`neurodock doctor` (8 s cap) passed, which is why the two disagreed. raise the
+cap to 5 s to match the host's real cold-start latency. also surface the probe's
+failure reason under the card (instead of a silent "not connected yet") and show
+a "checking…" state while probing, and skip overlapping auto-polls.

--- a/packages/extension-browser/PRIVACY.md
+++ b/packages/extension-browser/PRIVACY.md
@@ -1,7 +1,7 @@
 # Privacy policy — NeuroDock browser extension
 
-**Last reviewed:** 2026-05-20
-**Applies to:** `@neurodock/extension-browser` v0.0.2 and later, on Chrome,
+**Last reviewed:** 2026-06-20
+**Applies to:** `@neurodock/extension-browser` v0.1.2 and later, on Chrome,
 Microsoft Edge, and Mozilla Firefox.
 **Source of truth for this policy:** this file, in the NeuroDock monorepo at
 [`packages/extension-browser/PRIVACY.md`](./PRIVACY.md). If a store listing
@@ -27,6 +27,29 @@ opaque consent prose every day and we will not add to that pile.
   middle and never sees that traffic.
 - There is no NeuroDock account. There is no sign-in. There is no "user".
   There is just your browser and the providers you authorise.
+
+---
+
+## Data collection, handling, storage & sharing (at a glance)
+
+For store reviewers and anyone who wants the four required answers in one place.
+None of these four sections is omitted; each is expanded in §3 below.
+
+- **Collection.** The extension collects **no personal data for NeuroDock**. It
+  reads only the specific text you select or type when you trigger a translation,
+  plus which supported site you are on. There is no account, no identifier, no
+  analytics, and no telemetry.
+- **Handling.** That text is used solely to produce the translation you asked
+  for, at the moment you ask for it. It is processed by the model endpoint **you**
+  configure — mock by default, a local server, or a cloud provider with your own
+  API key — and is used for nothing else.
+- **Storage.** Your profile, preferences, optional API key, and optional local
+  history are stored **only on your device** (`chrome.storage.local` plus an
+  extension-scoped IndexedDB). NeuroDock operates no server and stores nothing.
+- **Sharing.** Nothing is shared with NeuroDock or any third party by the
+  extension. In cloud mode your request goes directly from your browser to the
+  provider you chose, governed by that provider's policy. Nothing is sold or
+  shared — there is no collected data to sell or share.
 
 ---
 

--- a/packages/extension-browser/src/components/PowerUpCard.tsx
+++ b/packages/extension-browser/src/components/PowerUpCard.tsx
@@ -23,7 +23,7 @@ import { useFullSetupStatus } from "../lib/full-setup.js";
 export const FULL_SETUP_COMMAND = "npx @neurodock/cli@latest setup";
 
 export function PowerUpCard(): React.ReactElement {
-  const { status, recheck } = useFullSetupStatus();
+  const { status, detail, recheck } = useFullSetupStatus();
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -83,11 +83,26 @@ export function PowerUpCard(): React.ReactElement {
         </button>
       </div>
       <p data-testid="power-up-status" className="nd-muted">
-        Not connected yet.{" "}
-        <button type="button" className="nd-linkbtn" onClick={recheck}>
-          Check again
-        </button>
+        {status === "checking" ? (
+          "Checking…"
+        ) : (
+          <>
+            Not connected yet.{" "}
+            <button type="button" className="nd-linkbtn" onClick={recheck}>
+              Check again
+            </button>
+          </>
+        )}
       </p>
+      {status !== "checking" && detail ? (
+        <p
+          data-testid="power-up-detail"
+          className="nd-muted nd-powerup-detail"
+          title={detail}
+        >
+          {detail}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/packages/extension-browser/src/lib/full-setup.ts
+++ b/packages/extension-browser/src/lib/full-setup.ts
@@ -17,17 +17,37 @@ export type FullSetupStatus = NativeHostStatus | "checking";
 
 export function useFullSetupStatus(pollMs = 4000): {
   status: FullSetupStatus;
+  /**
+   * When not connected, the reason from the last probe (timeout, host-not-found,
+   * permission-not-granted, …). Surfaced so the card is diagnosable rather than
+   * a silent "Not connected yet". Undefined when active.
+   */
+  detail?: string;
   recheck: () => void;
 } {
   const [status, setStatus] = useState<FullSetupStatus>("checking");
+  const [detail, setDetail] = useState<string | undefined>(undefined);
   const mounted = useRef(true);
+  // A probe spawns a fresh host process; with the generous cold-start timeout a
+  // probe can outlast the poll interval. Skip overlapping AUTO-polls, but never
+  // block the user's "Check again" gesture (it may need to prompt).
+  const inFlight = useRef(false);
 
   // `nativeMessaging` is an optional permission, so the auto-probe must stay
   // NON-interactive (no prompt without a user gesture). The "Check again"
   // button is the gesture that may request it — see `recheck`.
   const probe = useCallback(async (interactive: boolean) => {
-    const hello = await probeNativeHost({ interactive });
-    if (mounted.current) setStatus(hello.status);
+    if (inFlight.current && !interactive) return;
+    inFlight.current = true;
+    try {
+      const hello = await probeNativeHost({ interactive });
+      if (mounted.current) {
+        setStatus(hello.status);
+        setDetail(hello.status === "active" ? undefined : hello.detail);
+      }
+    } finally {
+      inFlight.current = false;
+    }
   }, []);
 
   useEffect(() => {
@@ -44,8 +64,9 @@ export function useFullSetupStatus(pollMs = 4000): {
   // User gesture: allowed to request the optional nativeMessaging permission.
   const recheck = useCallback(() => {
     setStatus("checking");
+    setDetail(undefined);
     void probe(true);
   }, [probe]);
 
-  return { status, recheck };
+  return { status, detail, recheck };
 }

--- a/packages/extension-browser/src/lib/native-host-client.ts
+++ b/packages/extension-browser/src/lib/native-host-client.ts
@@ -60,7 +60,13 @@ interface NativeRuntime {
 }
 
 const HOST_NAME = "com.neurodock.profile";
-const DEFAULT_TIMEOUT_MS = 1500;
+// Chrome spawns a FRESH host process for every connectNative() — so every probe
+// is a cold start: cmd.exe → node → the ~600 KB bundle, frequently with Windows
+// Defender real-time scanning the spawn. That legitimately takes 1–3 s on the
+// first hit. The old 1 s ping cap timed out before a healthy host could pong,
+// so the extension reported "Not connected" while `neurodock doctor` (8 s cap)
+// passed. Match the host's real cold-start latency. See verifyLiveLaunch (8 s).
+const DEFAULT_TIMEOUT_MS = 5000;
 
 function getRuntime(): NativeRuntime | null {
   const g = globalThis as unknown as { chrome?: { runtime?: NativeRuntime } };
@@ -237,7 +243,7 @@ export async function probeNativeHost(
     };
   }
   try {
-    const r = await session.request("ping", undefined, undefined, 1000);
+    const r = await session.request("ping");
     session.close();
     if (!r.ok) {
       return { status: "error", detail: r.error ?? "ping failed" };

--- a/packages/extension-browser/tests/unit/full-setup.test.ts
+++ b/packages/extension-browser/tests/unit/full-setup.test.ts
@@ -29,6 +29,28 @@ describe("useFullSetupStatus", () => {
     await waitFor(() => expect(result.current.status).toBe("absent"));
   });
 
+  it("surfaces the probe detail when not connected (diagnosable, not a black box)", async () => {
+    vi.spyOn(nativeHost, "probeNativeHost").mockResolvedValue({
+      status: "absent",
+      detail: "native host: request nd-1 timed out after 5000ms",
+    });
+    const { result } = renderHook(() => useFullSetupStatus(0));
+    await waitFor(() => expect(result.current.status).toBe("absent"));
+    expect(result.current.detail).toBe(
+      "native host: request nd-1 timed out after 5000ms",
+    );
+  });
+
+  it("clears the detail once connected", async () => {
+    vi.spyOn(nativeHost, "probeNativeHost").mockResolvedValue({
+      status: "active",
+      version: "0.3.1",
+    });
+    const { result } = renderHook(() => useFullSetupStatus(0));
+    await waitFor(() => expect(result.current.status).toBe("active"));
+    expect(result.current.detail).toBeUndefined();
+  });
+
   it("recheck re-probes on demand", async () => {
     const spy = vi
       .spyOn(nativeHost, "probeNativeHost")

--- a/packages/extension-browser/tests/unit/power-up-card.test.tsx
+++ b/packages/extension-browser/tests/unit/power-up-card.test.tsx
@@ -28,6 +28,19 @@ describe("PowerUpCard", () => {
     );
   });
 
+  it("shows the failure reason when the host probe fails (not a black box)", async () => {
+    vi.spyOn(nativeHost, "probeNativeHost").mockResolvedValue({
+      status: "absent",
+      detail: "native host: request nd-1 timed out after 5000ms",
+    });
+    render(<PowerUpCard />);
+    await waitFor(() =>
+      expect(screen.getByTestId("power-up-detail")).toHaveTextContent(
+        /timed out/i,
+      ),
+    );
+  });
+
   it("shows Connected when the host is active", async () => {
     vi.spyOn(nativeHost, "probeNativeHost").mockResolvedValue({
       status: "active",


### PR DESCRIPTION
## Why

Two extension-side follow-ups to the native-host connection work, bundled as the next store version (**0.1.2**).

### 1. Make "not connected" diagnosable (this is what found the real bug)
The "Turn on full NeuroDock" card showed a silent "Not connected yet" with no reason. This PR:
- **Surfaces the actual probe failure** under the card (e.g. *"Specified native messaging host not found"*) instead of a black box, and shows a "Checking…" state while probing. This detail line is exactly what let us identify the Chromium-manifest root cause fixed in #116.
- **Raises the ping timeout 1s → 5s** to match the host's real cold-start latency (Chrome spawns a fresh host process per probe; `neurodock doctor` already used 8s). Skips overlapping auto-polls.

### 2. Chrome privacy-policy disclosure (rejection fix)
Chrome rejected 0.0.38 with "Privacy policy does not contain necessary information." The policy already covered collection/handling/storage/sharing, but in prose. Added an explicit **at-a-glance block naming each of the four required topics** so a reviewer ticking boxes can't miss a section. (The remaining fix is dashboard-side — see PR discussion.)

## Test plan
- [x] `full-setup.test.ts` — surfaces `detail` when not connected; clears it when active.
- [x] `power-up-card.test.tsx` — shows the failure reason; "Checking…" state.
- [x] Rebased clean onto current main (post-#116); extension files untouched by #116.

## Changeset
- `@neurodock/extension-browser: patch` (→ 0.1.2)

After merge + the Chrome dashboard privacy fields are set, tag `extension-browser@0.1.2` to resubmit to all stores.
