### PR TITLE
fix: bump dompurify override to >=3.4.11 (security sweep)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
   ws: '>=8.21.0'
-  dompurify: '>=3.4.9'
+  dompurify: '>=3.4.11'
   '@babel/core': ^7.29.6
   js-yaml@4: 4.2.0
   vite@6: ^6.4.3
@@ -2885,8 +2885,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -8449,7 +8449,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9754,7 +9754,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.47
       khroma: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,11 +42,10 @@ overrides:
   # ws >=8.0.0 <8.21.0 can be driven to memory-exhaustion DoS from tiny
   # fragments/data chunks (high, dependabot #48). Transitive. Force the fix.
   "ws": ">=8.21.0"
-  # dompurify <3.4.9 carries a cluster of sanitizer-bypass advisories
-  # (dependabot #54-#60). Transitive. Force the latest patched line.
-  # Note: #57 (IN_PLACE attacker-controlled nodeName) has no upstream fix
-  # yet and is low-risk for our usage; this raises everything else to 3.4.9.
-  "dompurify": ">=3.4.9"
+  # dompurify carries a cluster of sanitizer-bypass advisories. The latest,
+  # GHSA-cmwh-pvxp-8882 (vulnerable <=3.4.10), is fixed in 3.4.11 — so the
+  # prior >=3.4.9 floor no longer covered it. Transitive. Force the patched line.
+  "dompurify": ">=3.4.11"
   # @babel/core <=7.29.0 -> 7.29.6: arbitrary file read via sourceMappingURL
   # comment (low, dependabot #49). Transitive, build-time only. Caret-pinned
   # to the 7.x line (a bare >=7.29.6 resolves to the 8.0.0 major).


### PR DESCRIPTION
## Dependabot sweep (transitive override)

`dompurify` was pinned `>=3.4.9`, which resolved to **3.4.10** — still vulnerable to **GHSA-cmwh-pvxp-8882** (sanitizer bypass, vulnerable `<=3.4.10`, fixed **3.4.11**). Bumped the pnpm-workspace override to `>=3.4.11`; lockfile now resolves dompurify **3.4.11**. Transitive only; the patched line ships with the next extension build.

### The rest of the sweep (for the record)
- **pydantic-settings** 2.14.2 — merged (#117).
- **npm-minor-patch group** (7 updates) — merged (#119).
- **actions/checkout** 6→7 — merged (#118).
- **undici** (high+med+low, `<7.28.0`) — `packages/remote` only (the root "undici" matches are `undici-types`). Dependabot PR #98 (rebasing) carries the `packages/remote` lockfile bump.
- **js-yaml@3.14.2** — build-time-only transitive via `read-yaml-file@1.x`; the advisory's only fix is 4.2.0 (a breaking major) with no 3.x patch. The 4.x instance is already pinned to 4.2.0. Alert dismissed (tolerable risk, reopen if `read-yaml-file` ships a fixed line).
